### PR TITLE
Match github.com empty comment behavior (Fixes #587)

### DIFF
--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -549,20 +549,22 @@ export class PullRequestManager implements IPullRequestManager {
 
 	private handleError(e: any) {
 		if (e.code && e.code === 422) {
+			let errorObject: RestErrorResult;
 			try {
-				let errorObject: RestErrorResult = e.message && JSON.parse(e.message);
-				const firstError = errorObject && errorObject.errors && errorObject.errors[0];
-				if (firstError && firstError.code === 'missing_field' && firstError.field === 'body') {
-					throw new Error('Body can\'t be blank');
-				} else {
-					throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
-				}
+				errorObject = e.message && JSON.parse(e.message);
 			}
 			catch {
 				// If we failed to parse the JSON re-throw the original error
 				// since it will have a more useful stack
 				throw e;
 			}
+			const firstError = errorObject && errorObject.errors && errorObject.errors[0];
+			if (firstError && firstError.code === 'missing_field' && firstError.field === 'body') {
+				throw new Error('Body can\'t be blank');
+			} else {
+				throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
+			}
+
 		} else {
 			throw e;
 		}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -552,8 +552,7 @@ export class PullRequestManager implements IPullRequestManager {
 			let errorObject: RestErrorResult;
 			try {
 				errorObject = e.message && JSON.parse(e.message);
-			}
-			catch {
+			} catch {
 				// If we failed to parse the JSON re-throw the original error
 				// since it will have a more useful stack
 				throw e;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -553,12 +553,10 @@ export class PullRequestManager implements IPullRequestManager {
 			const firstError = errorObject && errorObject.errors && errorObject.errors[0];
 			if (firstError && firstError.code === 'missing_field' && firstError.field === 'body') {
 				throw new Error('Body can\'t be blank');
-			}
-			else {
+			} else {
 				throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
 			}
-		}
-		else {
+		} else {
 			throw e;
 		}
 	}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -24,6 +24,17 @@ interface PageInformation {
 	hasMorePages: boolean;
 }
 
+interface RestErrorResult {
+	errors: RestError[];
+	message: string;
+}
+
+interface RestError {
+	code: string;
+	field: string;
+	resource: string;
+}
+
 export class PullRequestManager implements IPullRequestManager {
 	private _activePullRequest?: IPullRequestModel;
 	private _credentialStore: CredentialStore;
@@ -362,11 +373,7 @@ export class PullRequestManager implements IPullRequestManager {
 
 			return ret.data;
 		} catch (e) {
-			if (e.code && e.code === 422) {
-				throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
-			} else {
-				throw e;
-			}
+			this.handleError(e);
 		}
 	}
 
@@ -386,11 +393,7 @@ export class PullRequestManager implements IPullRequestManager {
 
 			return ret.data;
 		} catch (e) {
-			if (e.code && e.code === 422) {
-				throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
-			} else {
-				throw e;
-			}
+			this.handleError(e);
 		}
 	}
 
@@ -425,7 +428,7 @@ export class PullRequestManager implements IPullRequestManager {
 			repo: remote.repositoryName,
 			number: pullRequest.prNumber,
 		})
-		.then(x => {
+			.then(x => {
 				this._telemetry.on('pr.merge');
 				return x.data;
 			});
@@ -542,6 +545,22 @@ export class PullRequestManager implements IPullRequestManager {
 
 	async checkout(branchName: string): Promise<void> {
 		return this.repository.checkout(branchName);
+	}
+
+	private handleError(e: any) {
+		if (e.code && e.code === 422) {
+			const errorObject: RestErrorResult = e.message && JSON.parse(e.message);
+			const firstError = errorObject && errorObject.errors && errorObject.errors[0];
+			if (firstError && firstError.code === 'missing_field' && firstError.field === 'body') {
+				throw new Error('Body can\'t be blank');
+			}
+			else {
+				throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
+			}
+		}
+		else {
+			throw e;
+		}
 	}
 
 	//#endregion

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -549,12 +549,19 @@ export class PullRequestManager implements IPullRequestManager {
 
 	private handleError(e: any) {
 		if (e.code && e.code === 422) {
-			const errorObject: RestErrorResult = e.message && JSON.parse(e.message);
-			const firstError = errorObject && errorObject.errors && errorObject.errors[0];
-			if (firstError && firstError.code === 'missing_field' && firstError.field === 'body') {
-				throw new Error('Body can\'t be blank');
-			} else {
-				throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
+			try {
+				let errorObject: RestErrorResult = e.message && JSON.parse(e.message);
+				const firstError = errorObject && errorObject.errors && errorObject.errors[0];
+				if (firstError && firstError.code === 'missing_field' && firstError.field === 'body') {
+					throw new Error('Body can\'t be blank');
+				} else {
+					throw new Error('There is already a pending review for this pull request on GitHub. Please finish or dismiss this review to be able to leave more comments');
+				}
+			}
+			catch {
+				// If we failed to parse the JSON re-throw the original error
+				// since it will have a more useful stack
+				throw e;
 			}
 		} else {
 			throw e;


### PR DESCRIPTION
When you submit a comment and only give new lines it gives a misleading error message.

![image](https://user-images.githubusercontent.com/304410/47133335-381cc080-d25d-11e8-921f-08c4fa9eb815.png)


This PR (fixes #587) contains a small change to match the error behavior that GitHub.com uses in this case 
![image](https://user-images.githubusercontent.com/304410/47133447-a82b4680-d25d-11e8-8926-3438cf7d1ba4.png)


I also added some types for the error object. I looked in the octokit typings and didn't see something there. This is my first time contributing to this repo so please let me know if I am missing or need to change anything.


Thanks for the awesome extension.