### PR TITLE
Display a message before opening file diffs in the browser

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -154,7 +154,11 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffGitHub', (uri: string) => {
 		vscode.window
 			.showWarningMessage('This file is either too large, of an unsupported type, or has only been renamed. Would you like to view it on GitHub?', 'Open in GitHub')
-			.then(() => vscode.commands.executeCommand('vscode.open', uri));
+			.then(result => {
+				if (result === 'Open in GitHub') {
+					vscode.commands.executeCommand('vscode.open', uri);
+				}
+			});
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.deleteLocalBranch', async (e: PRNode) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -151,6 +151,12 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		vscode.commands.executeCommand('vscode.diff', parentFilePath, filePath, fileName, opts);
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffGitHub', (uri: string) => {
+		vscode.window
+			.showWarningMessage('This file is either too large, of an unsupported type, or has only been renamed. Would you like to view it on GitHub?', 'Open in GitHub')
+			.then(() => vscode.commands.executeCommand('vscode.open', uri));
+	}));
+
 	context.subscriptions.push(vscode.commands.registerCommand('pr.deleteLocalBranch', async (e: PRNode) => {
 		const pullRequestModel = ensurePR(prManager, e);
 		const DELETE_BRANCH_FORCE = 'delete branch (even if not merged)';

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -38,7 +38,7 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 
 		this.command = {
 			title: 'show remote file',
-			command: 'vscode.open',
+			command: 'pr.openDiffGitHub',
 			arguments: [
 				vscode.Uri.parse(this.blobUrl)
 			]


### PR DESCRIPTION
This addresses https://github.com/Microsoft/vscode-pull-request-github/issues/442 by displaying a message with an 'Open in Github' link for diffs that come back without a `patch` field.

Wording and everything is can be changed, I just put down what I thought was most clear. I wasn't comfortable trying to infer why the particular diff came back without a patch since I didn't find any documentation detailing which types of diffs are unsupported in the API.