### PR TITLE
Setup initial open file diff event from pr description

### DIFF
--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -231,6 +231,19 @@ function addEventListeners(pr: PullRequest): void {
 			branch: pr.repositoryDefaultBranch
 		});
 	});
+
+	let fileDiffButtons = document.getElementsByClassName("file-diff-btn")!;
+	console.log(`found ${fileDiffButtons.length} file diff buttons`);
+
+	for (let fileDiffButton of Array.from(fileDiffButtons)) {
+		console.log(`Adding click listener to ${fileDiffButton.outerHTML}`);
+		fileDiffButton.addEventListener('click', (e) => {
+			vscode.postMessage({
+				command: 'pr.file-diff',
+				path: (<HTMLElement>e.target).getAttribute('data-path'),
+			});
+		});
+	}
 }
 
 function clearTextArea() {

--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -352,7 +352,7 @@ export function renderReview(timelineEvent: ReviewEvent): string {
 				}
 
 				diffView = `<div class="diff">
-					<div class="diffHeader">${comments[0].path}</div>
+					<div class="diffHeader">${comments[0].path} &nbsp; <a href="#" class="file-diff-btn" data-path="${comments[0].path}">Show Diff</a> </div>
 					${diffLines.join('')}
 				</div>`;
 			}

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -225,6 +225,12 @@ export class PullRequestOverviewPanel {
 				return this.checkoutDefaultBranch(message.branch);
 			case 'pr.comment':
 				return this.createComment(message.text);
+			case 'pr.file-diff':
+				const options: vscode.TextDocumentShowOptions = {
+					preserveFocus: true
+				};
+				vscode.commands.executeCommand('pr.openDiffView', [`pr:/${message.path}?`, `pr:/${message.path}?`, message.path, false, options]);
+				return true;
 		}
 	}
 


### PR DESCRIPTION
## Summary
When comments on files show up in the PR description, the file has no way of being opened/ opening the full diff of that file.
This PR is to discuss and add a Show Diff / Open File button(s) to the file name bar on comments in the description view.

![image](https://user-images.githubusercontent.com/4755420/47262004-8ebe1080-d490-11e8-9ccd-39cf273d97bb.png)

This is a WIP.