### PR TITLE
Edit/delete comments within the editor

### DIFF
--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -27,5 +27,8 @@ export interface Comment {
 	created_at: string;
 	updated_at: string;
 	html_url: string;
+
 	absolutePosition?: number;
+	canEdit: boolean;
+	canDelete: boolean;
 }

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -178,6 +178,8 @@ export interface IPullRequestManager {
 	createCommentReply(pullRequest: IPullRequestModel, body: string, reply_to: string): Promise<Comment>;
 	createComment(pullRequest: IPullRequestModel, body: string, path: string, position: number): Promise<Comment>;
 	mergePullRequest(pullRequest: IPullRequestModel): Promise<any>;
+	editComment(pullRequest: IPullRequestModel, commentId: string, text: string): Promise<Comment>;
+	deleteComment(pullRequest: IPullRequestModel, commentId: string): Promise<void>;
 	closePullRequest(pullRequest: IPullRequestModel): Promise<any>;
 	approvePullRequest(pullRequest: IPullRequestModel, message?: string): Promise<any>;
 	requestChanges(pullRequest: IPullRequestModel, message?: string): Promise<any>;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -398,26 +398,34 @@ export class PullRequestManager implements IPullRequestManager {
 	}
 
 	async editComment(pullRequest: IPullRequestModel, commentId: string, text: string): Promise<Comment> {
-		const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
+		try {
+			const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
 
-		const ret = await octokit.pullRequests.editComment({
-			owner: remote.owner,
-			repo: remote.repositoryName,
-			body: text,
-			comment_id: commentId
-		});
+			const ret = await octokit.pullRequests.editComment({
+				owner: remote.owner,
+				repo: remote.repositoryName,
+				body: text,
+				comment_id: commentId
+			});
 
-		return this.addCommentPermissions(ret.data, remote);
+			return this.addCommentPermissions(ret.data, remote);
+		} catch (e) {
+			throw new Error(formatError(e));
+		}
 	}
 
 	async deleteComment(pullRequest: IPullRequestModel, commentId: string): Promise<void> {
-		const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
+		try {
+			const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
 
-		await octokit.pullRequests.deleteComment({
-			owner: remote.owner,
-			repo: remote.repositoryName,
-			comment_id: commentId
-		});
+			await octokit.pullRequests.deleteComment({
+				owner: remote.owner,
+				repo: remote.repositoryName,
+				comment_id: commentId
+			});
+		} catch (e) {
+			throw new Error(formatError(e));
+		}
 	}
 
 	private addCommentPermissions(rawComment: Comment, remote: Remote): Comment {

--- a/src/typings/vscode.proposed.d.ts
+++ b/src/typings/vscode.proposed.d.ts
@@ -518,7 +518,14 @@ declare module 'vscode' {
 	 */
 
 	interface CommentInfo {
+		/**
+		 * All of the comment threads associated with the document.
+		 */
 		threads: CommentThread[];
+
+		/**
+		 * The ranges of the document which support commenting.
+		 */
 		commentingRanges?: Range[];
 	}
 
@@ -533,19 +540,85 @@ declare module 'vscode' {
 		Expanded = 1
 	}
 
+	/**
+	 * A collection of comments representing a conversation at a particular range in a document.
+	 */
 	interface CommentThread {
+		/**
+		 * A unique identifier of the comment thread.
+		 */
 		threadId: string;
+
+		/**
+		 * The uri of the document the thread has been created on.
+		 */
 		resource: Uri;
+
+		/**
+		 * The range the comment thread is located within the document. The thread icon will be shown
+		 * at the first line of the range.
+		 */
 		range: Range;
+
+		/**
+		 * The ordered comments of the thread.
+		 */
 		comments: Comment[];
+
+		/**
+		 * Whether the thread should be collapsed or expanded when opening the document. Defaults to Collapsed.
+		 */
 		collapsibleState?: CommentThreadCollapsibleState;
 	}
 
+	/**
+	 * A comment is displayed within the editor or the Comments Panel, depending on how it is provided.
+	 */
 	interface Comment {
+		/**
+		 * The id of the comment
+		 */
 		commentId: string;
+
+		/**
+		 * The text of the comment
+		 */
 		body: MarkdownString;
+
+		/**
+		 * The display name of the user who created the comment
+		 */
 		userName: string;
-		gravatar: string;
+
+		/**
+		 * The icon path for the user who created the comment
+		 */
+		userIconPath?: Uri;
+
+		/**
+		 * @deprecated Use userIconPath instead. The avatar src of the user who created the comment
+		 */
+		gravatar?: string;
+
+		/**
+		 * Whether the current user has permission to edit the comment.
+		 *
+		 * This will be treated as false if the comment is provided by a `WorkspaceCommentProvider`, or
+		 * if it is provided by a `DocumentCommentProvider` and  no `editComment` method is given.
+		 */
+		canEdit?: boolean;
+
+		/**
+		 * Whether the current user has permission to delete the comment.
+		 *
+		 * This will be treated as false if the comment is provided by a `WorkspaceCommentProvider`, or
+		 * if it is provided by a `DocumentCommentProvider` and  no `deleteComment` method is given.
+		 */
+		canDelete?: boolean;
+
+		/**
+		 * The command to be executed if the comment is selected in the Comments Panel
+		 */
 		command?: Command;
 	}
 
@@ -567,18 +640,48 @@ declare module 'vscode' {
 	}
 
 	interface DocumentCommentProvider {
+		/**
+		 * Provide the commenting ranges and comment threads for the given document. The comments are displayed within the editor.
+		 */
 		provideDocumentComments(document: TextDocument, token: CancellationToken): Promise<CommentInfo>;
-		createNewCommentThread?(document: TextDocument, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
-		replyToCommentThread?(document: TextDocument, range: Range, commentThread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
-		onDidChangeCommentThreads?: Event<CommentThreadChangedEvent>;
+
+		/**
+		 * Called when a user adds a new comment thread in the document at the specified range, with body text.
+		 */
+		createNewCommentThread(document: TextDocument, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
+
+		/**
+		 * Called when a user replies to a new comment thread in the document at the specified range, with body text.
+		 */
+		replyToCommentThread(document: TextDocument, range: Range, commentThread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
+
+		/**
+		 * Called when a user edits the comment body to the be new text text.
+		 */
+		editComment?(document: TextDocument, comment: Comment, text: string, token: CancellationToken): Promise<void>;
+
+		/**
+		 * Called when a user deletes the comment.
+		 */
+		deleteComment?(document: TextDocument, comment: Comment, token: CancellationToken): Promise<void>;
+
+		/**
+		 * Notify of updates to comment threads.
+		 */
+		onDidChangeCommentThreads: Event<CommentThreadChangedEvent>;
 	}
 
 	interface WorkspaceCommentProvider {
+		/**
+		 * Provide all comments for the workspace. Comments are shown within the comments panel. Selecting a comment
+		 * from the panel runs the comment's command.
+		 */
 		provideWorkspaceComments(token: CancellationToken): Promise<CommentThread[]>;
-		createNewCommentThread?(document: TextDocument, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
-		replyToCommentThread?(document: TextDocument, range: Range, commentThread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
 
-		onDidChangeCommentThreads?: Event<CommentThreadChangedEvent>;
+		/**
+		 * Notify of updates to comment threads.
+		 */
+		onDidChangeCommentThreads: Event<CommentThreadChangedEvent>;
 	}
 
 	namespace workspace {

--- a/src/view/prDocumentCommentProvider.ts
+++ b/src/view/prDocumentCommentProvider.ts
@@ -10,7 +10,7 @@ import { fromPRUri } from '../common/uri';
 
 export class PRDocumentCommentProvider implements vscode.DocumentCommentProvider {
 	private _onDidChangeCommentThreads: vscode.EventEmitter<vscode.CommentThreadChangedEvent> = new vscode.EventEmitter<vscode.CommentThreadChangedEvent>();
-	public onDidChangeCommentThreads?: vscode.Event<vscode.CommentThreadChangedEvent> = this._onDidChangeCommentThreads.event;
+	public onDidChangeCommentThreads: vscode.Event<vscode.CommentThreadChangedEvent> = this._onDidChangeCommentThreads.event;
 
 	private _prDocumentCommentProviders: {[key: number]: vscode.DocumentCommentProvider} = {};
 
@@ -63,6 +63,28 @@ export class PRDocumentCommentProvider implements vscode.DocumentCommentProvider
 		}
 
 		return await this._prDocumentCommentProviders[params.prNumber].replyToCommentThread(document, range, commentThread, text, token);
+	}
+
+	async editComment(document: vscode.TextDocument, comment: vscode.Comment, text: string, token: vscode.CancellationToken): Promise<void> {
+		const params = fromPRUri(document.uri);
+		const commentProvider = this._prDocumentCommentProviders[params.prNumber];
+
+		if (!commentProvider) {
+			throw new Error(`Couldn't find document provider`);
+		}
+
+		return await commentProvider.editComment(document, comment, text, token);
+	}
+
+	async deleteComment(document: vscode.TextDocument, comment: vscode.Comment, token: vscode.CancellationToken): Promise<void> {
+		const params = fromPRUri(document.uri);
+		const commentProvider = this._prDocumentCommentProviders[params.prNumber];
+
+		if (!commentProvider) {
+			throw new Error(`Couldn't find document provider`);
+		}
+
+		return await commentProvider.deleteComment(document, comment, token);
 	}
 }
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -301,7 +301,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 				commentId: comment.id,
 				body: new vscode.MarkdownString(comment.body),
 				userName: comment.user.login,
-				gravatar: comment.user.avatar_url
+				gravatar: comment.user.avatar_url,
+				canEdit: comment.canEdit,
+				canDelete: comment.canDelete
 			});
 
 			matchedFile.comments.push(comment);
@@ -342,7 +344,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 				commentId: rawComment.id,
 				body: new vscode.MarkdownString(rawComment.body),
 				userName: rawComment.user.login,
-				gravatar: rawComment.user.avatar_url
+				gravatar: rawComment.user.avatar_url,
+				canEdit: rawComment.canEdit,
+				canDelete: rawComment.canDelete
 			};
 
 			let commentThread: vscode.CommentThread = {
@@ -363,6 +367,82 @@ export class ReviewManager implements vscode.DecorationProvider {
 			});
 
 			return commentThread;
+		} catch (e) {
+			throw new Error(formatError(e));
+		}
+	}
+
+	private async editComment(document: vscode.TextDocument, comment: vscode.Comment, text: string): Promise<void> {
+		try {
+			const matchedFile = this.findMatchedFileByUri(document);
+			if (!matchedFile) {
+				throw new Error('Unable to find matching file');
+			}
+
+			const editedComment = await this._prManager.editComment(this._prManager.activePullRequest, comment.commentId, text);
+
+			// Update the cached comments of the file
+			const matchingCommentIndex = matchedFile.comments.findIndex(c => c.id === comment.commentId);
+			if (matchingCommentIndex > -1) {
+				matchedFile.comments.splice(matchingCommentIndex, 1, editedComment);
+				const changedThreads = this.fileCommentsToCommentThreads(matchedFile, matchedFile.comments.filter(c => c.position === editedComment.position), vscode.CommentThreadCollapsibleState.Expanded);
+
+				this._onDidChangeWorkspaceCommentThreads.fire({
+					added: [],
+					changed: changedThreads,
+					removed: []
+				});
+			}
+
+			// Also update this._comments
+			const indexInAllComments = this._comments.findIndex(c => c.id === comment.commentId);
+			if (indexInAllComments > -1) {
+				this._comments.splice(indexInAllComments, 1, editedComment);
+			}
+		} catch (e) {
+			throw new Error(formatError(e));
+		}
+	}
+
+	private async deleteComment(document: vscode.TextDocument, comment: vscode.Comment): Promise<void> {
+		try {
+			const matchedFile = this.findMatchedFileByUri(document);
+			if (!matchedFile) {
+				throw new Error('Unable to find matching file');
+			}
+
+			await this._prManager.deleteComment(this._prManager.activePullRequest, comment.commentId);
+			const matchingCommentIndex = matchedFile.comments.findIndex(c => c.id === comment.commentId);
+			if (matchingCommentIndex > -1) {
+				const [ deletedComment ] = matchedFile.comments.splice(matchingCommentIndex, 1);
+				const updatedThreadComments = matchedFile.comments.filter(c => c.position === deletedComment.position);
+
+				// If the deleted comment was the last in its thread, remove the thread
+				if (updatedThreadComments.length) {
+					const changedThreads = this.fileCommentsToCommentThreads(matchedFile, updatedThreadComments, vscode.CommentThreadCollapsibleState.Expanded);
+					this._onDidChangeWorkspaceCommentThreads.fire({
+						added: [],
+						changed: changedThreads,
+						removed: []
+					});
+				} else {
+					this._onDidChangeWorkspaceCommentThreads.fire({
+						added: [],
+						changed: [],
+						removed: [{
+							threadId: deletedComment.id,
+							resource: vscode.Uri.file(nodePath.resolve(this._repository.rootUri.fsPath, deletedComment.path)),
+							comments: [],
+							range: null
+						}]
+					});
+				}
+			}
+
+			const indexInAllComments = this._comments.findIndex(c => c.id === comment.commentId);
+			if (indexInAllComments > -1) {
+				this._comments.splice(indexInAllComments, 1);
+			}
 		} catch (e) {
 			throw new Error(formatError(e));
 		}
@@ -596,7 +676,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 							arguments: [
 								fileChange
 							]
-						}
+						},
+						canEdit: comment.canEdit,
+						canDelete: comment.canDelete
 					};
 				}),
 				collapsibleState: collapsibleState
