### PR TITLE
update css with proper padding for commits

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -22,6 +22,11 @@ a:focus, input:focus, select:focus, textarea:focus {
 	border: none;
 }
 
+#timeline-events {
+	padding: 8px 0;
+	border-bottom: 1px solid var(--border-color);
+}
+
 h2 {
 	margin: 0;
 }
@@ -282,12 +287,8 @@ body .overview-title button {
 	border-top: 1px solid var(--border-color);
 }
 
-.comment-container:last-of-type {
-	border-bottom: 1px solid var(--border-color);
-}
-
 .comment-container[data-type="commit"] {
-	padding: 8px 0;
+	padding: 5px 0;
 }
 
 .comment-container[data-type="commit"] + .comment-container[data-type="commit"],


### PR DESCRIPTION
#293

- fixed border to outer container of timeline events
- added improved padding for comment container of commit types

![](https://i.imgur.com/CLC1jcb.png)

Padding should be `5px` in my opinion because the base height of a `comment-container` with type `data-type="commit"` is `18px`. Based on this and with golden ratio we will get around of margin of `~10px-11px` (`18 * 0.61 = 10.98`). Basically this is a padding of 5px on top and on bottom of the `comment-container` elements.