### PR TITLE
Receive GitHub auth tokens with a URI handler rather than a WebSocket

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -304,11 +304,10 @@ END OF omnidan/node-emoji NOTICES AND INFORMATION
 
 
 %% bitinn/node-fetch NOTICES AND INFORMATION BEGIN HERE
-=========================================
 The MIT License (MIT)
 
 Copyright (c) 2016 David Frank
-
+=======
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -316,8 +315,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -328,6 +327,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
 END OF bitinn/node-fetch NOTICES AND INFORMATION
+
+
+%% axios/axios NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present Matt Zabriskie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF axios/axios NOTICES AND INFORMATION
 
 
 %% stefanpenner/es6-promise NOTICES AND INFORMATION BEGIN HERE

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -304,10 +304,11 @@ END OF omnidan/node-emoji NOTICES AND INFORMATION
 
 
 %% bitinn/node-fetch NOTICES AND INFORMATION BEGIN HERE
+=========================================
 The MIT License (MIT)
 
 Copyright (c) 2016 David Frank
-=======
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -315,8 +316,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/package.json
+++ b/package.json
@@ -297,7 +297,11 @@
   },
   "dependencies": {
     "@octokit/rest": "^15.9.5",
+<<<<<<< HEAD
     "es6-promise": "^4.2.5",
+=======
+    "axios": "^0.18.0",
+>>>>>>> Receive GitHub auth tokens with a URI handler rather than a WebSocket backchannel.
     "git-credential-node": "^1.1.0",
     "iconv-lite": "0.4.23",
     "markdown-it": "^8.4.0",
@@ -305,7 +309,10 @@
     "markdown-it-sanitizer": "github:rebornix/markdown-it-sanitizer#master",
     "moment": "^2.22.1",
     "node-emoji": "^1.8.1",
+<<<<<<< HEAD
     "node-fetch": "^2.1.1",
+=======
+>>>>>>> Receive GitHub auth tokens with a URI handler rather than a WebSocket backchannel.
     "telemetry-github": "https://github.com/shana/telemetry/releases/download/0.3.2/telemetry-github-v0.3.2.tgz",
     "vscode": "^1.1.18",
     "ws": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -297,11 +297,8 @@
   },
   "dependencies": {
     "@octokit/rest": "^15.9.5",
-<<<<<<< HEAD
     "es6-promise": "^4.2.5",
-=======
     "axios": "^0.18.0",
->>>>>>> Receive GitHub auth tokens with a URI handler rather than a WebSocket backchannel.
     "git-credential-node": "^1.1.0",
     "iconv-lite": "0.4.23",
     "markdown-it": "^8.4.0",
@@ -309,10 +306,7 @@
     "markdown-it-sanitizer": "github:rebornix/markdown-it-sanitizer#master",
     "moment": "^2.22.1",
     "node-emoji": "^1.8.1",
-<<<<<<< HEAD
     "node-fetch": "^2.1.1",
-=======
->>>>>>> Receive GitHub auth tokens with a URI handler rather than a WebSocket backchannel.
     "telemetry-github": "https://github.com/shana/telemetry/releases/download/0.3.2/telemetry-github-v0.3.2.tgz",
     "vscode": "^1.1.18",
     "ws": "^6.0.0"

--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -3,7 +3,7 @@ import { IHostConfiguration, HostHelper } from './configuration';
 import * as https from 'https';
 import Logger from '../common/logger';
 import { handler as uriHandler } from '../common/uri';
-import { toPromise, PromiseAdapter } from '../common/utils';
+import { PromiseAdapter, promiseFromEmitter } from '../common/utils';
 import axios from 'axios';
 const SCOPES: string = 'read:user user:email repo write:discussion';
 const GHE_OPTIONAL_SCOPES: object = {'write:discussion': true};
@@ -138,7 +138,7 @@ export class GitHubServer {
 			`${AUTH_RELAY_SERVER}/authorize?authServer=${host}&callbackUri=${CALLBACK_URI}&scope=${SCOPES}`
 		);
 		vscode.commands.executeCommand('vscode.open', uri);
-		return uriHandler[toPromise](verifyToken(host));
+		return promiseFromEmitter(uriHandler, verifyToken(host));
 	}
 
 	public async validate(username?: string, token?: string): Promise<IHostConfiguration> {

--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -7,8 +7,6 @@ import axios from 'axios';
 const SCOPES: string = 'read:user user:email repo write:discussion';
 const GHE_OPTIONAL_SCOPES: object = {'write:discussion': true};
 
-// const AUTH_RELAY_SERVER = 'http://localhost:55555'
-// const AUTH_RELAY_SERVER = 'https://client-auth-staging-14a768b.herokuapp.com'
 const AUTH_RELAY_SERVER = 'https://vscode-auth.github.com'
 const EXTENSION_ID = 'GitHub.vscode-pull-request-github'
 const CALLBACK_PATH = '/did-authenticate'

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { Uri } from 'vscode';
+import { Uri, UriHandler, EventEmitter } from 'vscode';
 import { IPullRequestModel } from '../github/interface';
 
 export interface ReviewUriParams {
@@ -101,3 +101,11 @@ export function toPRUri(uri: Uri, pullRequestModel: IPullRequestModel, commit: s
 		query: JSON.stringify(params)
 	});
 }
