### PR TITLE
In memory content provider for pull request tree view.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { ReviewManager } from './view/reviewManager';
 import { PullRequestOverviewPanel } from './github/pullRequestOverview';
 import { fromReviewUri } from './common/uri';
-import { FileChangeNode } from './view/treeNodes/fileChangeNode';
+import { GitFileChangeNode } from './view/treeNodes/fileChangeNode';
 import { PRNode } from './view/treeNodes/pullRequestNode';
 import { IPullRequestManager, IPullRequestModel, IPullRequest } from './github/interface';
 import { Comment } from './common/comment';
@@ -47,7 +47,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: IP
 		}
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('pr.openFileInGitHub', (e: FileChangeNode) => {
+	context.subscriptions.push(vscode.commands.registerCommand('pr.openFileInGitHub', (e: GitFileChangeNode) => {
 		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(e.blobUrl));
 	}));
 
@@ -123,7 +123,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: IP
 		PullRequestOverviewPanel.createOrShow(context.extensionPath, prManager, pullRequest);
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('pr.viewChanges', async (fileChange: FileChangeNode) => {
+	context.subscriptions.push(vscode.commands.registerCommand('pr.viewChanges', async (fileChange: GitFileChangeNode) => {
 		// Show the file change in a diff view.
 		let { path, ref, commit } = fromReviewUri(fileChange.filePath);
 		let previousCommit = `${commit}^`;

--- a/src/common/diffHunk.ts
+++ b/src/common/diffHunk.ts
@@ -251,7 +251,7 @@ export function getGitChangeType(status: string): GitChangeType {
 	}
 }
 
-export async function parseDiff2(reviews: any[], repository: Repository, parentCommit: string): Promise<(InMemFileChange | SlimFileChange)[]> {
+export async function parseDiff(reviews: any[], repository: Repository, parentCommit: string): Promise<(InMemFileChange | SlimFileChange)[]> {
 	let fileChanges: (InMemFileChange | SlimFileChange)[] = [];
 
 	for (let i = 0; i < reviews.length; i++) {

--- a/src/common/diffHunk.ts
+++ b/src/common/diffHunk.ts
@@ -267,7 +267,8 @@ export async function parseDiff(reviews: any[], repository: Repository, parentCo
 
 		let originalFileExist = await repository.checkFileExistence(parentCommit, review.filename);
 		let diffHunks = parsePatch(review.patch);
-		fileChanges.push(new InMemFileChange(parentCommit, gitChangeType, review.filename, review.patch, diffHunks, !originalFileExist, review.blob_url))
+		let isPartial = !originalFileExist && gitChangeType !== GitChangeType.ADD;
+		fileChanges.push(new InMemFileChange(parentCommit, gitChangeType, review.filename, review.patch, diffHunks, isPartial, review.blob_url))
 	}
 
 	return fileChanges;

--- a/src/common/diffHunk.ts
+++ b/src/common/diffHunk.ts
@@ -7,8 +7,7 @@
  * Inspired by and includes code from GitHub/VisualStudio project, obtained from  https://github.com/github/VisualStudio/blob/master/src/GitHub.Exports/Models/DiffLine.cs
  */
 
-import * as path from 'path';
-import { getFileContent, writeTmpFile, GitChangeType, RichFileChange, SlimFileChange } from './file';
+import { GitChangeType, SlimFileChange, InMemFileChange } from './file';
 import { Repository } from './repository';
 import { Comment } from './comment';
 
@@ -167,7 +166,34 @@ export function* parseDiffHunk(diffHunkPatch: string): IterableIterator<DiffHunk
 	}
 }
 
-async function parseModifiedHunkComplete(originalContent, patch, a, b) {
+function parsePatch(patch: string): DiffHunk[] {
+	let diffHunkReader = parseDiffHunk(patch);
+	let diffHunkIter = diffHunkReader.next();
+	let diffHunks = [];
+
+	let right = [];
+	while (!diffHunkIter.done) {
+		let diffHunk = diffHunkIter.value;
+		diffHunks.push(diffHunk);
+
+		for (let j = 0; j < diffHunk.diffLines.length; j++) {
+			let diffLine = diffHunk.diffLines[j];
+			if (diffLine.type === DiffChangeType.Delete || diffLine.type === DiffChangeType.Control) {
+			} else if (diffLine.type === DiffChangeType.Add) {
+				right.push(diffLine.text);
+			} else {
+				let codeInFirstLine = diffLine.text;
+				right.push(codeInFirstLine);
+			}
+		}
+
+		diffHunkIter = diffHunkReader.next();
+	}
+
+	return diffHunks;
+}
+
+export function getModifiedContentFromDiffHunk(originalContent, patch) {
 	let left = originalContent.split(/\r|\n|\r\n/);
 	let diffHunkReader = parseDiffHunk(patch);
 	let diffHunkIter = diffHunkReader.next();
@@ -207,44 +233,7 @@ async function parseModifiedHunkComplete(originalContent, patch, a, b) {
 		}
 	}
 
-	let contentPath = await writeTmpFile(right.join('\n'), path.extname(b));
-	let originalContentPath = await writeTmpFile(left.join('\n'), path.extname(a));
-
-	return new RichFileChange(contentPath, originalContentPath, GitChangeType.MODIFY, b, diffHunks, false);
-}
-
-async function parseModifiedHunkFast(modifyDiffInfo, a, b) {
-	let left = [];
-	let right = [];
-
-	let diffHunkReader = parseDiffHunk(modifyDiffInfo);
-	let diffHunkIter = diffHunkReader.next();
-	let diffHunks = [];
-
-	while (!diffHunkIter.done) {
-		let diffHunk = diffHunkIter.value;
-		diffHunks.push(diffHunk);
-		for (let i = 0, len = diffHunk.diffLines.length; i < len; i++) {
-			let diffLine = diffHunk.diffLines[i];
-			if (diffLine.type === DiffChangeType.Add) {
-				right.push(diffLine.text);
-			} else if (diffLine.type === DiffChangeType.Delete) {
-				left.push(diffLine.text);
-			} else if (diffLine.type === DiffChangeType.Control) {
-				// nothing
-			} else {
-				left.push(diffLine.text);
-				right.push(diffLine.text);
-			}
-		}
-
-		diffHunkIter = diffHunkReader.next();
-	}
-
-	let contentPath = await writeTmpFile(right.join('\n'), path.extname(b));
-	let originalContentPath = await writeTmpFile(left.join('\n'), path.extname(a));
-
-	return new RichFileChange(contentPath, originalContentPath, GitChangeType.MODIFY, b, diffHunks, true);
+	return right.join('\n');
 }
 
 export function getGitChangeType(status: string): GitChangeType {
@@ -262,61 +251,25 @@ export function getGitChangeType(status: string): GitChangeType {
 	}
 }
 
-export async function parseDiff(reviews: any[], repository: Repository, parentCommit: string): Promise<(RichFileChange | SlimFileChange)[]> {
-	let fileChanges: (RichFileChange | SlimFileChange)[] = [];
+export async function parseDiff2(reviews: any[], repository: Repository, parentCommit: string): Promise<(InMemFileChange | SlimFileChange)[]> {
+	let fileChanges: (InMemFileChange | SlimFileChange)[] = [];
+
 	for (let i = 0; i < reviews.length; i++) {
 		let review = reviews[i];
+
 		if (!review.patch) {
 			const gitChangeType = getGitChangeType(review.status);
 			fileChanges.push(new SlimFileChange(review.blob_url, gitChangeType, review.filename));
 			continue;
 		}
 
-		if (review.status === 'modified') {
-			let fileName = review.filename;
-			try {
-				let originalContent = await getFileContent(repository.path, parentCommit, fileName);
-				let richFileChange = await parseModifiedHunkComplete(originalContent, review.patch, fileName, fileName);
-				richFileChange.blobUrl = review.blob_url;
-				fileChanges.push(richFileChange);
-			} catch (e) {
-				let richFileChange = await parseModifiedHunkFast(review.patch, fileName, fileName);
-				richFileChange.blobUrl = review.blob_url;
-				fileChanges.push(richFileChange);
-			}
-		} else if (review.status === 'removed' || review.status === 'added' || review.status === 'renamed') {
-			if (!review.patch) {
-				continue;
-			}
+		const gitChangeType = getGitChangeType(review.status);
 
-			const gitChangeType = getGitChangeType(review.status);
-			let contentArray = [];
-			let fileName = review.filename;
-			let prDiffReader = parseDiffHunk(review.patch);
-			let prDiffIter = prDiffReader.next();
-			let diffHunks = [];
-
-			while (!prDiffIter.done) {
-				let diffHunk = prDiffIter.value;
-				diffHunks.push(diffHunk);
-				for (let j = 0, len = diffHunk.diffLines.length; j < len; j++) {
-					let diffLine = diffHunk.diffLines[j];
-					if (diffLine.type !== DiffChangeType.Control) {
-						contentArray.push(diffLine.text);
-					}
-				}
-				prDiffIter = prDiffReader.next();
-			}
-
-			let contentFilePath = await writeTmpFile(contentArray.join('\n'), path.extname(fileName));
-			let emptyContentFilePath = await writeTmpFile('', path.extname(fileName));
-			let richFileChange = review.status === 'removed' ?
-				new RichFileChange(emptyContentFilePath, contentFilePath, gitChangeType, fileName, diffHunks, false) :
-				new RichFileChange(contentFilePath, emptyContentFilePath, gitChangeType, fileName, diffHunks, false);
-			richFileChange.blobUrl = review.blob_url;
-			fileChanges.push(richFileChange);
-		}
+		let originalFileExist = await repository.checkFileExistence(parentCommit, review.filename);
+		let diffHunks = parsePatch(review.patch);
+		fileChanges.push(new InMemFileChange(parentCommit, gitChangeType, review.filename, review.patch, diffHunks, !originalFileExist, review.blob_url))
 	}
+
 	return fileChanges;
 }
 

--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -3,28 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs';
-import * as tmp from 'tmp';
 import { DiffHunk } from './diffHunk';
 import { exec } from './git';
 
-export async function writeTmpFile(content: string, ext: string): Promise<string> {
-	return new Promise<string>((resolve, reject) => {
-		tmp.file({ postfix: ext }, async (err: any, tmpFilePath: string) => {
-			if (err) {
-				reject(err);
-				return;
-			}
-
-			try {
-				fs.appendFileSync(tmpFilePath, content);
-				resolve(tmpFilePath);
-			} catch (ex) {
-				reject(ex);
-			}
-		});
-	});
-}
 
 export async function getFileContent(rootDir: string, commitSha: string, sourceFilePath: string): Promise<string> {
 	const result = await exec([
@@ -55,15 +36,17 @@ export enum GitChangeType {
 	UNMERGED
 }
 
-export class RichFileChange {
-	public blobUrl: string;
+export class InMemFileChange {
+
 	constructor(
-		public readonly filePath: string,
-		public readonly originalFilePath: string,
+		public readonly baseCommit: string,
 		public readonly status: GitChangeType,
 		public readonly fileName: string,
+		public readonly patch: string,
 		public readonly diffHunks: DiffHunk[],
-		public readonly isPartial: boolean
+
+		public readonly isPartial: boolean,
+		public blobUrl: string
 	) { }
 }
 

--- a/src/common/repository.ts
+++ b/src/common/repository.ts
@@ -407,6 +407,12 @@ export class Repository {
 			return null;
 		}
 	}
+
+	async checkFileExistence(commitSha: string, fileName: string): Promise<boolean> {
+		let result = await this.run(['cat-file', '-e', `${commitSha}:` + fileName.replace(/\\/g, '/')]);
+
+		return result.exitCode === 0;
+	}
 }
 
 function parseRemote(remoteName: string, url: string): Remote | null {

--- a/src/common/resources.ts
+++ b/src/common/resources.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { GitChangeType } from './file';
-import { FileChangeNode, RemoteFileChangeNode } from '../view/treeNodes/fileChangeNode';
+import { GitFileChangeNode, RemoteFileChangeNode } from '../view/treeNodes/fileChangeNode';
 
 export class Resource {
 	static icons: any;
@@ -42,7 +42,7 @@ export class Resource {
 		};
 	}
 
-	static getFileStatusUri(element: FileChangeNode | RemoteFileChangeNode): vscode.Uri | { light: vscode.Uri, dark: vscode.Uri } {
+	static getFileStatusUri(element: GitFileChangeNode | RemoteFileChangeNode): vscode.Uri | { light: vscode.Uri, dark: vscode.Uri } {
 		let iconUri: vscode.Uri;
 		let iconDarkUri: vscode.Uri;
 

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -101,3 +101,20 @@ export function fromFileChangeNodeUri(uri: Uri): FileChangeNodeUriParams {
 		return null;
 	}
 }
+
+export function toInMemUri(uri: Uri, pullRequestModel: IPullRequestModel, commit: string, fileName: string, base: boolean): Uri {
+	const params = {
+		commit: commit,
+		base: base,
+		fileName: fileName,
+		prNumber: pullRequestModel.prNumber
+	};
+
+	let path = uri.path;
+
+	return uri.with({
+		scheme: 'pr',
+		path,
+		query: JSON.stringify(params)
+	});
+}

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -20,7 +20,7 @@ export function fromReviewUri(uri: Uri): ReviewUriParams {
 }
 
 export interface PRUriParams {
-	path: string;
+	commit?: string;
 	base: boolean;
 	fileName: string;
 	prNumber: number;
@@ -60,24 +60,7 @@ export function toReviewUri(uri: Uri, filePath: string, ref: string, commit: str
 	});
 }
 
-export function toPRUri(uri: Uri, pullRequestModel: IPullRequestModel, fileInRepo: string, fileName: string, base: boolean): Uri {
-	const params = {
-		path: uri.path,
-		base: base,
-		fileName: fileName,
-		prNumber: pullRequestModel.prNumber
-	};
 
-	let path = uri.path;
-
-	// path = `${path}.git`;
-
-	return uri.with({
-		scheme: 'pr',
-		path,
-		query: JSON.stringify(params),
-	});
-}
 
 export interface FileChangeNodeUriParams {
 	hasComments?: boolean;
@@ -102,8 +85,8 @@ export function fromFileChangeNodeUri(uri: Uri): FileChangeNodeUriParams {
 	}
 }
 
-export function toInMemUri(uri: Uri, pullRequestModel: IPullRequestModel, commit: string, fileName: string, base: boolean): Uri {
-	const params = {
+export function toPRUri(uri: Uri, pullRequestModel: IPullRequestModel, commit: string, fileName: string, base: boolean): Uri {
+	const params: PRUriParams = {
 		commit: commit,
 		base: base,
 		fileName: fileName,

--- a/src/view/inMemPRContentProvider.ts
+++ b/src/view/inMemPRContentProvider.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as vscode from 'vscode';
+import { fromPRUri } from '../common/uri';
+
+export class InMemPRContentProvider implements vscode.TextDocumentContentProvider {
+	private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+	get onDidChange(): vscode.Event<vscode.Uri> { return this._onDidChange.event; }
+
+	private _prFileChangeContentProviders: {[key: number]: (uri: vscode.Uri) => Promise<string>} = {};
+
+	constructor() {}
+
+	async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
+		let { prNumber } = fromPRUri(uri);
+
+		if (prNumber) {
+			let provider = this._prFileChangeContentProviders[prNumber];
+
+			if (provider) {
+				return await provider(uri);
+			}
+		}
+
+		return '';
+	}
+
+	registerTextDocumentContent(prNumber: number, provider: (uri: vscode.Uri) => Promise<string>): vscode.Disposable {
+		this._prFileChangeContentProviders[prNumber] = provider;
+
+		return {
+			dispose: () => {
+				this._prFileChangeContentProviders[prNumber] = null;
+			}
+		}
+	}
+}
+
+const inMemPRContentProvider = new InMemPRContentProvider();
+
+export function getInMemPRContentProvider(): InMemPRContentProvider {
+	return inMemPRContentProvider;
+}

--- a/src/view/inMemPRContentProvider.ts
+++ b/src/view/inMemPRContentProvider.ts
@@ -29,7 +29,7 @@ export class InMemPRContentProvider implements vscode.TextDocumentContentProvide
 		return '';
 	}
 
-	registerTextDocumentContent(prNumber: number, provider: (uri: vscode.Uri) => Promise<string>): vscode.Disposable {
+	registerTextDocumentContentProvider(prNumber: number, provider: (uri: vscode.Uri) => Promise<string>): vscode.Disposable {
 		this._prFileChangeContentProviders[prNumber] = provider;
 
 		return {

--- a/src/view/prChangesTreeDataProvider.ts
+++ b/src/view/prChangesTreeDataProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { Resource } from '../common/resources';
 import { IPullRequestModel, IPullRequestManager } from '../github/interface';
-import { FileChangeNode, RemoteFileChangeNode } from './treeNodes/fileChangeNode';
+import { GitFileChangeNode, RemoteFileChangeNode } from './treeNodes/fileChangeNode';
 import { DescriptionNode } from './treeNodes/descriptionNode';
 import { TreeNode } from './treeNodes/treeNode';
 import { FilesCategoryNode } from './treeNodes/filesCategoryNode';
@@ -14,11 +14,11 @@ import { CommitsNode } from './treeNodes/commitsCategoryNode';
 import { Comment } from '../common/comment';
 
 export class PullRequestChangesTreeDataProvider extends vscode.Disposable implements vscode.TreeDataProvider<TreeNode> {
-	private _onDidChangeTreeData = new vscode.EventEmitter<FileChangeNode | DescriptionNode>();
+	private _onDidChangeTreeData = new vscode.EventEmitter<GitFileChangeNode | DescriptionNode>();
 	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 	private _disposables: vscode.Disposable[] = []
 
-	private _localFileChanges: (FileChangeNode | RemoteFileChangeNode)[] = [];
+	private _localFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[] = [];
 	private _comments: Comment[] = [];
 	private _pullrequest: IPullRequestModel = null;
 	private _pullRequestManager: IPullRequestManager;
@@ -32,7 +32,7 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 		this._onDidChangeTreeData.fire();
 	}
 
-	async showPullRequestFileChanges(pullRequestManager: IPullRequestManager, pullrequest: IPullRequestModel, fileChanges: (FileChangeNode | RemoteFileChangeNode)[], comments: Comment[]) {
+	async showPullRequestFileChanges(pullRequestManager: IPullRequestManager, pullrequest: IPullRequestModel, fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[], comments: Comment[]) {
 		this._pullRequestManager = pullRequestManager;
 		this._pullrequest = pullrequest;
 		this._comments = comments;
@@ -59,7 +59,7 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 		return element.getTreeItem();
 	}
 
-	getChildren(element?: FileChangeNode): vscode.ProviderResult<TreeNode[]> {
+	getChildren(element?: GitFileChangeNode): vscode.ProviderResult<TreeNode[]> {
 		if (!element) {
 			const descriptionNode = new DescriptionNode('Description',
 				{

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { IConfiguration } from '../authentication/configuration';
 import { Repository } from '../common/repository';
@@ -11,8 +10,9 @@ import { TreeNode } from './treeNodes/treeNode';
 import { PRCategoryActionNode, CategoryTreeNode, PRCategoryActionType } from './treeNodes/categoryNode';
 import { IPullRequestManager, PRType } from '../github/interface';
 import { fromFileChangeNodeUri } from '../common/uri';
+import { getInMemPRContentProvider } from './inmemPRContentProvider';
 
-export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<TreeNode>, vscode.TextDocumentContentProvider, vscode.DecorationProvider, vscode.Disposable {
+export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<TreeNode>, vscode.DecorationProvider, vscode.Disposable {
 	private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode>();
 	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 	private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
@@ -26,7 +26,7 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 		private _prManager: IPullRequestManager
 	) {
 		this._disposables = [];
-		this._disposables.push(vscode.workspace.registerTextDocumentContentProvider('pr', this));
+		this._disposables.push(vscode.workspace.registerTextDocumentContentProvider('pr', getInMemPRContentProvider()));
 		this._disposables.push(vscode.window.registerDecorationProvider(this));
 		this._disposables.push(vscode.commands.registerCommand('pr.refreshList', _ => {
 			this._onDidChangeTreeData.fire();
@@ -85,16 +85,6 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 		}
 
 		return {};
-	}
-
-	async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
-		let { path } = JSON.parse(uri.query);
-		try {
-			let content = fs.readFileSync(vscode.Uri.file(path).fsPath);
-			return content.toString();
-		} catch (e) {
-			return '';
-		}
 	}
 
 	dispose() {

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -17,7 +17,7 @@ import { Repository } from '../common/repository';
 import { PullRequestChangesTreeDataProvider } from './prChangesTreeDataProvider';
 import { GitContentProvider } from './gitContentProvider';
 import { DiffChangeType } from '../common/diffHunk';
-import { FileChangeNode, RemoteFileChangeNode, fileChangeNodeFilter } from './treeNodes/fileChangeNode';
+import { GitFileChangeNode, RemoteFileChangeNode, fileChangeNodeFilter } from './treeNodes/fileChangeNode';
 import Logger from '../common/logger';
 import { PullRequestsTreeDataProvider } from './prsTreeDataProvider';
 import { IConfiguration } from '../authentication/configuration';
@@ -30,8 +30,8 @@ export class ReviewManager implements vscode.DecorationProvider {
 	private _disposables: vscode.Disposable[];
 
 	private _comments: Comment[] = [];
-	private _localFileChanges: (FileChangeNode | RemoteFileChangeNode)[] = [];
-	private _obsoleteFileChanges: (FileChangeNode | RemoteFileChangeNode)[] = [];
+	private _localFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[] = [];
+	private _obsoleteFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[] = [];
 	private _lastCommitSha: string;
 	private _updateMessageShown: boolean = false;
 	private _updateCurrentBranch: boolean = false;
@@ -182,7 +182,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		vscode.commands.executeCommand('pr.refreshList');
 	}
 
-	private findMatchedFileByUri(document: vscode.TextDocument): FileChangeNode {
+	private findMatchedFileByUri(document: vscode.TextDocument): GitFileChangeNode {
 		const uri = document.uri;
 
 		let fileName: string;
@@ -374,7 +374,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 
 			this._comments = comments;
 			this._localFileChanges.forEach(change => {
-				if (change instanceof FileChangeNode) {
+				if (change instanceof GitFileChangeNode) {
 					change.comments = this._comments.filter(comment => change.fileName === comment.path && comment.position !== null);
 				}
 			});
@@ -406,7 +406,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 						change.blobUrl
 					);
 				}
-				let changedItem = new FileChangeNode(
+				let changedItem = new GitFileChangeNode(
 					pr,
 					change.status,
 					change.fileName,
@@ -428,7 +428,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 				let commentsForFile = groupBy(commentsForCommit, comment => comment.path);
 				for (let fileName in commentsForFile) {
 					let oldComments = commentsForFile[fileName];
-					let obsoleteFileChange = new FileChangeNode(
+					let obsoleteFileChange = new GitFileChangeNode(
 						pr,
 						GitChangeType.MODIFY,
 						fileName,
@@ -452,7 +452,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 
 	}
 
-	private outdatedCommentsToCommentThreads(fileChange: FileChangeNode, comments: Comment[], collapsibleState: vscode.CommentThreadCollapsibleState = vscode.CommentThreadCollapsibleState.Expanded): vscode.CommentThread[] {
+	private outdatedCommentsToCommentThreads(fileChange: GitFileChangeNode, comments: Comment[], collapsibleState: vscode.CommentThreadCollapsibleState = vscode.CommentThreadCollapsibleState.Expanded): vscode.CommentThread[] {
 		if (!comments || !comments.length) {
 			return [];
 		}
@@ -585,7 +585,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 					const fileName = document.uri.fsPath;
 					const matchedFiles = fileChangeNodeFilter(this._localFileChanges).filter(fileChange => path.resolve(this._repository.path, fileChange.fileName) === fileName);
 					if (matchedFiles && matchedFiles.length) {
-						const matchedFile: FileChangeNode = matchedFiles[0];
+						const matchedFile: GitFileChangeNode = matchedFiles[0];
 
 						let contentDiff: string;
 						if (document.isDirty) {
@@ -740,7 +740,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		});
 	}
 
-	private findMatchedFileChange(fileChanges: (FileChangeNode | RemoteFileChangeNode)[], uri: vscode.Uri): FileChangeNode {
+	private findMatchedFileChange(fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[], uri: vscode.Uri): GitFileChangeNode {
 		let query = JSON.parse(uri.query);
 		let matchedFiles = fileChanges.filter(fileChange => {
 			if (fileChange instanceof RemoteFileChangeNode) {
@@ -766,7 +766,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		});
 
 		if (matchedFiles && matchedFiles.length) {
-			return matchedFiles[0] as FileChangeNode;
+			return matchedFiles[0] as GitFileChangeNode;
 		}
 
 		return null;

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -335,7 +335,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			return oldComments.some(oldComment => {
 				const matchingComment = newComments.filter(newComment => newComment.commentId === oldComment.commentId);
 				if (matchingComment.length !== 1) {
-					return true;
+					return true; 
 				}
 
 				if (matchingComment[0].body.value !== oldComment.body.value) {

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { parseDiff2 } from '../common/diffHunk';
+import { parseDiff } from '../common/diffHunk';
 import { getDiffLineByPosition, getLastDiffLine, mapCommentsToHead, mapHeadLineToDiffHunkPosition, mapOldPositionToNew, getZeroBased, getAbsolutePosition } from '../common/diffPositionMapping';
 import { toReviewUri, fromReviewUri, fromPRUri } from '../common/uri';
 import { groupBy, formatError } from '../common/utils';
@@ -396,7 +396,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			let headSha = pr.head.sha;
 			let mergeBase = pr.mergeBase;
 
-			const contentChanges = await parseDiff2(data, this._repository, mergeBase);
+			const contentChanges = await parseDiff(data, this._repository, mergeBase);
 			this._localFileChanges = contentChanges.map(change => {
 				if (change instanceof SlimFileChange) {
 					return new RemoteFileChangeNode(

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { parseDiff } from '../common/diffHunk';
+import { parseDiff2 } from '../common/diffHunk';
 import { getDiffLineByPosition, getLastDiffLine, mapCommentsToHead, mapHeadLineToDiffHunkPosition, mapOldPositionToNew, getZeroBased, getAbsolutePosition } from '../common/diffPositionMapping';
 import { toReviewUri, fromReviewUri, fromPRUri } from '../common/uri';
 import { groupBy, formatError } from '../common/utils';
@@ -396,7 +396,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			let headSha = pr.head.sha;
 			let mergeBase = pr.mergeBase;
 
-			const contentChanges = await parseDiff(data, this._repository, mergeBase);
+			const contentChanges = await parseDiff2(data, this._repository, mergeBase);
 			this._localFileChanges = contentChanges.map(change => {
 				if (change instanceof SlimFileChange) {
 					return new RemoteFileChangeNode(

--- a/src/view/treeNodes/commitNode.ts
+++ b/src/view/treeNodes/commitNode.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { IPullRequestModel, Commit, IPullRequestManager } from '../../github/interface';
 import { TreeNode } from './treeNode';
-import { FileChangeNode } from './fileChangeNode';
+import { GitFileChangeNode } from './fileChangeNode';
 import { toReviewUri } from '../../common/uri';
 import { getGitChangeType } from '../../common/diffHunk';
 import { Comment } from '../../common/comment';
@@ -39,7 +39,7 @@ export class CommitNode extends TreeNode implements vscode.TreeItem {
 			const matchingComments = this.comments.filter(comment => comment.path === change.filename && comment.original_commit_id === this.commit.sha);
 			const fileName = change.filename;
 			const uri = vscode.Uri.parse(path.join(`commit~${this.commit.sha.substr(0, 8)}`, fileName));
-			const fileChangeNode = new FileChangeNode(
+			const fileChangeNode = new GitFileChangeNode(
 				this.pullRequest,
 				getGitChangeType(change.status),
 				fileName,

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -42,6 +42,79 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	}
 }
 
+export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
+	public label: string;
+	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
+	public resourceUri: vscode.Uri;
+	public parentSha: string;
+	public contextValue: string;
+	public command: vscode.Command;
+
+	constructor(
+		public readonly pullRequest: IPullRequestModel,
+		public readonly status: GitChangeType,
+		public readonly fileName: string,
+		public readonly blobUrl: string,
+		public readonly filePath: vscode.Uri,
+		public readonly parentFilePath: vscode.Uri,
+		public readonly isPartial: boolean,
+		public readonly patch: string,
+		public readonly diffHunks: DiffHunk[],
+
+		public comments: Comment[] = [],
+		public readonly sha?: string,
+	) {
+		super();
+		this.contextValue = 'filechange';
+		this.label = fileName;
+
+		if (this.comments && this.comments.length) {
+			this.iconPath = Resource.icons.light.Comment;
+		} else {
+			this.iconPath = Resource.getFileStatusUri(this);
+		}
+
+		this.resourceUri = toFileChangeNodeUri(this.filePath, comments.length > 0);
+
+		let opts: vscode.TextDocumentShowOptions = {
+			preserveFocus: true
+		};
+
+		if (this.comments && this.comments.length) {
+			let sortedActiveComments = this.comments.filter(comment => comment.position).sort((a, b) => {
+				return a.position - b.position;
+			});
+
+			if (sortedActiveComments.length) {
+				let comment = sortedActiveComments[0];
+				let diffLine = getDiffLineByPosition(this.diffHunks, comment.position === null ? comment.original_position : comment.position);
+
+				if (diffLine) {
+					// If the diff is a deletion, the new line number is invalid so use the old line number. Ensure the line number is positive.
+					let lineNumber = Math.max(getZeroBased(diffLine.type === DiffChangeType.Delete ? diffLine.oldLineNumber : diffLine.newLineNumber), 0);
+					opts.selection = new vscode.Range(lineNumber, 0, lineNumber, 0);
+				}
+			}
+		}
+
+		this.command = {
+			title: 'show diff',
+			command: 'pr.openDiffView',
+			arguments: [
+				this.parentFilePath,
+				this.filePath,
+				this.fileName,
+				this.isPartial,
+				opts
+			]
+		};
+	}
+
+	getTreeItem(): vscode.TreeItem {
+		return this;
+	}
+}
+
 export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -13,6 +13,9 @@ import { Comment } from '../../common/comment';
 import { getDiffLineByPosition, getZeroBased } from '../../common/diffPositionMapping';
 import { toFileChangeNodeUri } from '../../common/uri';
 
+/**
+ * File change node whose content can not be resolved locally and we direct users to GitHub.
+ */
 export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
@@ -42,6 +45,9 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	}
 }
 
+/**
+ * File change node whose content is stored in memory and resolved when being revealed.
+ */
 export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
@@ -115,7 +121,10 @@ export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 	}
 }
 
-export class FileChangeNode extends TreeNode implements vscode.TreeItem {
+/**
+ * File change node whose content can be resolved by git commit sha.
+ */
+export class GitFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
 	public resourceUri: vscode.Uri;
@@ -186,6 +195,6 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 	}
 }
 
-export function fileChangeNodeFilter(nodes: (FileChangeNode | RemoteFileChangeNode)[]): FileChangeNode[] {
-	return nodes.filter(node => node instanceof FileChangeNode) as FileChangeNode[];
+export function fileChangeNodeFilter(nodes: (GitFileChangeNode | RemoteFileChangeNode)[]): GitFileChangeNode[] {
+	return nodes.filter(node => node instanceof GitFileChangeNode) as GitFileChangeNode[];
 }

--- a/src/view/treeNodes/filesCategoryNode.ts
+++ b/src/view/treeNodes/filesCategoryNode.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { FileChangeNode, RemoteFileChangeNode } from './fileChangeNode';
+import { GitFileChangeNode, RemoteFileChangeNode } from './fileChangeNode';
 import { TreeNode } from './treeNode';
 
 export class FilesCategoryNode extends TreeNode implements vscode.TreeItem {
 	public label: string = 'Files';
 	public collapsibleState: vscode.TreeItemCollapsibleState;
 
-	constructor(private _fileChanges: (FileChangeNode | RemoteFileChangeNode)[]) {
+	constructor(private _fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[]) {
 		super();
 		this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
 	}

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -14,14 +14,14 @@ import { fromPRUri, toInMemUri } from '../../common/uri';
 import { groupBy, formatError } from '../../common/utils';
 import { IPullRequestManager, IPullRequestModel } from '../../github/interface';
 import { DescriptionNode } from './descriptionNode';
-import { FileChangeNode, RemoteFileChangeNode, InMemFileChangeNode } from './fileChangeNode';
+import { GitFileChangeNode, RemoteFileChangeNode, InMemFileChangeNode } from './fileChangeNode';
 import { TreeNode } from './treeNode';
 import { getInMemPRContentProvider } from '../inmemPRContentProvider';
 
 export function providePRDocumentComments(
 	document: vscode.TextDocument,
 	prNumber: number,
-	fileChanges: (RemoteFileChangeNode | FileChangeNode)[]) {
+	fileChanges: (RemoteFileChangeNode | GitFileChangeNode)[]) {
 	const params = fromPRUri(document.uri);
 
 	if (params.prNumber !== prNumber) {
@@ -111,7 +111,7 @@ export function providePRDocumentComments(
 }
 
 export class PRNode extends TreeNode {
-	private _contentChanges: (RemoteFileChangeNode | FileChangeNode)[];
+	private _contentChanges: (RemoteFileChangeNode | GitFileChangeNode)[];
 	private _documentCommentsProvider: vscode.Disposable;
 	private _inMemPRContentProvider: vscode.Disposable;
 

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -171,7 +171,7 @@ export class PRNode extends TreeNode {
 				return changedItem;
 			});
 
-			this._inMemPRContentProvider = getInMemPRContentProvider().registerTextDocumentContent(this.pullRequestModel.prNumber, async (uri: vscode.Uri) => {
+			this._inMemPRContentProvider = getInMemPRContentProvider().registerTextDocumentContentProvider(this.pullRequestModel.prNumber, async (uri: vscode.Uri) => {
 				let params = JSON.parse(uri.query);
 				let fileChanges = this._contentChanges.filter(contentChange => (contentChange instanceof InMemFileChangeNode) && contentChange.fileName === params.fileName);
 				if (fileChanges.length) {
@@ -357,6 +357,10 @@ export class PRNode extends TreeNode {
 
 		if (this._documentCommentsProvider) {
 			this._documentCommentsProvider.dispose();
+		}
+
+		if (this._inMemPRContentProvider) {
+			this._inMemPRContentProvider.dispose();
 		}
 	}
 }

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { parseDiff2, getModifiedContentFromDiffHunk, DiffChangeType } from '../../common/diffHunk';
+import { parseDiff, getModifiedContentFromDiffHunk, DiffChangeType } from '../../common/diffHunk';
 import { mapHeadLineToDiffHunkPosition, getZeroBased, getAbsolutePosition, getPositionInDiff } from '../../common/diffPositionMapping';
 import { SlimFileChange, getFileContent } from '../../common/file';
 import Logger from '../../common/logger';
@@ -144,7 +144,7 @@ export class PRNode extends TreeNode {
 			const data = await this._prManager.getPullRequestChangedFiles(this.pullRequestModel);
 			await this._prManager.fullfillPullRequestMissingInfo(this.pullRequestModel);
 			let mergeBase = this.pullRequestModel.mergeBase;
-			const rawChanges = await parseDiff2(data, this.repository, mergeBase);
+			const rawChanges = await parseDiff(data, this.repository, mergeBase);
 			this._contentChanges = rawChanges.map(change => {
 				if (change instanceof SlimFileChange) {
 					return new RemoteFileChangeNode(


### PR DESCRIPTION
Re #27 . We now move the inmem content provider for file changes nodes in both pull request tree view and Review Mode's changes in PR. The benefits are somewhat huge

* we don't need to resolve file content when expanding the PR node, we only need to check whether the `mergeBase` commit exist or not.
* we resolve file content only when they are being visited
* no local temp files