### PR TITLE
Show more details in PR tree view tooltip, closes #568.

### DIFF
--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as moment from 'moment';
 import { parseDiff, getModifiedContentFromDiffHunk, DiffChangeType } from '../../common/diffHunk';
 import { mapHeadLineToDiffHunkPosition, getZeroBased, getAbsolutePosition, getPositionInDiff } from '../../common/diffPositionMapping';
 import { SlimFileChange, GitChangeType } from '../../common/file';
@@ -304,7 +303,6 @@ export class PRNode extends TreeNode {
 			title,
 			prNumber,
 			author,
-			createdAt,
 		} = this.pullRequestModel;
 
 		const {
@@ -313,10 +311,9 @@ export class PRNode extends TreeNode {
 
 		const labelPrefix = (currentBranchIsForThisPR ? '✓ ' : '');
 		const tooltipPrefix = (currentBranchIsForThisPR ? 'Current Branch * ' : '');
-		const titleAndPRNumber = `${title} (#${prNumber.toString()})`;
-		const createdAtFromNow = moment(createdAt).fromNow();
-		const label = `${labelPrefix}${titleAndPRNumber}`;
-		const tooltip = `${tooltipPrefix}${titleAndPRNumber}\nBy ${login} ${createdAtFromNow}`;
+		const formattedPRNumber = prNumber.toString();
+		const label = `${labelPrefix}${title} (#${formattedPRNumber})`;
+		const tooltip = `${tooltipPrefix}${title} (#${formattedPRNumber} by ${login})`;
 
 		return {
 			label,

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as moment from 'moment';
 import { parseDiff, getModifiedContentFromDiffHunk, DiffChangeType } from '../../common/diffHunk';
 import { mapHeadLineToDiffHunkPosition, getZeroBased, getAbsolutePosition, getPositionInDiff } from '../../common/diffPositionMapping';
 import { SlimFileChange, GitChangeType } from '../../common/file';

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -298,10 +298,29 @@ export class PRNode extends TreeNode {
 	}
 
 	getTreeItem(): vscode.TreeItem {
-		let currentBranchIsForThisPR = this.pullRequestModel.equals(this._prManager.activePullRequest);
+		const currentBranchIsForThisPR = this.pullRequestModel.equals(this._prManager.activePullRequest);
+
+		const {
+			title,
+			prNumber,
+			author,
+			createdAt,
+		} = this.pullRequestModel;
+
+		const {
+			login,
+		} = author;
+
+		const labelPrefix = (currentBranchIsForThisPR ? '✓ ' : '');
+		const tooltipPrefix = (currentBranchIsForThisPR ? 'Current Branch * ' : '');
+		const titleAndPRNumber = `${title} (#${prNumber.toString()})`;
+		const createdAtFromNow = moment(createdAt).fromNow();
+		const label = `${labelPrefix}${titleAndPRNumber}`;
+		const tooltip = `${tooltipPrefix}${titleAndPRNumber}\nBy ${login} ${createdAtFromNow}`;
+
 		return {
-			label: (currentBranchIsForThisPR ? '✓ ' : '') + this.pullRequestModel.title + ' (#' + this.pullRequestModel.prNumber.toString() + ')',
-			tooltip: (currentBranchIsForThisPR ? 'Current Branch * ' : '') + this.pullRequestModel.title + ' (#' + this.pullRequestModel.prNumber.toString() + ')',
+			label,
+			tooltip,
 			collapsibleState: 1,
 			contextValue: 'pullrequest' + (this._isLocal ? ':local' : '') + (currentBranchIsForThisPR ? ':active' : ':nonactive'),
 			iconPath: this.pullRequestModel.userAvatarUri

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -313,7 +313,7 @@ export class PRNode extends TreeNode {
 		const tooltipPrefix = (currentBranchIsForThisPR ? 'Current Branch * ' : '');
 		const formattedPRNumber = prNumber.toString();
 		const label = `${labelPrefix}${title} (#${formattedPRNumber})`;
-		const tooltip = `${tooltipPrefix}${title} (#${formattedPRNumber} by ${login})`;
+		const tooltip = `${tooltipPrefix}${title} (#${formattedPRNumber}) by ${login}`;
 
 		return {
 			label,


### PR DESCRIPTION
- Show the PR's `author login name` and `creation date` in the `GitHub Pull Requests` tree node tooltips.

**Before:**

![screen shot 2018-10-14 at 12 13 14 pm](https://user-images.githubusercontent.com/8648231/46913525-3678a180-cfac-11e8-9af4-d81fbe41ebb2.png)

**After:**

![screen shot 2018-10-14 at 12 13 14 pmb](https://user-images.githubusercontent.com/8648231/46913527-409aa000-cfac-11e8-93f1-95e16f325b7a.png)