+
+class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
+	public handleUri(uri: Uri) {
+		this.fire(uri)
+	}
+}
+
+export const handler = new UriEventHandler

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -104,8 +104,8 @@ export function toPRUri(uri: Uri, pullRequestModel: IPullRequestModel, commit: s
 
 class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
 	public handleUri(uri: Uri) {
-		this.fire(uri)
+		this.fire(uri);
 	}
 }
 
-export const handler = new UriEventHandler
+export const handler = new UriEventHandler;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -156,6 +156,7 @@ const passthrough = (value, resolve) => resolve(value);
  *
  * The default adapter is the passthrough function `(value, resolve) => resolve(value)`.
  *
+ * @param {EventEmitter<T>} emitter the event source
  * @param {PromiseAdapter<T, U>?} adapter controls resolution of the returned promise
  * @returns {Promise<U>} a promise that resolves or rejects as specified by the adapter
  */

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -148,16 +148,35 @@ export interface PromiseAdapter<T, U> {
 
 declare module 'vscode' {
 	interface EventEmitter<T> {
+		/**
+		 * Return a promise that resolves with the next emitted event, or with some future
+		 * event as decided by an adapter.
+		 *
+		 * If specified, the adapter is a function that will be called with
+		 * `(event, resolve, reject)`. It will be called once per event until it resolves or
+		 * rejects.
+		 *
+		 * The default adapter is the passthrough function `(value, resolve) => resolve(value)`.
+		 *
+		 * @param {PromiseAdapter<T, U>?} adapter controls resolution of the returned promise
+		 * @returns {Promise<U>} a promise that resolves or rejects as specified by the adapter
+		 */
 		[toPromise]<U>(adapter?: PromiseAdapter<T, U>): Promise<U>;
 	}
 }
 
-const passthrough = (value, resolve, reject) => resolve(value);
+const passthrough = (value, resolve) => resolve(value);
 
 EventEmitter.prototype[toPromise] = async function<T, U>(adapter=passthrough as PromiseAdapter<T, U>) {
 	let subscription;
 	return new Promise<U>((resolve, reject) =>
-		subscription = this.event((value: T) => adapter(value, resolve, reject))
+		subscription = this.event((value: T) => {
+			try {
+				adapter(value, resolve, reject);
+			} catch(error) {
+				reject(error);
+			}
+		})
 	).then(
 		(result: U) => {
 			subscription.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { PullRequestManager } from './github/pullRequestManager';
 import { formatError, onceEvent } from './common/utils';
 import { GitExtension, API as GitAPI, Repository } from './typings/git';
 import { Telemetry } from './common/telemetry';
+import { handler as uriHandler } from './common/uri';
 import { ITelemetry } from './github/interface';
 
 // fetch.promise polyfill
@@ -42,6 +43,8 @@ async function init(context: vscode.ExtensionContext, git: GitAPI, repository: R
 	});
 
 	context.subscriptions.push(configuration.listenForVSCodeChanges());
+
+	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
 
 	const prManager = new PullRequestManager(configuration, repository, telemetry);
 	const reviewManager = new ReviewManager(context, configuration, repository, prManager, telemetry);

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as utils from '../../common/utils';
+import { EventEmitter } from 'vscode';
 import * as Octokit from '@octokit/rest';
 
 describe('utils', () => {
@@ -32,6 +33,88 @@ describe('utils', () => {
 		it('should format an error with submessages that are strings', () => {
 			const error = new Error(`{"message":"Validation Failed","errors":["Can not approve your own pull request"],"documentation_url":"https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review"}`);
 			assert.equal(utils.formatError(error), 'Validation Failed: Can not approve your own pull request');
+		});
+	});
+
+	describe.only('EventEmitter[toPromise]', () => {
+		const hasListeners = (emitter: any) =>
+			!emitter._listeners!.isEmpty();
+
+		describe('without arguments', () => {
+			it('should return a promise for the next event', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = emitter[utils.toPromise]();
+				emitter.fire('hello');
+				emitter.fire('world');
+				const value = await promise;
+				assert.equal(value, 'hello');
+			});
+
+			it('should unsubscribe after the promise resolves', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = emitter[utils.toPromise]();
+				assert(hasListeners(emitter), 'should subscribe');
+				emitter.fire('hello');
+				await promise;
+				assert(!hasListeners(emitter), 'should unsubscribe');
+			});
+		});
+
+		describe('with an adapter', () => {
+			const count: utils.PromiseAdapter<string, number> =
+				(str, resolve, reject) =>
+					str.length <= 4
+						? resolve(str.length)
+						: reject(new Error('the string is too damn long'));
+
+			it('should return a promise that uses the adapter\'s value', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = emitter[utils.toPromise](count);
+				assert(hasListeners(emitter), 'should subscribe');
+				emitter.fire('hell');
+				const value = await promise;
+				assert(!hasListeners(emitter), 'should unsubscribe');
+				assert.equal(value, 'hell'.length);
+			});
+
+			it('should return a promise that rejects if the adapter does', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = emitter[utils.toPromise](count);
+				assert(hasListeners(emitter), 'should subscribe');
+				emitter.fire('hello');
+				await promise
+					.then(
+						() => { throw new Error('promise should have rejected'); },
+						e => assert.equal(e.message, 'the string is too damn long')
+					);
+				assert(!hasListeners(emitter), 'should unsubscribe');
+			});
+
+			const door: utils.PromiseAdapter<string, boolean> =
+				(password, resolve, reject) =>
+					password === 'sesame'
+						? resolve(true)
+						:
+					password === 'mellon'
+						? reject(new Error('wrong fable'))
+						:
+						{/* the door is silent */};
+
+			const tick = () => new Promise(resolve => setImmediate(resolve));
+			it('should stay subscribed until the adapter resolves', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = emitter[utils.toPromise](door);
+				let hasResolved = false; promise.then(() => hasResolved = true);
+				emitter.fire('password');
+				emitter.fire('12345');
+				await tick();
+				assert.equal(hasResolved, false, 'shouldn\'t have resolved yet');
+				assert(hasListeners(emitter), 'should still be listening');
+				emitter.fire('sesame');
+				await tick();
+				assert.equal(hasResolved, true, 'should have resolved');
+				assert(!hasListeners(emitter), 'should have unsubscribed');
+			});
 		});
 	});
 });

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -90,6 +90,19 @@ describe('utils', () => {
 				assert(!hasListeners(emitter), 'should unsubscribe');
 			});
 
