### PR TITLE
Support ssh remotes

### DIFF
--- a/src/common/protocol.ts
+++ b/src/common/protocol.ts
@@ -150,6 +150,54 @@ export class Protocol {
 		}
 	}
 
+	toString(): string {
+		// based on Uri scheme for SSH https://tools.ietf.org/id/draft-salowey-secsh-uri-00.html#anchor1 and heuristics of how GitHub handles ssh url
+		// sshUri        = `ssh:`
+		//    - omitted
+		// hier-part     =  "//" authority path-abempty
+		//    - // is omitted
+		// authority     = [ [ ssh-info ] "@" host ] [ ":" port]
+		//   - ssh-info: git
+		//   - host: ${this.host}
+		//   - port: omitted
+		// path-abempty  = <as specified in [RFC3986]>
+		//   - we use relative path here `${this.owner}/${this.repositoryName}`
+		if (this.type === ProtocolType.SSH) {
+			return `git@${this.host}:${this.owner}/${this.repositoryName}`;
+		}
+
+		if (this.type === ProtocolType.GIT) {
+			return `git://git@${this.host}:${this.owner}/${this.repositoryName}`;
+		}
+
+		let normalizedUri = this.normalizeUri();
+		if (normalizedUri) {
+			return normalizedUri.toString();
+		}
+
+		return null;
+	}
+
+	with(change: { type?: ProtocolType; host?: string; owner?: string; repositoryName?: string; }): Protocol {
+		if (change.type) {
+			this.type = change.type;
+		}
+
+		if (change.host) {
+			this.host = change.host;
+		}
+
+		if (change.owner) {
+			this.owner = change.owner;
+		}
+
+		if (change.repositoryName) {
+			this.repositoryName = change.repositoryName;
+		}
+
+		return this;
+	}
+
 	equals(other: Protocol) {
 		return this.normalizeUri().toString().toLocaleLowerCase() === other.normalizeUri().toString().toLocaleLowerCase();
 	}

--- a/src/common/protocol.ts
+++ b/src/common/protocol.ts
@@ -178,7 +178,7 @@ export class Protocol {
 		return null;
 	}
 
