### PR TITLE
Refactor renderTimelineEvents to return HTMLElements instead of a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,6 +324,7 @@
     "gulp-util": "^3.0.8",
     "mocha": "^5.2.0",
     "style-loader": "^0.21.0",
+    "svg-inline-loader": "^0.8.0",
     "ts-loader": "^4.0.1",
     "tslint": "^5.11.0",
     "tslint-webpack-plugin": "^1.2.2",

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -38,17 +38,16 @@ body hr {
 	margin: 0 !important;
 	padding: 0;
 }
-body .review-comment {
-	display: flex;
 
-}
-
-body .review-comment .avatar-container {
+body .comment-container .avatar-container {
 	margin-right: 12px;
-	flex-shrink: 0;
 }
 
-body .review-comment .avatar-container img.avatar {
+body .comment-container .avatar-container a {
+	display: flex;
+}
+
+body .comment-container .avatar-container img.avatar {
 	margin-right: 0;
 }
 
@@ -66,21 +65,11 @@ body a.avatar-link:focus {
 	outline-offset: 2px;
 }
 
-body .review-comment .review-comment-contents {
-	width: 100%;
-	display: flex;
-	margin: 0;
-}
-
-body .review-comment .review-comment-contents.comment,
-body .review-comment .review-comment-contents.review {
+body .comment-container.comment,
+body .comment-container.review {
 	background-color: var(--vscode-editor-background);
 }
 
-body .comment-container:last-child .comment {
-	padding-bottom: 12px;
-	border-bottom: none;
-}
 
 .review-comment-container {
 	width: 100%;
@@ -88,7 +77,7 @@ body .comment-container:last-child .comment {
 	flex-direction: column;
 }
 
-body .review-comment .review-comment-header {
+body .comment-container .review-comment-header {
 	display: flex;
 	align-items: center;
 	width: 100%;
@@ -98,20 +87,32 @@ body .review-comment .review-comment-header {
 	color: var(--vscode-foreground);
 }
 
-body .review-comment .review-comment-header > span, a.avatar-link,
-body .review-comment .review-comment-header > span, a.author {
+.review-comment-header .comment-actions {
+	margin-left: auto;
+}
+
+.comment-actions button {
+	background-color: transparent;
+	padding: 2px 6px 3px;
+}
+
+.comment-actions button svg {
+	margin-right: 0;
+}
+
+body .comment-container .review-comment-header > span, a {
 	margin-right: 4px;
 }
 
-body .review-comment .review-comment-contents .comment-body {
+body .comment-container .comment-body {
 	padding: 4px 0 0;
 }
 
-body .review-comment .review-comment-contents .comment-body > p {
+body .comment-container .comment-body > p {
 	margin-top: 0;
 }
 
-body .review-comment .review-comment-contents .comment-body > p:last-child {
+body .comment-container  .comment-body > p:last-child {
 	margin-bottom: 0;
 }
 
@@ -127,7 +128,7 @@ body .hidden {
 	display: none !important;
 }
 
-body button {
+button {
 	background-color: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
 	border-radius: 0px;
@@ -252,6 +253,10 @@ body .overview-title button {
 	fill: var(--vscode-foreground);
 }
 
+.comment-container.commit {
+	padding: 8px 0;
+}
+
 .commit, .review {
 	display: flex;
 	width: 100%;
@@ -260,7 +265,7 @@ body .overview-title button {
 	color: var(--vscode-foreground);
 }
 
-.review-comment-contents.review {
+.review {
 	margin: 0px 8px;
 	padding: 4px 0;
 }
@@ -301,6 +306,9 @@ body .overview-title button {
 	position: relative;
 	padding: 20px 0;
 	border-top: 1px solid var(--border-color);
+	width: 100%;
+	display: flex;
+	margin: 0;
 }
 
 .comment-container:last-of-type {
@@ -316,23 +324,13 @@ body .overview-title button {
 	border-top: none;
 }
 
-.comment-body div[data-type="review-comment"] {
-	padding: 0 20px;
+.comment-body .review-comment {
+	padding: 12px;
+	box-sizing: border-box;
+	border-top: none;
 	border-right: 1px solid var(--vscode-notifications-background);
 	border-left: 1px solid var(--vscode-notifications-background);
 	border-bottom: 1px solid var(--vscode-notifications-background);
-}
-
-.comment-body div[data-type="review-comment"] .comment-container {
-	padding: 12px 0;
-}
-
-.comment-body div[data-type="review-comment"] .comment-container:last-child {
-	border-bottom: none;
-}
-
-.comment-body div[data-type="review-comment"] .comment-container:last-child .comment {
-	padding-bottom: 0;
 }
 
 .comment-body .line {
@@ -346,7 +344,7 @@ body .comment-form {
 	padding: 20px 0 10px;
 }
 
-body .comment-form textarea {
+textarea {
 	display: block;
 	box-sizing: border-box;
 	padding: 10px;
@@ -361,13 +359,12 @@ body .comment-form textarea {
 	font-family: var(--vscode-editor-font-family);
 }
 
+textarea:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+}
 .reply-button {
 	margin-left: auto;
 	margin-right: 0 !important;
-}
-
-body .comment-form textarea:focus {
-	outline: 1px solid var(--vscode-focusBorder);
 }
 
 body .comment-form .form-actions {

--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -227,57 +227,104 @@ function groupBy<T>(arr: T[], fn: (el: T) => string): { [key: string]: T[] } {
 	}, Object.create(null));
 }
 
-export function renderComment(comment: CommentEvent | Comment): string {
-	return `<div class="comment-container" data-type="comment">
+function renderUserIcon(iconLink: string, iconSrc: string): HTMLElement {
+	const iconContainer = document.createElement('div');
+	iconContainer.className = 'avatar-container';
 
-	<div class="review-comment" role="treeitem">
-		<div class="review-comment-contents comment">
-			<div class="avatar-container">
-				<a class="avatar-link" href="${comment.user.html_url}"><img class="avatar" src="${comment.user.avatar_url}"></a>
-			</div>
-			<div class="review-comment-container">
-				<div class="review-comment-header">
-					<a class="author" href="${comment.user.html_url}">${comment.user.login}</a>
-					<div class="timestamp">${moment(comment.created_at).fromNow()}</div>
-				</div>
-				<div class="comment-body">
-					${md.render(emoji.emojify(comment.body))}
-				</div>
-			</div>
-		</div>
-	</div>
-</div>`;
+	const avatarLink = document.createElement('a');
+	avatarLink.className = 'avatar-link';
+	(<HTMLAnchorElement>avatarLink).href = iconLink;
+
+	const avatar = document.createElement('img');
+	avatar.className = 'avatar';
+	(<HTMLImageElement>avatar).src = iconSrc;
+
+	iconContainer.appendChild(avatarLink).appendChild(avatar);
+
+	return iconContainer;
 }
 
-export function renderCommit(timelineEvent: CommitEvent): string {
+export function renderComment(comment: CommentEvent | Comment, additionalClass?: string): HTMLElement {
+	const commentContainer = document.createElement('div');
+	commentContainer.id = `comment${comment.id.toString()}`;
+	commentContainer.classList.add('comment-container', 'comment');
 
+	if (additionalClass) {
+		commentContainer.classList.add(additionalClass);
+	}
+
+	const userIcon = renderUserIcon(comment.user.html_url, comment.user.avatar_url);
+	const reviewCommentContainer = document.createElement('div');
+	reviewCommentContainer.className = 'review-comment-container';
+	commentContainer.appendChild(userIcon);
+	commentContainer.appendChild(reviewCommentContainer);
+
+	const commentHeader = document.createElement('div');
+	commentHeader.className = 'review-comment-header';
+	const authorLink = document.createElement('a');
+	authorLink.className = 'author';
+	(<HTMLAnchorElement>authorLink).href = comment.user.html_url;
+	authorLink.textContent = comment.user.login;
+
+	const timestamp = document.createElement('div');
+	timestamp.className = 'timestamp';
+	timestamp.textContent = moment(comment.created_at).fromNow();
+
+	const commentBody = document.createElement('div');
+	commentBody.className = 'comment-body';
+	commentBody.innerHTML  = md.render(emoji.emojify(comment.body));
+
+	commentHeader.appendChild(authorLink);
+	commentHeader.appendChild(timestamp);
+
+	reviewCommentContainer.appendChild(commentHeader);
+	reviewCommentContainer.appendChild(commentBody);
+
+	return commentContainer;
+}
+
+export function renderCommit(timelineEvent: CommitEvent): HTMLElement {
 	const shaShort = timelineEvent.sha.substring(0, 7);
-	const avatar = timelineEvent.author.avatar_url
-		? `<div class="avatar-container"><a class="avatar-link" href="${timelineEvent.author.html_url}"><img class="avatar" src="${timelineEvent.author.avatar_url}"></a></div>`
-		: '';
-	const login = timelineEvent.author.login
-		? `<a class="author" href="${timelineEvent.author.html_url}">${timelineEvent.author.login}</a>`
-		: timelineEvent.author.name;
 
-	return `<div class="comment-container"  data-type="commit">
+	const commentContainer = document.createElement('div');
+	commentContainer.classList.add('comment-container', 'commit');
+	const commitMessage = document.createElement('div');
+	commitMessage.className = 'commit-message';
 
-	<div class="review-comment" role="treeitem">
-		<div class="review-comment-contents commit">
-			<div class="commit">
-				<div class="commit-message">
-					<svg class="octicon octicon-git-commit" width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-						<path fill-rule="evenodd" clip-rule="evenodd" d="M10.86 3C10.41 1.28 8.86 0 7 0C5.14 0 3.59 1.28 3.14 3H0V5H3.14C3.59 6.72 5.14 8 7 8C8.86 8 10.41 6.72 10.86 5H14V3H10.86V3ZM7 6.2C5.78 6.2 4.8 5.22 4.8 4C4.8 2.78 5.78 1.8 7 1.8C8.22 1.8 9.2 2.78 9.2 4C9.2 5.22 8.22 6.2 7 6.2V6.2Z" transform="translate(0 4)"/>
-					</svg>
-					${avatar}
-					<div class="message">
-						${login} ${timelineEvent.message}
-					</div>
-				</div>
-				<a class="sha" href="${timelineEvent.html_url}">${shaShort}</a>
-			</div>
-		</div>
-	</div>
-</div>`;
+	const commitIcon = document.createElement('span');
+	commitIcon.innerHTML = `<svg class="octicon octicon-git-commit" width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M10.86 3C10.41 1.28 8.86 0 7 0C5.14 0 3.59 1.28 3.14 3H0V5H3.14C3.59 6.72 5.14 8 7 8C8.86 8 10.41 6.72 10.86 5H14V3H10.86V3ZM7 6.2C5.78 6.2 4.8 5.22 4.8 4C4.8 2.78 5.78 1.8 7 1.8C8.22 1.8 9.2 2.78 9.2 4C9.2 5.22 8.22 6.2 7 6.2V6.2Z" transform="translate(0 4)"/>
+	</svg>`;
+
+	commitMessage.appendChild(commitIcon);
+
+	const message = document.createElement('div');
+	message.className = 'message';
+	if (timelineEvent.author.html_url && timelineEvent.author.avatar_url) {
+		const userIcon = renderUserIcon(timelineEvent.author.html_url, timelineEvent.author.avatar_url);
+		commitMessage.appendChild(userIcon);
+
+		const login = document.createElement('a');
+		login.className = 'author';
+		(<HTMLAnchorElement>login).href = timelineEvent.author.html_url;
+		login.textContent = timelineEvent.author.login!;
+		commitMessage.appendChild(login);
+		message.textContent = timelineEvent.message;
+	} else {
+		message.textContent = `${timelineEvent.author.name} ${timelineEvent.message}`;
+	}
+
+	commitMessage.appendChild(message);
+
+	const sha = document.createElement('a');
+	sha.className = 'sha';
+	(<HTMLAnchorElement>sha).href = timelineEvent.html_url;
+	sha.textContent = shaShort;
+
+	commentContainer.appendChild(commitMessage);
+	commentContainer.appendChild(sha);
+
+	return commentContainer;
 }
 
 function getDiffChangeClass(type: DiffChangeType) {
@@ -295,41 +342,73 @@ function getDiffChangeClass(type: DiffChangeType) {
 	}
 }
 
-export function renderReview(timelineEvent: ReviewEvent): string {
+export function renderReview(timelineEvent: ReviewEvent): HTMLElement | undefined {
 	if (timelineEvent.state === 'pending') {
-		return '';
+		return undefined;
 	}
 
-	let reviewState = '';
+	const commentContainer = document.createElement('div');
+	commentContainer.classList.add('comment-container', 'comment');
+	const userIcon = renderUserIcon(timelineEvent.user.html_url, timelineEvent.user.avatar_url);
+	const reviewCommentContainer = document.createElement('div');
+	reviewCommentContainer.className = 'review-comment-container';
+	commentContainer.appendChild(userIcon);
+	commentContainer.appendChild(reviewCommentContainer);
+
+	const commentHeader = document.createElement('div');
+	commentHeader.className = 'review-comment-header';
+
+	const userLogin = document.createElement('a');
+	(<HTMLAnchorElement>userLogin).href = timelineEvent.user.html_url;
+	userLogin.textContent = timelineEvent.user.login;
+
+	const reviewState = document.createElement('span');
 	switch (timelineEvent.state.toLowerCase()) {
 		case 'approved':
-			reviewState = `<span><a class="author" href="${timelineEvent.user.html_url}">${timelineEvent.user.login}</a> approved these changes</span>`;
+			reviewState.textContent = ` approved these changes`;
 			break;
 		case 'commented':
-			reviewState = `<span><a class="author" href="${timelineEvent.user.html_url}">${timelineEvent.user.login}</a> reviewed</span>`;
+			reviewState.textContent = ` reviewed`;
 			break;
 		case 'changes_requested':
-			reviewState = `<span><a class="author" href="${timelineEvent.user.html_url}">${timelineEvent.user.login}</a> requested changes</span>`;
+			reviewState.textContent = ` requested changes`;
 			break;
 		default:
 			break;
 	}
 
-	let reviewBody = timelineEvent.body ? `${md.render(emoji.emojify(timelineEvent.body))}` : '';
+	const timestamp = document.createElement('div');
+	timestamp.className = 'timestamp';
+	timestamp.textContent = moment(timelineEvent.submitted_at).fromNow();
 
-	let body = '';
+	commentHeader.appendChild(userLogin);
+	commentHeader.appendChild(reviewState);
+	commentHeader.appendChild(timestamp);
+
+	const reviewBody = document.createElement('div');
+	reviewBody.className = 'review-body';
+	if (timelineEvent.body) {
+		reviewBody.innerHTML = md.render(emoji.emojify(timelineEvent.body));
+	}
+
+	reviewCommentContainer.appendChild(commentHeader);
+	reviewCommentContainer.appendChild(reviewBody);
+
 	if (timelineEvent.comments) {
+		const commentBody = document.createElement('div');
+		commentBody.className = 'comment-body';
 		let groups = groupBy(timelineEvent.comments, comment => comment.path + ':' + (comment.position !== null ? `pos:${comment.position}` : `ori:${comment.original_position}`));
 
 		for (let path in groups) {
 			let comments = groups[path];
-			let diffView = '';
-			let diffLines: string[] = [];
+
 			if (comments && comments.length) {
+				let diffLines: HTMLElement[] = [];
+
 				for (let i = 0; i < comments[0].diff_hunks.length; i++) {
 					diffLines = comments[0].diff_hunks[i].diffLines.slice(-4).map(diffLine => {
 						const diffLineElement = document.createElement('div');
-						diffLineElement.classList.add(...['diffLine',  getDiffChangeClass(diffLine.type)]);
+						diffLineElement.classList.add('diffLine',  getDiffChangeClass(diffLine.type));
 
 						const oldLineNumber = document.createElement('span');
 						oldLineNumber.textContent = diffLine.oldLineNumber > 0 ? diffLine.oldLineNumber.toString() : ' ';
@@ -340,57 +419,42 @@ export function renderReview(timelineEvent: ReviewEvent): string {
 						newLineNumber.classList.add('lineNumber');
 
 						const lineContent = document.createElement('span');
-						lineContent.textContent = (diffLine as any)._raw;
+						lineContent.textContent = diffLine.raw;
 						lineContent.classList.add('lineContent');
 
 						diffLineElement.appendChild(oldLineNumber);
 						diffLineElement.appendChild(newLineNumber);
 						diffLineElement.appendChild(lineContent);
 
-						return diffLineElement.outerHTML;
+						return diffLineElement;
 					});
 				}
 
-				diffView = `<div class="diff">
-					<div class="diffHeader">${comments[0].path}</div>
-					${diffLines.join('')}
-				</div>`;
+				const diffView = document.createElement('div');
+				diffView.className = 'diff';
+				const diffHeader = document.createElement('div');
+				diffHeader.className = 'diffHeader';
+				diffHeader.textContent = comments[0].path;
+
+				diffView.appendChild(diffHeader);
+				diffLines.forEach(line => diffView.appendChild(line));
+
+				commentBody.appendChild(diffView);
 			}
 
-			body += `
-				${diffView}
-				<div data-type="review-comment">${ comments && comments.length ? comments.map(comment => renderComment(comment)).join('') : ''}</div>
-			`;
+			comments.map(comment => commentBody.appendChild(renderComment(comment, 'review-comment')));
 		}
+
+		reviewCommentContainer.appendChild(commentBody);
 	}
 
-	return `<div class="comment-container"  data-type="review">
+	commentContainer.appendChild(userIcon);
+	commentContainer.appendChild(reviewCommentContainer);
 
-	<div class="review-comment" role="treeitem">
-
-		<div class="review-comment-contents review">
-			<div class="avatar-container">
-				<a class="avatar-link" href="${timelineEvent.user.html_url}"><img class="avatar" src="${timelineEvent.user.avatar_url}"></a>
-			</div>
-			<div class="review-comment-container">
-				<div class="review-comment-header">
-					${reviewState}
-					<div class="timestamp">${moment(timelineEvent.submitted_at).fromNow()}</div>
-				</div>
-				<div class="review-body">
-					${reviewBody}
-				</div>
-				<div class="comment-body">
-					${body}
-				</div>
-			</div>
-		</div>
-
-	</div>
-</div>`;
+	return commentContainer;
 }
 
-export function renderTimelineEvent(timelineEvent: TimelineEvent): string {
+export function renderTimelineEvent(timelineEvent: TimelineEvent): HTMLElement | undefined {
 	switch (timelineEvent.event) {
 		case EventType.Committed:
 			return renderCommit((<CommitEvent>timelineEvent));
@@ -398,8 +462,9 @@ export function renderTimelineEvent(timelineEvent: TimelineEvent): string {
 			return renderComment((<CommentEvent>timelineEvent));
 		case EventType.Reviewed:
 			return renderReview((<ReviewEvent>timelineEvent));
+		default:
+			return undefined;
 	}
-	return '';
 }
 
 export function getStatus(state: PullRequestStateEnum) {

--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -5,6 +5,7 @@
 
 import * as moment from 'moment';
 import md from './mdRenderer';
+const commitIconSvg = require('../resources/icons/commit_icon.svg');
 const emoji = require('node-emoji');
 
 export enum DiffChangeType {
@@ -228,16 +229,16 @@ function groupBy<T>(arr: T[], fn: (el: T) => string): { [key: string]: T[] } {
 }
 
 function renderUserIcon(iconLink: string, iconSrc: string): HTMLElement {
-	const iconContainer = document.createElement('div');
+	const iconContainer: HTMLDivElement = document.createElement('div');
 	iconContainer.className = 'avatar-container';
 
-	const avatarLink = document.createElement('a');
+	const avatarLink: HTMLAnchorElement = document.createElement('a');
 	avatarLink.className = 'avatar-link';
-	(<HTMLAnchorElement>avatarLink).href = iconLink;
+	avatarLink.href = iconLink;
 
-	const avatar = document.createElement('img');
+	const avatar: HTMLImageElement = document.createElement('img');
 	avatar.className = 'avatar';
-	(<HTMLImageElement>avatar).src = iconSrc;
+	avatar.src = iconSrc;
 
 	iconContainer.appendChild(avatarLink).appendChild(avatar);
 
@@ -245,7 +246,7 @@ function renderUserIcon(iconLink: string, iconSrc: string): HTMLElement {
 }
 
 export function renderComment(comment: CommentEvent | Comment, additionalClass?: string): HTMLElement {
-	const commentContainer = document.createElement('div');
+	const commentContainer: HTMLDivElement = document.createElement('div');
 	commentContainer.id = `comment${comment.id.toString()}`;
 	commentContainer.classList.add('comment-container', 'comment');
 
@@ -254,23 +255,23 @@ export function renderComment(comment: CommentEvent | Comment, additionalClass?:
 	}
 
 	const userIcon = renderUserIcon(comment.user.html_url, comment.user.avatar_url);
-	const reviewCommentContainer = document.createElement('div');
+	const reviewCommentContainer: HTMLDivElement = document.createElement('div');
 	reviewCommentContainer.className = 'review-comment-container';
 	commentContainer.appendChild(userIcon);
 	commentContainer.appendChild(reviewCommentContainer);
 
-	const commentHeader = document.createElement('div');
+	const commentHeader: HTMLDivElement = document.createElement('div');
 	commentHeader.className = 'review-comment-header';
-	const authorLink = document.createElement('a');
+	const authorLink: HTMLAnchorElement = document.createElement('a');
 	authorLink.className = 'author';
-	(<HTMLAnchorElement>authorLink).href = comment.user.html_url;
+	authorLink.href = comment.user.html_url;
 	authorLink.textContent = comment.user.login;
 
-	const timestamp = document.createElement('div');
+	const timestamp: HTMLDivElement = document.createElement('div');
 	timestamp.className = 'timestamp';
 	timestamp.textContent = moment(comment.created_at).fromNow();
 
-	const commentBody = document.createElement('div');
+	const commentBody: HTMLDivElement = document.createElement('div');
 	commentBody.className = 'comment-body';
 	commentBody.innerHTML  = md.render(emoji.emojify(comment.body));
 
@@ -286,27 +287,22 @@ export function renderComment(comment: CommentEvent | Comment, additionalClass?:
 export function renderCommit(timelineEvent: CommitEvent): HTMLElement {
 	const shaShort = timelineEvent.sha.substring(0, 7);
 
-	const commentContainer = document.createElement('div');
+	const commentContainer: HTMLDivElement = document.createElement('div');
 	commentContainer.classList.add('comment-container', 'commit');
-	const commitMessage = document.createElement('div');
+	const commitMessage: HTMLDivElement = document.createElement('div');
 	commitMessage.className = 'commit-message';
 
-	const commitIcon = document.createElement('span');
-	commitIcon.innerHTML = `<svg class="octicon octicon-git-commit" width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<path fill-rule="evenodd" clip-rule="evenodd" d="M10.86 3C10.41 1.28 8.86 0 7 0C5.14 0 3.59 1.28 3.14 3H0V5H3.14C3.59 6.72 5.14 8 7 8C8.86 8 10.41 6.72 10.86 5H14V3H10.86V3ZM7 6.2C5.78 6.2 4.8 5.22 4.8 4C4.8 2.78 5.78 1.8 7 1.8C8.22 1.8 9.2 2.78 9.2 4C9.2 5.22 8.22 6.2 7 6.2V6.2Z" transform="translate(0 4)"/>
-	</svg>`;
+	commitMessage.insertAdjacentHTML('beforeend', commitIconSvg);
 
-	commitMessage.appendChild(commitIcon);
-
-	const message = document.createElement('div');
+	const message: HTMLDivElement = document.createElement('div');
 	message.className = 'message';
 	if (timelineEvent.author.html_url && timelineEvent.author.avatar_url) {
 		const userIcon = renderUserIcon(timelineEvent.author.html_url, timelineEvent.author.avatar_url);
 		commitMessage.appendChild(userIcon);
 
-		const login = document.createElement('a');
+		const login: HTMLAnchorElement = document.createElement('a');
 		login.className = 'author';
-		(<HTMLAnchorElement>login).href = timelineEvent.author.html_url;
+		login.href = timelineEvent.author.html_url;
 		login.textContent = timelineEvent.author.login!;
 		commitMessage.appendChild(login);
 		message.textContent = timelineEvent.message;
@@ -316,9 +312,9 @@ export function renderCommit(timelineEvent: CommitEvent): HTMLElement {
 
 	commitMessage.appendChild(message);
 
-	const sha = document.createElement('a');
+	const sha: HTMLAnchorElement = document.createElement('a');
 	sha.className = 'sha';
-	(<HTMLAnchorElement>sha).href = timelineEvent.html_url;
+	sha.href = timelineEvent.html_url;
 	sha.textContent = shaShort;
 
 	commentContainer.appendChild(commitMessage);
@@ -347,19 +343,19 @@ export function renderReview(timelineEvent: ReviewEvent): HTMLElement | undefine
 		return undefined;
 	}
 
-	const commentContainer = document.createElement('div');
+	const commentContainer: HTMLDivElement = document.createElement('div');
 	commentContainer.classList.add('comment-container', 'comment');
 	const userIcon = renderUserIcon(timelineEvent.user.html_url, timelineEvent.user.avatar_url);
-	const reviewCommentContainer = document.createElement('div');
+	const reviewCommentContainer: HTMLDivElement = document.createElement('div');
 	reviewCommentContainer.className = 'review-comment-container';
 	commentContainer.appendChild(userIcon);
 	commentContainer.appendChild(reviewCommentContainer);
 
-	const commentHeader = document.createElement('div');
+	const commentHeader: HTMLDivElement = document.createElement('div');
 	commentHeader.className = 'review-comment-header';
 
-	const userLogin = document.createElement('a');
-	(<HTMLAnchorElement>userLogin).href = timelineEvent.user.html_url;
+	const userLogin: HTMLAnchorElement = document.createElement('a');
+	userLogin.href = timelineEvent.user.html_url;
 	userLogin.textContent = timelineEvent.user.login;
 
 	const reviewState = document.createElement('span');
@@ -377,7 +373,7 @@ export function renderReview(timelineEvent: ReviewEvent): HTMLElement | undefine
 			break;
 	}
 
-	const timestamp = document.createElement('div');
+	const timestamp: HTMLDivElement = document.createElement('div');
 	timestamp.className = 'timestamp';
 	timestamp.textContent = moment(timelineEvent.submitted_at).fromNow();
 
@@ -385,7 +381,7 @@ export function renderReview(timelineEvent: ReviewEvent): HTMLElement | undefine
 	commentHeader.appendChild(reviewState);
 	commentHeader.appendChild(timestamp);
 
-	const reviewBody = document.createElement('div');
+	const reviewBody: HTMLDivElement = document.createElement('div');
 	reviewBody.className = 'review-body';
 	if (timelineEvent.body) {
 		reviewBody.innerHTML = md.render(emoji.emojify(timelineEvent.body));
@@ -395,7 +391,7 @@ export function renderReview(timelineEvent: ReviewEvent): HTMLElement | undefine
 	reviewCommentContainer.appendChild(reviewBody);
 
 	if (timelineEvent.comments) {
-		const commentBody = document.createElement('div');
+		const commentBody: HTMLDivElement = document.createElement('div');
 		commentBody.className = 'comment-body';
 		let groups = groupBy(timelineEvent.comments, comment => comment.path + ':' + (comment.position !== null ? `pos:${comment.position}` : `ori:${comment.original_position}`));
 
@@ -430,9 +426,9 @@ export function renderReview(timelineEvent: ReviewEvent): HTMLElement | undefine
 					});
 				}
 
-				const diffView = document.createElement('div');
+				const diffView: HTMLDivElement = document.createElement('div');
 				diffView.className = 'diff';
-				const diffHeader = document.createElement('div');
+				const diffHeader: HTMLDivElement = document.createElement('div');
 				diffHeader.className = 'diffHeader';
 				diffHeader.textContent = comments[0].path;
 

--- a/resources/icons/commit_icon.svg
+++ b/resources/icons/commit_icon.svg
@@ -1,0 +1,7 @@
+<svg class="octicon octicon-git-commit" width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M10.86 3C10.41 1.28 8.86 0
+	7 0C5.14 0 3.59 1.28 3.14 3H0V5H3.14C3.59 6.72 5.14 8 7 8C8.86 8 10.41 6.72
+	10.86 5H14V3H10.86V3ZM7 6.2C5.78 6.2 4.8 5.22 4.8 4C4.8 2.78 5.78 1.8 7
+	1.8C8.22 1.8 9.2 2.78 9.2 4C9.2 5.22 8.22 6.2 7 6.2V6.2Z"
+	transform="translate(0 4)"/>
+</svg>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,11 +27,15 @@ function getWebviewConfig(env) {
 				{
 					test: /\.css/,
 					use: ['style-loader', 'css-loader']
+				},
+				{
+					test: /\.svg/,
+					use: ['svg-inline-loader']
 				}
 			]
 		},
 		resolve: {
-			extensions: ['.tsx', '.ts', '.js']
+			extensions: ['.tsx', '.ts', '.js', '.svg']
 		},
 		devtool: !env.production ? 'inline-source-map' : undefined,
 		output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4488,6 +4488,16 @@ loader-runner@^2.3.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
   integrity sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=
 
+loader-utils@^0.2.11:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
+
 loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
@@ -6742,6 +6752,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simple-html-tokenizer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
+  integrity sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -7136,6 +7151,15 @@ supports-color@^3.2.3:
   integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   dependencies:
     has-flag "^1.0.0"
+
+svg-inline-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/svg-inline-loader/-/svg-inline-loader-0.8.0.tgz#7e9d905d80d0b4e68d2df21afcd08ee9e9a3ea6e"
+  integrity sha512-rynplY2eXFrdNomL1FvyTFQlP+dx0WqbzHglmNtA9M4IHRC3no2aPAl3ny9lUpJzFzFMZfWRK5YIclNU+FRePA==
+  dependencies:
+    loader-utils "^0.2.11"
+    object-assign "^4.0.1"
+    simple-html-tokenizer "^0.1.1"
 
 svgo@^0.7.0:
   version "0.7.2"


### PR DESCRIPTION
It's significantly easier to handle the comment edit UX with named HTML elements instead of strings. This is the first part of the work to have edit/delete support on comments there, just refactoring to use `document.createElement`