+			it('should return a promise that rejects if the adapter throws', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = emitter[utils.toPromise](() => { throw new Error('kaboom'); });
+				assert(hasListeners(emitter), 'should subscribe');
+				emitter.fire('hello');
+				await promise
+					.then(
+						() => { throw new Error('promise should have rejected'); },
+						e => assert.equal(e.message, 'kaboom')
+					);
+				assert(!hasListeners(emitter), 'should unsubscribe');
+			});
+
 			const door: utils.PromiseAdapter<string, boolean> =
 				(password, resolve, reject) =>
 					password === 'sesame'

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -36,14 +36,14 @@ describe('utils', () => {
 		});
 	});
 
-	describe('EventEmitter[toPromise]', () => {
+	describe('promiseFromEmitter', () => {
 		const hasListeners = (emitter: any) =>
 			!emitter._listeners!.isEmpty();
 
 		describe('without arguments', () => {
 			it('should return a promise for the next event', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise]();
+				const promise = utils.promiseFromEmitter(emitter);
 				emitter.fire('hello');
 				emitter.fire('world');
 				const value = await promise;
@@ -52,7 +52,7 @@ describe('utils', () => {
 
 			it('should unsubscribe after the promise resolves', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise]();
+				const promise = utils.promiseFromEmitter(emitter);
 				assert(hasListeners(emitter), 'should subscribe');
 				emitter.fire('hello');
 				await promise;
@@ -69,7 +69,7 @@ describe('utils', () => {
 
 			it('should return a promise that uses the adapter\'s value', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise](count);
+				const promise = utils.promiseFromEmitter(emitter, count);
 				assert(hasListeners(emitter), 'should subscribe');
 				emitter.fire('hell');
 				const value = await promise;
@@ -79,7 +79,7 @@ describe('utils', () => {
 
 			it('should return a promise that rejects if the adapter does', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise](count);
+				const promise = utils.promiseFromEmitter(emitter, count);
 				assert(hasListeners(emitter), 'should subscribe');
 				emitter.fire('hello');
 				await promise
@@ -92,7 +92,10 @@ describe('utils', () => {
 
 			it('should return a promise that rejects if the adapter throws', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise](() => { throw new Error('kaboom'); });
+				const promise = utils.promiseFromEmitter(
+					emitter,
+					() => { throw new Error('kaboom'); }
+				);
 				assert(hasListeners(emitter), 'should subscribe');
 				emitter.fire('hello');
 				await promise
@@ -116,7 +119,7 @@ describe('utils', () => {
 			const tick = () => new Promise(resolve => setImmediate(resolve));
 			it('should stay subscribed until the adapter resolves', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise](door);
+				const promise = utils.promiseFromEmitter(emitter, door);
 				let hasResolved = false; promise.then(() => hasResolved = true);
 				emitter.fire('password');
 				emitter.fire('12345');
@@ -131,7 +134,7 @@ describe('utils', () => {
 
 			it('should stay subscribed until the adapter rejects', async () => {
 				const emitter = new EventEmitter<string>();
-				const promise = emitter[utils.toPromise](door);
+				const promise = utils.promiseFromEmitter(emitter, door);
 				let hasResolved = false, hasRejected = false;
 				promise.then(() => hasResolved = true, () => hasRejected = true);
 				emitter.fire('password');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5446,7 +5446,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -7255,13 +7255,6 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
-
-tmp@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
-  integrity sha1-jzirlDjhcxXl29izZX6L+yd65Kc=
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 tmp@^0.0.33:
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,6 +613,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2144,7 +2152,7 @@ dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@3.1.0, debug@^3.1.0:
+debug@3.1.0, debug@=3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -2844,6 +2852,13 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
+
+follow-redirects@^1.3.0:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"
+  integrity sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -5431,7 +5446,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -7240,6 +7255,13 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  integrity sha1-jzirlDjhcxXl29izZX6L+yd65Kc=
+  dependencies:
+    os-tmpdir "~1.0.1"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
The good news: We'll no longer be opening a websocket to the auth server. This entirely removes the possibility of an IP mismatch. The code is a lot simpler as well, which is a nice bonus.

The bad news: Both the browser and VS Code will ask if you want to open the custom URI scheme. On top of that, the auth server asks you if you want to allow the extension to access GitHub, and then GitHub asks you if VS Code in general can access GitHub. Nobody asks you if GitHub can access GitHub, but it's only a matter of time.

Fixes #533, #462, #541 (probably! We now trigger the browser immediately, so the auth flow should have a fighting chance to get underway, though there's always the possibility that we'll quickly run aground on a different reef).

/cc: @sguthals @shana @RMacfarlane 