-	with(change: { type?: ProtocolType; host?: string; owner?: string; repositoryName?: string; }): Protocol {
+	update(change: { type?: ProtocolType; host?: string; owner?: string; repositoryName?: string; }): Protocol {
 		if (change.type) {
 			this.type = change.type;
 		}

--- a/src/common/remote.ts
+++ b/src/common/remote.ts
@@ -49,7 +49,7 @@ export class Remote {
 export function parseRemote(remoteName: string, url: string, originalProtocol?: Protocol): Remote | null {
 	let gitProtocol = new Protocol(url);
 	if (originalProtocol) {
-		gitProtocol.with({
+		gitProtocol.update({
 			type: originalProtocol.type
 		});
 	}

--- a/src/common/remote.ts
+++ b/src/common/remote.ts
@@ -46,8 +46,13 @@ export class Remote {
 	}
 }
 
-export function parseRemote(remoteName: string, url: string): Remote | null {
+export function parseRemote(remoteName: string, url: string, originalProtocol?: Protocol): Remote | null {
 	let gitProtocol = new Protocol(url);
+	if (originalProtocol) {
+		gitProtocol.with({
+			type: originalProtocol.type
+		});
+	}
 
 	if (gitProtocol.host) {
 		return new Remote(remoteName, url, gitProtocol);

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -44,7 +44,7 @@ export class GitHubRepository implements IGitHubRepository {
 				repo: remote.repositoryName
 			});
 
-			this.remote = parseRemote(remote.remoteName, data.clone_url);
+			this.remote = parseRemote(remote.remoteName, data.clone_url, remote.gitProtocol);
 		} catch (e) {
 			Logger.appendLine(`Unable to resolve remote: ${e}`);
 		}

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -118,6 +118,7 @@ export interface Commit {
 }
 
 export interface IPullRequestModel {
+	remote: Remote;
 	prNumber: number;
 	title: string;
 	html_url: string;

--- a/src/github/pullRequestGitHelper.ts
+++ b/src/github/pullRequestGitHelper.ts
@@ -37,7 +37,7 @@ export class PullRequestGitHelper {
 			// the branch is from a fork
 			// create remote for this fork
 			Logger.appendLine(`GitHelper> branch ${localBranchName} is from a fork. Create a remote first.`);
-			let remoteName = await PullRequestGitHelper.createRemote(repository, pullRequest.head.repositoryCloneUrl);
+			let remoteName = await PullRequestGitHelper.createRemote(repository, pullRequest.remote, pullRequest.head.repositoryCloneUrl);
 			// fetch the branch
 			let ref = `${pullRequest.head.ref}:${localBranchName}`;
 			await repository.fetch(remoteName, ref);
@@ -163,7 +163,7 @@ export class PullRequestGitHelper {
 		}
 	}
 
-	static async createRemote(repository: Repository, cloneUrl: Protocol) {
+	static async createRemote(repository: Repository, baseRemote: Remote, cloneUrl: Protocol) {
 		Logger.appendLine(`GitHelper> create remote for ${cloneUrl}.`);
 
 		let remotes = parseRepositoryRemotes(repository);
@@ -174,7 +174,10 @@ export class PullRequestGitHelper {
 		}
 
 		let remoteName = PullRequestGitHelper.getUniqueRemoteName(repository, cloneUrl.owner);
-		await repository.addRemote(remoteName, cloneUrl.normalizeUri().toString());
+		cloneUrl = cloneUrl.with({
+			type: baseRemote.gitProtocol.type
+		});
+		await repository.addRemote(remoteName, cloneUrl.toString());
 		await repository.setConfig(`remote.${remoteName}.${PullRequestRemoteMetadataKey}`, 'true');
 		return remoteName;
 	}

--- a/src/github/pullRequestGitHelper.ts
+++ b/src/github/pullRequestGitHelper.ts
@@ -174,7 +174,7 @@ export class PullRequestGitHelper {
 		}
 
 		let remoteName = PullRequestGitHelper.getUniqueRemoteName(repository, cloneUrl.owner);
-		cloneUrl = cloneUrl.with({
+		cloneUrl.update({
 			type: baseRemote.gitProtocol.type
 		});
 		await repository.addRemote(remoteName, cloneUrl.toString());

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -4,26 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Protocol } from '../../common/protocol';
+import { Protocol, ProtocolType } from '../../common/protocol';
 
 describe('Protocol', () => {
 	it('should handle HTTP and HTTPS remotes', () => {
 		[
-			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'http://rmacfarlane:password@github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'http://github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'http://github.com/Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'http://github.com:/Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'http://github.com:433/Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://rmacfarlane@github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://rmacfarlane:password@github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://github.com/Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://github.com:/Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://github.com:433/Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'https://github.enterprise.corp/Microsoft/vscode.git', expectedHost: 'github.enterprise.corp', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' }
+			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://rmacfarlane:password@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://github.com/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://github.com:/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://github.com:433/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://rmacfarlane@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://rmacfarlane:password@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://github.com/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://github.com:/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://github.com:433/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://github.enterprise.corp/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.enterprise.corp', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' }
 		].forEach(remote => {
 			const protocol = new Protocol(remote.uri);
+			assert.equal(protocol.type, remote.expectedType);
 			assert.equal(protocol.host, remote.expectedHost);
 			assert.equal(protocol.owner, remote.expectedOwner);
 			assert.equal(protocol.repositoryName, remote.expectedRepositoryName);
@@ -32,13 +33,14 @@ describe('Protocol', () => {
 
 	it('should handle SSH remotes', () => {
 		[
-			{ uri: 'ssh://git@github.com/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'ssh://github.com:Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'ssh://git@github.com:433/Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'ssh://user@git.server.org:project.git', expectedHost: 'git.server.org', expectedOwner: null, expectedRepositoryName: 'project' }
+			{ uri: 'ssh://git@github.com/Microsoft/vscode', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'ssh://github.com:Microsoft/vscode.git', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'ssh://git@github.com:433/Microsoft/vscode', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'ssh://user@git.server.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server.org', expectedOwner: null, expectedRepositoryName: 'project' }
 
 		].forEach(remote => {
 			const protocol = new Protocol(remote.uri);
+			assert.equal(protocol.type, remote.expectedType);
 			assert.equal(protocol.host, remote.expectedHost);
 			assert.equal(protocol.owner, remote.expectedOwner);
 			assert.equal(protocol.repositoryName, remote.expectedRepositoryName);
@@ -47,13 +49,14 @@ describe('Protocol', () => {
 
 	it('should handle SCP-like remotes', () => {
 		[
-			{ uri: 'git@github.com:Microsoft/vscode', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'git@github.com:Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'github.com:Microsoft/vscode.git', expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'user@git.server.org:project.git', expectedHost: 'git.server.org', expectedOwner: null, expectedRepositoryName: 'project' },
-			{ uri: 'git.server2.org:project.git', expectedHost: 'git.server2.org', expectedOwner: null, expectedRepositoryName: 'project' }
+			{ uri: 'git@github.com:Microsoft/vscode', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'git@github.com:Microsoft/vscode.git', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'github.com:Microsoft/vscode.git', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'user@git.server.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server.org', expectedOwner: null, expectedRepositoryName: 'project' },
+			{ uri: 'git.server2.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server2.org', expectedOwner: null, expectedRepositoryName: 'project' }
 		].forEach(remote => {
 			const protocol = new Protocol(remote.uri);
+			assert.equal(protocol.type, remote.expectedType);
 			assert.equal(protocol.host, remote.expectedHost);
 			assert.equal(protocol.owner, remote.expectedOwner);
 			assert.equal(protocol.repositoryName, remote.expectedRepositoryName);
@@ -62,13 +65,48 @@ describe('Protocol', () => {
 
 	it('should handle local remotes', () => {
 		[
-			{ uri: '/opt/git/project.git', expectedHost: '', expectedOwner: '', expectedRepositoryName: '' },
-			{ uri: 'file:///opt/git/project.git', expectedHost: '', expectedOwner: '', expectedRepositoryName: '' }
+			{ uri: '/opt/git/project.git', expectedType: ProtocolType.OTHER, expectedHost: '', expectedOwner: '', expectedRepositoryName: '' },
+			{ uri: 'file:///opt/git/project.git', expectedType: ProtocolType.Local, expectedHost: '', expectedOwner: '', expectedRepositoryName: '' }
 		].forEach(remote => {
 			const protocol = new Protocol(remote.uri);
+			assert.equal(protocol.type, remote.expectedType);
 			assert.equal(protocol.host, remote.expectedHost);
 			assert.equal(protocol.owner, remote.expectedOwner);
 			assert.equal(protocol.repositoryName, remote.expectedRepositoryName);
+		});
+	});
+
+	it('toString generate github remotes', () => {
+		[
+			{ uri: 'ssh://git@github.com/Microsoft/vscode', expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'ssh://github.com:Microsoft/vscode.git', expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'ssh://git@github.com:433/Microsoft/vscode', expected: 'git@github.com:Microsoft/vscode' },
+
+		].forEach(remote => {
+			const protocol = new Protocol(remote.uri);
+			assert.equal(protocol.toString(), remote.expected);
+		});
+	});
+
+	it('Protocol.with', () => {
+		[
+			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://rmacfarlane:password@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com:/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com:433/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://rmacfarlane@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://rmacfarlane:password@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com:/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com:433/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.enterprise.corp/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.enterprise.corp:Microsoft/vscode' }
+		].forEach(remote => {
+			const protocol = new Protocol(remote.uri);
+			protocol.with(remote.with);
+			assert.equal(protocol.toString(), remote.expected);
 		});
 	});
 });

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -88,24 +88,24 @@ describe('Protocol', () => {
 		});
 	});
 
-	it('Protocol.with', () => {
+	it('Protocol.update', () => {
 		[
-			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'http://rmacfarlane:password@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'http://github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'http://github.com/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'http://github.com:/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'http://github.com:433/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://rmacfarlane@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://rmacfarlane:password@github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://github.com/Microsoft/vscode', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://github.com/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://github.com:/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://github.com:433/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
-			{ uri: 'https://github.enterprise.corp/Microsoft/vscode.git', with: { type: ProtocolType.SSH }, expected: 'git@github.enterprise.corp:Microsoft/vscode' }
+			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://rmacfarlane:password@github.com/Microsoft/vscode', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com/Microsoft/vscode', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com:/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'http://github.com:433/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://rmacfarlane@github.com/Microsoft/vscode', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://rmacfarlane:password@github.com/Microsoft/vscode', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com/Microsoft/vscode', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com:/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.com:433/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.com:Microsoft/vscode' },
+			{ uri: 'https://github.enterprise.corp/Microsoft/vscode.git', change: { type: ProtocolType.SSH }, expected: 'git@github.enterprise.corp:Microsoft/vscode' }
 		].forEach(remote => {
 			const protocol = new Protocol(remote.uri);
-			protocol.with(remote.with);
+			protocol.update(remote.change);
 			assert.equal(protocol.toString(), remote.expected);
 		});
 	});


### PR DESCRIPTION
Fix https://github.com/Microsoft/vscode-pull-request-github/issues/273 . The logic in this PR is using the same scheme as the origin one (or where the PR is targeting) for the newly created remotes. For example, if the origin remote is using ssh and we try to create a new remote for a pr on the origin remote, we should use ssh instead of https.