### PR TITLE
Fix timing issue with initialization by relaxing selected repo condition

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { ReviewManager } from './view/reviewManager';
 import { registerCommands } from './commands';
 import Logger from './common/logger';
 import { PullRequestManager } from './github/pullRequestManager';
-import { formatError, filterEvent, onceEvent } from './common/utils';
+import { formatError, onceEvent } from './common/utils';
 import { GitExtension, API as GitAPI, Repository } from './typings/git';
 import { Telemetry } from './common/telemetry';
 import { ITelemetry } from './github/interface';
@@ -78,13 +78,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	const git = gitExtension.getAPI(1);
 
 	Logger.appendLine('Looking for git repository');
-	const firstSelectedRepository = git.repositories.filter(r => r.ui.selected)[0];
+	const firstRepository = git.repositories[0];
 
-	if (firstSelectedRepository) {
-		await init(context, git, firstSelectedRepository);
+	if (firstRepository) {
+		await init(context, git, firstRepository);
 	} else {
-		const onDidOpenRelevantRepository = filterEvent(git.onDidOpenRepository, r => r.ui.selected);
-		onceEvent(onDidOpenRelevantRepository)(r => init(context, git, r));
+		onceEvent(git.onDidOpenRepository)(r => init(context, git, r));
 	}
 }
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -189,7 +189,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		if (!this._validateStatusInProgress) {
 			this._validateStatusInProgress = this.validateState();
 		} else {
-			this._validateStatusInProgress.then(_ => this.validateState());
+			this._validateStatusInProgress.then(_ => this._validateStatusInProgress = this.validateState());
 		}
 	}
 


### PR DESCRIPTION
Small fix - when running out of sources, I noticed the tree view doesn't always get initialized. The `ui.selected` property is initialized to `false` and then gets updated as the workbench load, so there was a data race between that being updated and the extension activating.

Since the initial selected repository is always the first one in the list, or the first one opened, I opted for just removing the the `ui.selected` check.