### PR TITLE
Fixes #265, authentication status bar item added for each remote

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -23,7 +23,6 @@ export interface PullRequestData {
 export class GitHubRepository implements IGitHubRepository {
 	private _octokit: Octokit;
 	private _initialized: boolean;
-	private _authenticationStatus: vscode.StatusBarItem;
 	public get octokit(): Octokit {
 		if (this._octokit === undefined) {
 			if (!this._initialized) {
@@ -35,32 +34,7 @@ export class GitHubRepository implements IGitHubRepository {
 		return this._octokit;
 	}
 
-	public set octokit(newOctokit: Octokit) {
-		if (newOctokit !== this._octokit) {
-			this._octokit = newOctokit;
-
-			// update status bar item
-			this.updateAuthenticationStatus();
-		}
-	}
-
 	constructor(public readonly remote: Remote, private readonly _credentialStore: CredentialStore) {
-		this._authenticationStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-		const normalizedUri = this.remote.gitProtocol.normalizeUri();
-		this._authenticationStatus.text = `${remote.owner}/${remote.repositoryName} ⟷ Sign in to ${normalizedUri.authority}`;
-		this._authenticationStatus.command = 'pr.signin';
-		this._authenticationStatus.show();
-	}
-
-	updateAuthenticationStatus() {
-		setTimeout(async () => {
-			if (this._octokit) {
-				const currentUser = await this._octokit.users.get({});
-				const userName = currentUser.data.login;
-				this._authenticationStatus.text = `${this.remote.owner}/${this.remote.repositoryName} ⟷ ${userName}`;
-				this._authenticationStatus.command = null;
-			}
-		}, 0);
 	}
 
 	async ensure(): Promise<GitHubRepository> {
@@ -73,10 +47,10 @@ export class GitHubRepository implements IGitHubRepository {
 				SIGNIN_COMMAND);
 
 			if (result === SIGNIN_COMMAND) {
-				this.octokit = await this._credentialStore.login(this.remote);
+				this._octokit = await this._credentialStore.login(this.remote);
 			}
 		} else {
-			this.octokit = await this._credentialStore.getOctokit(this.remote);
+			this._octokit = await this._credentialStore.getOctokit(this.remote);
 		}
 
 		return this;
@@ -85,9 +59,9 @@ export class GitHubRepository implements IGitHubRepository {
 	async authenticate(): Promise<boolean> {
 		this._initialized = true;
 		if (!await this._credentialStore.hasOctokit(this.remote)) {
-			this.octokit = await this._credentialStore.login(this.remote);
+			this._octokit = await this._credentialStore.login(this.remote);
 		} else {
-			this.octokit = this._credentialStore.getOctokit(this.remote);
+			this._octokit = this._credentialStore.getOctokit(this.remote);
 		}
 		return this.octokit !== undefined;
 	}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -74,7 +74,7 @@ export class PullRequestManager implements IPullRequestManager {
 
 		const repositoriesByAuthority: GitHubRepository[] = uniqBy(repositories, repository => repository.remote.gitProtocol.normalizeUri().authority);
 		repositoriesByAuthority.forEach(repository => {
-			this._credentialStore.createAuthenticationStatusBarItem(repository.remote);
+			this._credentialStore.hasOctokit(repository.remote);
 		});
 
 		this._githubRepositories = repositories;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -72,11 +72,6 @@ export class PullRequestManager implements IPullRequestManager {
 			}
 		}
 
-		const repositoriesByAuthority: GitHubRepository[] = uniqBy(repositories, repository => repository.remote.gitProtocol.normalizeUri().authority);
-		repositoriesByAuthority.forEach(repository => {
-			this._credentialStore.hasOctokit(repository.remote);
-		});
-
 		this._githubRepositories = repositories;
 
 		for (let repository of this._githubRepositories) {

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -72,6 +72,11 @@ export class PullRequestManager implements IPullRequestManager {
 			}
 		}
 
+		const repositoriesByAuthority: GitHubRepository[] = uniqBy(repositories, repository => repository.remote.gitProtocol.normalizeUri().authority);
+		repositoriesByAuthority.forEach(repository => {
+			this._credentialStore.createAuthenticationStatusBarItem(repository.remote);
+		});
+
 		this._githubRepositories = repositories;
 
 		for (let repository of this._githubRepositories) {


### PR DESCRIPTION
This changes the implementation of the status bar item to be per authority instead of per remote, fixing #265

I still need to fix the status bar text when it's first created and the user's credentials are already in settings or the credential manager. Right now the behavior is that it shows "Sign into X" until `hasOctokit` is called when the user interacts with the tree.

