### PR TITLE
Add "Reviewed by me" as a top-level filter in viewlet #460

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -210,6 +210,9 @@ export class GitHubRepository implements IGitHubRepository {
 			case PRType.Mine:
 				filter = `author:${user}`;
 				break;
+			case PRType.ReviewedByMe:
+				filter = `-review:none -review:required reviewed-by:${user}`;
+				break;
 			default:
 				break;
 		}

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -204,14 +204,14 @@ export class GitHubRepository implements IGitHubRepository {
 			case PRType.RequestReview:
 				filter = `review-requested:${user}`;
 				break;
+			case PRType.ReviewedByMe:
+				filter = `-review:none -review:required reviewed-by:${user}`;
+				break;
 			case PRType.AssignedToMe:
 				filter = `assignee:${user}`;
 				break;
 			case PRType.Mine:
 				filter = `author:${user}`;
-				break;
-			case PRType.ReviewedByMe:
-				filter = `-review:none -review:required reviewed-by:${user}`;
 				break;
 			default:
 				break;

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -16,7 +16,8 @@ export enum PRType {
 	Mine = 2,
 	Mention = 3,
 	All = 4,
-	LocalPullRequest = 5
+	LocalPullRequest = 5,
+	ReviewedByMe = 6
 }
 
 export enum ReviewEvent {
@@ -206,6 +207,7 @@ export interface ITelemetry {
 	on(action: 'prListExpandAssignedToMe'): Promise<void>;
 	on(action: 'prListExpandMine'): Promise<void>;
 	on(action: 'prListExpandAll'): Promise<void>;
+	on(action: 'prListExpandReviewedByMe'): Promise<void>;
 	on(action: 'prCheckoutFromContext'): Promise<void>;
 	on(action: 'prCheckoutFromDescription'): Promise<void>;
 	on(action: string): Promise<void>;

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -64,6 +64,7 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.RequestReview),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.AssignedToMe),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.Mine),
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.ReviewedByMe),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.All)
 			];
 

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -62,9 +62,9 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 			let result = [
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.LocalPullRequest),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.RequestReview),
+				new CategoryTreeNode(this._prManager, this._telemetry, PRType.ReviewedByMe),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.AssignedToMe),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.Mine),
-				new CategoryTreeNode(this._prManager, this._telemetry, PRType.ReviewedByMe),
 				new CategoryTreeNode(this._prManager, this._telemetry, PRType.All)
 			];
 

--- a/src/view/treeNodes/categoryNode.ts
+++ b/src/view/treeNodes/categoryNode.ts
@@ -96,6 +96,9 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 			case PRType.LocalPullRequest:
 				this.label = 'Local Pull Request Branches';
 				break;
+			case PRType.ReviewedByMe:
+				this.label = 'Reviewed By Me';
+				break;
 			default:
 				break;
 		}
@@ -127,6 +130,9 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 							break;
 						case PRType.RequestReview:
 							this._telemetry.on('prList.expand.requestReview');
+							break;
+						case PRType.ReviewedByMe:
+							this._telemetry.on('prList.expand.reviewedByMe');
 							break;
 						case PRType.Mine:
 							this._telemetry.on('prList.expand.mine');

--- a/src/view/treeNodes/categoryNode.ts
+++ b/src/view/treeNodes/categoryNode.ts
@@ -87,6 +87,9 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 			case PRType.RequestReview:
 				this.label = 'Waiting For My Review';
 				break;
+			case PRType.ReviewedByMe:
+				this.label = 'Reviewed By Me';
+				break;
 			case PRType.AssignedToMe:
 				this.label = 'Assigned To Me';
 				break;
@@ -95,9 +98,6 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 				break;
 			case PRType.LocalPullRequest:
 				this.label = 'Local Pull Request Branches';
-				break;
-			case PRType.ReviewedByMe:
-				this.label = 'Reviewed By Me';
 				break;
 			default:
 				break;


### PR DESCRIPTION
Due to the limitation to GitHub search query, we are not allowed to put OR condition. Therefore, we are not able to achieve review:approved OR review:changes_requested in a proper manner. The workaround is to exclude the other review status from the full review statuses list.

Ref:
[https://help.github.com/articles/searching-issues-and-pull-requests/#search-by-pull-request-review-status](url) 