### PR TITLE
Migrate hosts setting to githubPullRequests namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,28 @@
           "default": true,
           "description": "Enable usage data and errors to be sent to a GitHub online service"
         },
+        "githubPullRequests.hosts": {
+          "type": "array",
+          "default": [],
+          "description": "List of host credentials. For example, \"github.hosts\": [ { \"host\": \"https://github.com\", \"token\": \"GITHUB TOKEN\" } ]",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "The host name of the GitHub server (for eg., 'https://github.com')"
+              },
+              "username": {
+                "type": "string",
+                "description": "The username to access GitHub (optional)"
+              },
+              "token": {
+                "type": "string",
+                "description": "GitHub access token with the following scopes: read:user, user:email, repo, write:discussion"
+              }
+            }
+          }
+        },
         "telemetry.optout": {
           "type": "boolean",
           "default": false,
@@ -46,6 +68,7 @@
         "github.hosts": {
           "type": "array",
           "default": [],
+          "deprecationMessage": "The setting `github.hosts` has been deprecated in favor of `githubPullRequests.hosts`.",
           "description": "List of host credentials. For example, \"github.hosts\": [ { \"host\": \"https://github.com\", \"token\": \"GITHUB TOKEN\" } ]",
           "items": {
             "type": "object",

--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -47,6 +47,8 @@ class VSSettings implements ISettings {
 		].filter(({ value }) => value !== undefined);
 
 		if (values.length > 0) {
+			Logger.appendLine(`Migrating deprecated 'telemetry.${DEPRECATED_CONFIG_SECTION}' setting.`);
+
 			values.forEach(({ target, value }) => {
 				this._config.update(CONFIG_SECTION, !value, target);
 				deprecated.update(DEPRECATED_CONFIG_SECTION, undefined, target);

--- a/src/test/authentication/vsConfiguration.test.ts
+++ b/src/test/authentication/vsConfiguration.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { VSCodeConfiguration } from '../../authentication/vsConfiguration';
+
+describe('VSCodeConfiguration', () => {
+	it('should migrate deprecated hosts setting', async () => {
+		const key = 'hosts';
+		const deprecated = vscode.workspace.getConfiguration('github');
+		const migrated = vscode.workspace.getConfiguration('githubPullRequests');
+		const target = vscode.ConfigurationTarget.Global;
+		const hosts = [
+			{
+				host: 'https://github.local',
+				username: 'octocat',
+				token: 'abcd1234'
+			}
+		];
+
+		// Reset the workspace
+		await deprecated.update(key, undefined, target);
+		await migrated.update(key, undefined, target);
+
+		// Change setting to force migration to run
+		await deprecated.update(key, hosts, target);
+
+		vscode.workspace.onDidChangeConfiguration(async () => {
+			assert.equal(deprecated.get(key), undefined);
+			assert.equal(migrated.get(key), hosts);
+
+			// Clean up the workspace
+			await deprecated.update(key, undefined, target);
+			await migrated.update(key, undefined, target);
+		});
+
+		const configuration = new VSCodeConfiguration();
+
+		await configuration.loadConfiguration();
+	});
+});


### PR DESCRIPTION
As a followup to #529, this moves the host setting to the new namespace and deprecates the old setting.

Additionally I added logging if the migration happens.