@@ -646,7 +728,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 						body: new vscode.MarkdownString(comment.body),
 						userName: comment.user.login,
 						gravatar: comment.user.avatar_url,
-						command: command
+						command: command,
+						canEdit: comment.canEdit,
+						canDelete: comment.canDelete
 					};
 				}),
 				collapsibleState: collapsibleState
@@ -831,7 +915,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 									commentId: comment.id,
 									body: new vscode.MarkdownString(comment.body),
 									userName: comment.user.login,
-									gravatar: comment.user.avatar_url
+									gravatar: comment.user.avatar_url,
+									canEdit: comment.canEdit,
+									canDelete: comment.canDelete
 								};
 							}),
 							collapsibleState: vscode.CommentThreadCollapsibleState.Expanded
@@ -844,7 +930,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 				}
 			},
 			createNewCommentThread: this.createNewCommentThread.bind(this),
-			replyToCommentThread: this.replyToCommentThread.bind(this)
+			replyToCommentThread: this.replyToCommentThread.bind(this),
+			editComment: this.editComment.bind(this),
+			deleteComment: this.deleteComment.bind(this)
 		});
 
 		this._workspaceCommentProvider = vscode.workspace.registerWorkspaceCommentProvider({
@@ -857,8 +945,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 					return this.outdatedCommentsToCommentThreads(fileChange, fileChange.comments, vscode.CommentThreadCollapsibleState.Expanded);
 				});
 				return [...comments, ...outdatedComments].reduce((prev, curr) => prev.concat(curr), []);
-			},
-			createNewCommentThread: this.createNewCommentThread.bind(this), replyToCommentThread: this.replyToCommentThread.bind(this)
+			}
 		});
 	}
 


### PR DESCRIPTION
![comment_edit](https://user-images.githubusercontent.com/3672607/47319799-7bcc4d00-d604-11e8-85a2-cc903865f2bd.gif)

use the new APIs to allow editing and deleting comments. I'm restricting edit/delete to only non-outdated comments that match the logged in user, but we could relax that if needed.

I'll send a separate PR for adding edit/delete actions to comments on the description page