### PR TITLE
Add multiroot support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "enableProposedApi": true,
   "preview": true,
-  "version": "0.1.5",
+  "version": "0.2.0",
   "publisher": "GitHub",
   "engines": {
     "vscode": "^1.28.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "version": "0.1.5",
   "publisher": "GitHub",
   "engines": {
-    "vscode": "^1.27.0"
+    "vscode": "^1.28.0"
   },
   "categories": [
     "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,14 +11,14 @@ import { ReviewManager } from './view/reviewManager';
 import { registerCommands } from './commands';
 import Logger from './common/logger';
 import { PullRequestManager } from './github/pullRequestManager';
-import { formatError, isDescendant, filterEvent, onceEvent } from './common/utils';
-import { GitExtension, Repository } from './typings/git';
+import { formatError, filterEvent, onceEvent } from './common/utils';
+import { GitExtension, API as GitAPI, Repository } from './typings/git';
 import { Telemetry } from './common/telemetry';
 import { ITelemetry } from './github/interface';
 
 let telemetry: ITelemetry;
 
-async function init(context: vscode.ExtensionContext, repository: Repository): Promise<void> {
+async function init(context: vscode.ExtensionContext, git: GitAPI, repository: Repository): Promise<void> {
 	Logger.appendLine('Git repository found, initializing review manager and pr tree view.');
 
 	const configuration = new VSCodeConfiguration();
@@ -41,6 +41,30 @@ async function init(context: vscode.ExtensionContext, repository: Repository): P
 	const prManager = new PullRequestManager(configuration, repository, telemetry);
 	const reviewManager = new ReviewManager(context, configuration, repository, prManager, telemetry);
 	registerCommands(context, prManager, reviewManager, telemetry);
+
+	/**
+	 * Since selection changes are per repository, selecting a different repo will trigger two
+	 * selection change events, one for the repository losing selection and one for the repository gaining selection.
+	 * Try to debounce these so that only one update is done.
+	 */
+	let updateRepositoryTimer;
+	git.repositories.forEach(repo => {
+		(<any>repo).ui.onDidChange(_ => {
+			if (updateRepositoryTimer) {
+				clearTimeout(updateRepositoryTimer);
+			}
+
+			updateRepositoryTimer = setTimeout(() => {
+				// no multi select support yet, always show PRs of first selected repository
+				const firstSelectedRepository = git.repositories.filter(r => r.ui.selected)[0];
+				if (firstSelectedRepository) {
+					prManager.repository = firstSelectedRepository;
+					reviewManager.repository = firstSelectedRepository;
+				}
+			}, 50);
+		});
+	});
+
 	telemetry.on('startup');
 }
 
@@ -51,18 +75,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	telemetry = new Telemetry(context);
 
 	const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git').exports;
-	const api = gitExtension.getAPI(1);
+	const git = gitExtension.getAPI(1);
 
 	Logger.appendLine('Looking for git repository');
+	const firstSelectedRepository = git.repositories.filter(r => r.ui.selected)[0];
 
-	const rootPath = vscode.workspace.rootPath;
-	const repository = api.repositories.filter(r => isDescendant(r.rootUri.fsPath, rootPath))[0];
-
-	if (repository) {
-		await init(context, repository);
+	if (firstSelectedRepository) {
+		await init(context, git, firstSelectedRepository);
 	} else {
-		const onDidOpenRelevantRepository = filterEvent(api.onDidOpenRepository, r => isDescendant(r.rootUri.fsPath, rootPath));
-		onceEvent(onDidOpenRelevantRepository)(r => init(context, r));
+		const onDidOpenRelevantRepository = filterEvent(git.onDidOpenRepository, r => r.ui.selected);
+		onceEvent(onDidOpenRelevantRepository)(r => init(context, git, r));
 	}
 }
 

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -143,7 +143,7 @@ export interface IGitHubRepository {
 
 export interface IPullRequestManager {
 	activePullRequest?: IPullRequestModel;
-	readonly repository: Repository;
+	repository: Repository;
 	readonly onDidChangeActivePullRequest: vscode.Event<void>;
 	getLocalPullRequests(): Promise<IPullRequestModel[]>;
 	deleteLocalPullRequest(pullRequest: IPullRequestModel): Promise<void>;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -36,7 +36,7 @@ export class PullRequestManager implements IPullRequestManager {
 
 	constructor(
 		private _configuration: Configuration,
-		readonly repository: Repository,
+		private _repository: Repository,
 		private readonly _telemetry: ITelemetry
 	) {
 		this._githubRepositories = [];
@@ -51,6 +51,14 @@ export class PullRequestManager implements IPullRequestManager {
 	set activePullRequest(pullRequest: IPullRequestModel) {
 		this._activePullRequest = pullRequest;
 		this._onDidChangeActivePullRequest.fire();
+	}
+
+	get repository(): Repository {
+		return this._repository;
+	}
+
+	set repository(repository: Repository) {
+		this._repository = repository;
 	}
 
 	async clearCredentialCache(): Promise<void> {

--- a/src/typings/git.d.ts
+++ b/src/typings/git.d.ts
@@ -74,11 +74,17 @@ export interface RepositoryState {
 	readonly onDidChange: Event<void>;
 }
 
+export interface RepositoryUIState {
+	readonly selected: boolean;
+	readonly onDidChange: Event<void>;
+}
+
 export interface Repository {
 
 	readonly rootUri: Uri;
 	readonly inputBox: InputBox;
 	readonly state: RepositoryState;
+	readonly ui: RepositoryUIState;
 
 	getConfigs(): Promise<{ key: string; value: string; }[]>;
 	getConfig(key: string): Promise<string>;
@@ -141,6 +147,7 @@ export const enum GitErrorCodes {
 	NotAGitRepository = 'NotAGitRepository',
 	NotAtRepositoryRoot = 'NotAtRepositoryRoot',
 	Conflict = 'Conflict',
+	StashConflict = 'StashConflict',
 	UnmergedChanges = 'UnmergedChanges',
 	PushRejected = 'PushRejected',
 	RemoteConnectionError = 'RemoteConnectionError',

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import { IConfiguration } from '../authentication/configuration';
-import { Repository } from '../typings/git';
 import { TreeNode } from './treeNodes/treeNode';
 import { PRCategoryActionNode, CategoryTreeNode, PRCategoryActionType } from './treeNodes/categoryNode';
 import { IPullRequestManager, PRType, ITelemetry } from '../github/interface';
@@ -23,7 +22,6 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 
 	constructor(
 		private _configuration: IConfiguration,
-		private _repository: Repository,
 		private _prManager: IPullRequestManager,
 		private _telemetry: ITelemetry
 	) {
@@ -62,17 +60,17 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 			}
 
 			let result = [
-				new CategoryTreeNode(this._prManager, this._telemetry, this._repository, PRType.LocalPullRequest),
-				new CategoryTreeNode(this._prManager, this._telemetry, this._repository, PRType.RequestReview),
-				new CategoryTreeNode(this._prManager, this._telemetry, this._repository, PRType.AssignedToMe),
-				new CategoryTreeNode(this._prManager, this._telemetry, this._repository, PRType.Mine),
-				new CategoryTreeNode(this._prManager, this._telemetry, this._repository, PRType.All)
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.LocalPullRequest),
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.RequestReview),
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.AssignedToMe),
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.Mine),
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.All)
 			];
 
 			this._childrenDisposables = result;
 			return Promise.resolve(result);
 		}
-		if (this._repository.state.remotes.length === 0) {
+		if (this._prManager.repository.state.remotes.length === 0) {
 			return Promise.resolve([new PRCategoryActionNode(PRCategoryActionType.Empty)]);
 		}
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -137,7 +137,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			this._prsTreeDataProvider.refresh(prNode);
 		}));
 
-		this._prsTreeDataProvider = new PullRequestsTreeDataProvider(this._configuration, _repository, _prManager, this._telemetry);
+		this._prsTreeDataProvider = new PullRequestsTreeDataProvider(this._configuration, _prManager, this._telemetry);
 		this._disposables.push(this._prsTreeDataProvider);
 		this._disposables.push(vscode.window.registerDecorationProvider(this));
 
@@ -169,6 +169,11 @@ export class ReviewManager implements vscode.DecorationProvider {
 		}
 
 		return this._statusBarItem;
+	}
+
+	set repository(repository: Repository) {
+		this._repository = repository;
+		this.updateState();
 	}
 
 	private pollForStatusChange() {

--- a/src/view/treeNodes/categoryNode.ts
+++ b/src/view/treeNodes/categoryNode.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { Repository } from '../../typings/git';
 import { IPullRequestManager, IPullRequestModel, PRType, ITelemetry } from '../../github/interface';
 import { PRNode } from './pullRequestNode';
 import { TreeNode } from './treeNode';
@@ -75,7 +74,6 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 	constructor(
 		private _prManager: IPullRequestManager,
 		private _telemetry: ITelemetry,
-		private _repository: Repository,
 		private _type: PRType
 	) {
 		super();
@@ -154,7 +152,7 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 		}
 
 		if (this.prs && this.prs.length) {
-			let nodes: TreeNode[] = this.prs.map(prItem => new PRNode(this._prManager, this._repository, prItem, this._type === PRType.LocalPullRequest));
+			let nodes: TreeNode[] = this.prs.map(prItem => new PRNode(this._prManager, prItem, this._type === PRType.LocalPullRequest));
 			if (hasMorePages) {
 				nodes.push(new PRCategoryActionNode(PRCategoryActionType.More, this));
 			}

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -9,7 +9,6 @@ import { parseDiff, getModifiedContentFromDiffHunk, DiffChangeType } from '../..
 import { mapHeadLineToDiffHunkPosition, getZeroBased, getAbsolutePosition, getPositionInDiff } from '../../common/diffPositionMapping';
 import { SlimFileChange, GitChangeType } from '../../common/file';
 import Logger from '../../common/logger';
-import { Repository } from '../../typings/git';
 import { Resource } from '../../common/resources';
 import { fromPRUri, toPRUri } from '../../common/uri';
 import { groupBy, formatError } from '../../common/utils';
@@ -214,7 +213,6 @@ export class PRNode extends TreeNode {
 
 	constructor(
 		private _prManager: IPullRequestManager,
-		private repository: Repository,
 		public pullRequestModel: IPullRequestModel,
 		private _isLocal: boolean
 	) {
@@ -234,7 +232,7 @@ export class PRNode extends TreeNode {
 			const data = await this._prManager.getPullRequestChangedFiles(this.pullRequestModel);
 			await this._prManager.fullfillPullRequestMissingInfo(this.pullRequestModel);
 			let mergeBase = this.pullRequestModel.mergeBase;
-			const rawChanges = await parseDiff(data, this.repository, mergeBase);
+			const rawChanges = await parseDiff(data, this._prManager.repository, mergeBase);
 			let fileChanges = rawChanges.map(change => {
 				if (change instanceof SlimFileChange) {
 					return new RemoteFileChangeNode(
@@ -404,8 +402,8 @@ export class PRNode extends TreeNode {
 				}
 			} else {
 				const originalFileName = fileChange.status === GitChangeType.RENAME ? fileChange.previousFileName : fileChange.fileName;
-				const originalFilePath = path.join(this.repository.rootUri.fsPath, originalFileName);
-				const originalContent = await this.repository.show(params.commit, originalFilePath);
+				const originalFilePath = path.join(this._prManager.repository.rootUri.fsPath, originalFileName);
+				const originalContent = await this._prManager.repository.show(params.commit, originalFilePath);
 
 				if (params.base) {
 					return originalContent;


### PR DESCRIPTION
When there are multiple folders in the workspace, changing selection updates the view (and all review state) to be the selected folder.

![folder_select](https://user-images.githubusercontent.com/3672607/45836568-119d5100-bcc2-11e8-83bb-e009dac24c8c.gif)

Doesn't add multi-select since the UI for that hasn't been decided (tree view for each selected folder? one tree view with top level nodes being the folders?), just shows the first selected folder in this case.

https://github.com/Microsoft/vscode-pull-request-github/issues/386