### PR TITLE
Improve keyboard focus

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -248,7 +248,6 @@ body .overview-title button {
 	display: flex;
 	align-items: center;
 	line-height: 18px;
-	overflow: hidden;
 	white-space: nowrap;
 }
 

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -139,6 +139,11 @@ body button {
 	user-select: none;
 }
 
+button:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
 button:hover:enabled, button:focus:enabled {
 	background-color: var(--vscode-button-hoverBackground);
 	cursor: pointer;
@@ -573,7 +578,8 @@ code {
 }
 
 .vscode-high-contrast button {
-	background: none;
+	outline: none;
+	background: none !important;
 	border: 1px solid var(--vscode-contrastBorder);
 }
 

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -345,7 +345,6 @@ body .comment-form textarea:focus {
 }
 
 body .comment-form .form-actions {
-	overflow: auto;
 	padding-top: 20px;
 	margin-bottom: 10px;
 	display: flex;


### PR DESCRIPTION
Fixes #319

This adds an outline offset for buttons so that they're noticeable and also shows the full outline for avatars (was previously cut off)

<img width="144" alt="image" src="https://user-images.githubusercontent.com/35271042/46326509-e5cb7680-c5b1-11e8-93fd-97e289a71d1f.png">
<img width="108" alt="image" src="https://user-images.githubusercontent.com/35271042/46326512-ebc15780-c5b1-11e8-9e0b-d279c22c8b2f.png">
