### PR TITLE
Fix probing servers for scopes, and fix other mismatch errors when loading hosts

### DIFF
--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -132,7 +132,7 @@ export class GitHubManager {
 			return this.servers.get(host.authority);
 		}
 
-		const options = GitHubManager.getOptions(host, 'HEAD');
+		const options = GitHubManager.getOptions(host, 'HEAD', '/rate_limit');
 		return new Promise<boolean>((resolve, _) => {
 			const get = https.request(options, res => {
 				const ret = res.headers['x-github-request-id'];
@@ -149,7 +149,7 @@ export class GitHubManager {
 		});
 	}
 
-	public static getOptions(hostUri: vscode.Uri, method: string = 'GET', token?: string) {
+	public static getOptions(hostUri: vscode.Uri, method: string = 'GET', path: string, token?: string) {
 		const headers: {
 			'user-agent': string;
 			authorization?: string;
@@ -163,7 +163,7 @@ export class GitHubManager {
 			host: HostHelper.getApiHost(hostUri).authority,
 			port: 443,
 			method,
-			path: HostHelper.getApiPath(hostUri, '/rate_limit'),
+			path: HostHelper.getApiPath(hostUri, path),
 			headers,
 		};
 	}
@@ -207,7 +207,7 @@ export class GitHubServer {
 	}
 
 	public async checkAnonymousAccess(): Promise<boolean> {
-		const options = GitHubManager.getOptions(this.hostUri);
+		const options = GitHubManager.getOptions(this.hostUri, 'GET', '/rate_limit');
 		return new Promise<boolean>((resolve, _) => {
 			const get = https.request(options, res => {
 				resolve(res.statusCode === 200);
@@ -228,7 +228,7 @@ export class GitHubServer {
 			token = this.hostConfiguration.token;
 		}
 
-		const options = GitHubManager.getOptions(this.hostUri, 'GET', token);
+		const options = GitHubManager.getOptions(this.hostUri, 'GET', '/user', token);
 
 		return new Promise<IHostConfiguration>((resolve, _) => {
 			const get = https.request(options, res => {


### PR DESCRIPTION
Fixes #382

Some enterprise servers may not have the /rate_limit path. This is fine for checking whether the server is a GitHub instance (the headers will be returned regardless), but it doesn't work for checking scopes. Since the user:read scope is mandatory, valid credentials will work with the /user endpoint.

This has the added benefit that we can also grab the username in the process so that we can show it elsewhere (not a part of this patch)