### PR TITLE
Add a command to manually accept a token response.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
     },
     "commands": [
       {
+        "command": "auth.inputTokenCallback",
+        "title": "Manually Provide Authentication Response",
+        "category": "GitHub Pull Requests"
+      },
+      {
         "command": "pr.pick",
         "title": "Checkout Pull Request",
         "category": "GitHub Pull Requests"

--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -8,8 +8,7 @@ import axios from 'axios';
 const SCOPES: string = 'read:user user:email repo write:discussion';
 const GHE_OPTIONAL_SCOPES: object = {'write:discussion': true};
 
-// const AUTH_RELAY_SERVER = 'https://vscode-auth.github.com';
-const AUTH_RELAY_SERVER = 'https://client-auth-staging-14a768b.herokuapp.com';
+const AUTH_RELAY_SERVER = 'https://vscode-auth.github.com';
 const EXTENSION_ID = 'GitHub.vscode-pull-request-github';
 const CALLBACK_PATH = '/did-authenticate';
 const CALLBACK_URI = vscode.version.endsWith('-insider')

--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -8,7 +8,8 @@ import axios from 'axios';
 const SCOPES: string = 'read:user user:email repo write:discussion';
 const GHE_OPTIONAL_SCOPES: object = {'write:discussion': true};
 
-const AUTH_RELAY_SERVER = 'https://vscode-auth.github.com';
+// const AUTH_RELAY_SERVER = 'https://vscode-auth.github.com';
+const AUTH_RELAY_SERVER = 'https://client-auth-staging-14a768b.herokuapp.com';
 const EXTENSION_ID = 'GitHub.vscode-pull-request-github';
 const CALLBACK_PATH = '/did-authenticate';
 const CALLBACK_URI = vscode.version.endsWith('-insider')

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -194,13 +194,13 @@ export class CredentialStore {
 
 	private willStartLogin(authority: string): void {
 		const status = this._authenticationStatusBarItems.get(authority);
-		status.text = `Signing in to ${authority}...`;
+		status.text = `$(mark-github) Signing in to ${authority}...`;
 		status.command = AUTH_INPUT_TOKEN_CMD;
 	}
 
 	private didEndLogin(authority: string): void {
 		const status = this._authenticationStatusBarItems.get(authority);
-		status.text = `Signed in to ${authority}`;
+		status.text = `$(mark-github) Signed in to ${authority}`;
 		status.command = null;
 	}
 

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -101,7 +101,7 @@ export class CredentialStore {
 
 		// the remote url might be http[s]/git/ssh but we always go through https for the api
 		// so use a normalized http[s] url regardless of the original protocol
-		const {scheme, authority} = remote.gitProtocol.normalizeUri();
+		const { scheme, authority } = remote.gitProtocol.normalizeUri();
 		const host = `${scheme}://${authority}`;
 
 		let retry: boolean = true;


### PR DESCRIPTION
This sets up a command triggered by clicking on the status indicator during auth. The command prompts for the token (really for the URI response), parses it as a URI, and dispatches it.

Fixes #570 #573