### PR TITLE
Save telemetry with timestamps, one report per day.

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
     "markdown-it": "^8.4.0",
     "markdown-it-checkbox": "^1.1.0",
     "moment": "^2.22.1",
-    "telemetry-github": "https://github.com/shana/telemetry/releases/download/0.1.1/telemetry-github-v0.1.1.tgz",
+    "telemetry-github": "https://github.com/shana/telemetry/releases/download/0.2.2/telemetry-github-v0.2.2.tgz",
     "tmp": "^0.0.31",
     "vscode": "^1.1.18",
     "ws": "^6.0.0"

--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -173,7 +173,7 @@ class MementoDatabase implements IStatsDatabase {
 
 	private get metrics() {
 		try {
-			return (this._context.globalState.get<DBEntry[]>(TELEMETRY_KEY) || [])
+			return (this._context.globalState.get<DBEntry[]>(TELEMETRY_KEY) || []);
 		} catch { }
 		return [];
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6171,9 +6171,9 @@ tar@^4:
     safe-buffer "^5.1.1"
     yallist "^3.0.2"
 
-"telemetry-github@https://github.com/shana/telemetry/releases/download/0.1.1/telemetry-github-v0.1.1.tgz":
-  version "0.1.1"
-  resolved "https://github.com/shana/telemetry/releases/download/0.1.1/telemetry-github-v0.1.1.tgz#b329dc67f4b3bbc9540f8d0db79e2efaf06606b3"
+"telemetry-github@https://github.com/shana/telemetry/releases/download/0.2.2/telemetry-github-v0.2.2.tgz":
+  version "0.2.2"
+  resolved "https://github.com/shana/telemetry/releases/download/0.2.2/telemetry-github-v0.2.2.tgz#91d5c3b170f03ea325e5ab5092729b81d55e41ad"
   dependencies:
     uuid "^3.3.2"
   optionalDependencies:


### PR DESCRIPTION
Reports older than the current day get submitted in bulk when stats get posted.