### PR TITLE
Add category to commands shown in palette and scope them to appropriate contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,42 +52,31 @@
         {
           "id": "prStatus",
           "name": "Changes In Pull Request",
-          "when": "git:ispr"
+          "when": "github:inReviewMode"
         }
       ]
     },
     "commands": [
       {
-        "command": "pr.refreshList",
-        "title": "Refresh",
-        "icon": {
-          "dark": "resources/icons/dark/refresh.svg",
-          "light": "resources/icons/light/refresh.svg"
-        }
-      },
-      {
         "command": "pr.pick",
-        "title": "Checkout Pull Request"
-      },
-      {
-        "command": "pr.loadMore",
-        "title": "Load More"
+        "title": "Checkout Pull Request",
+        "category": "GitHub Pull Requests"
       },
       {
         "command": "pr.close",
-        "title": "Close Pull Request"
+        "title": "Close Pull Request",
+        "category": "GitHub Pull Requests"
       },
       {
         "command": "pr.openInGitHub",
-        "title": "Open in GitHub"
+        "title": "Open Pull Request in GitHub",
+        "category": "GitHub Pull Requests"
       },
       {
         "command": "pr.openDescription",
-        "title": "View Pull Request Description"
-      },
-      {
-        "command": "pr.viewChanges",
-        "title": "View Changes"
+        "title": "View Pull Request Description",
+        "category": "GitHub Pull Requests",
+        "when": "github:inReviewMode"
       },
       {
         "command": "review.openFile",
@@ -96,9 +85,40 @@
           "light": "resources/icons/light/open-file.svg",
           "dark": "resources/icons/dark/open-file.svg"
         }
+      },
+      {
+        "command": "pr.refreshList",
+        "title": "Refresh",
+        "icon": {
+          "dark": "resources/icons/dark/refresh.svg",
+          "light": "resources/icons/light/refresh.svg"
+        },
+        "category": "GitHub Pull Requests"
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "pr.pick",
+          "when": "false"
+        },
+        {
+          "command": "review.openFile",
+          "when": "false"
+        },
+        {
+          "command": "pr.close",
+          "when": "github:inReviewMode"
+        },
+        {
+          "command": "pr.openInGitHub",
+          "when": "github:inReviewMode"
+        },
+        {
+          "command": "pr.openDescription",
+          "when": "github:inReviewMode"
+        }
+      ],
       "view/title": [
         {
           "command": "pr.refreshList",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,20 @@ import { FileChangeNode } from './view/treeNodes/fileChangeNode';
 import { PRNode } from './view/treeNodes/pullRequestNode';
 import { IPullRequestManager, IPullRequestModel } from './github/interface';
 
+function ensurePR(prManager: IPullRequestManager, pr?: PRNode | IPullRequestModel): IPullRequestModel {
+	// If the command is called from the command palette, no arguments are passed.
+	if (!pr) {
+		if (!prManager.activePullRequest) {
+			vscode.window.showErrorMessage('Unable to find current pull request.');
+			return;
+		}
+
+		return prManager.activePullRequest;
+	} else {
+		return pr instanceof PRNode ? pr.pullRequestModel : pr;
+	}
+}
+
 export function registerCommands(context: vscode.ExtensionContext, prManager: IPullRequestManager, reviewManager: ReviewManager) {
 	// initialize resources
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openInGitHub', (e: PRNode | FileChangeNode) => {
@@ -45,22 +59,8 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: IP
 		});
 	}));
 
-	function ensurePR(pr?: PRNode | IPullRequestModel): IPullRequestModel {
-		// If the command is called from the command palette, no arguments are passed.
-		if (!pr) {
-			if (!prManager.activePullRequest) {
-				vscode.window.showErrorMessage('Unable to find current pull request.');
-				return;
-			}
-
-			return prManager.activePullRequest;
-		} else {
-			return pr instanceof PRNode ? pr.pullRequestModel : pr;
-		}
-	}
-
 	context.subscriptions.push(vscode.commands.registerCommand('pr.close', async (pr?: PRNode) => {
-		const pullRequest = ensurePR(pr);
+		const pullRequest = ensurePR(prManager, pr);
 		vscode.window.showWarningMessage(`Are you sure you want to close PR`, 'Yes', 'No').then(async value => {
 			if (value === 'Yes') {
 				let newPR = await prManager.closePullRequest(pullRequest);
@@ -72,7 +72,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: IP
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDescription', async (pr: IPullRequestModel) => {
-		const pullRequest = ensurePR(pr);
+		const pullRequest = ensurePR(prManager, pr);
 		// Create and show a new webview
 		PullRequestOverviewPanel.createOrShow(context.extensionPath, prManager, pullRequest);
 	}));

--- a/src/view/prFileChangesTreeDataProvider.ts
+++ b/src/view/prFileChangesTreeDataProvider.ts
@@ -24,7 +24,7 @@ export class PullRequestFileChangesTreeDataProvider extends vscode.Disposable im
 		this._pullrequest = pullrequest;
 		await vscode.commands.executeCommand(
 			'setContext',
-			'git:ispr',
+			'github:inReviewMode',
 			true
 		);
 		this._localFileChanges = fileChanges;
@@ -34,7 +34,7 @@ export class PullRequestFileChangesTreeDataProvider extends vscode.Disposable im
 	async hide() {
 		await vscode.commands.executeCommand(
 			'setContext',
-			'git:ispr',
+			'github:inReviewMode',
 			false
 		);
 	}


### PR DESCRIPTION
Adds "GitHub Pull Requests" category to all contributed commands that appear in the command palette. Limits the command palette contributions to 

- "GitHub Pull Requests: Refresh"

when the user isn't in PR Mode, and

- "GitHub Pull Requests: Close Pull Request"
- "GitHub Pull Requests: Open Pull Request in GitHub"
- "GitHub Pull Requests: View Pull Request Description"
- "GitHub Pull Requests: Refresh"

when in PR Mode that act on the currently checked out PR.