### PR TITLE
Use SSH config to parse hosts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
+				"${workspaceFolder}/out/test",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test"
 			],

--- a/package.json
+++ b/package.json
@@ -345,6 +345,7 @@
     "moment": "^2.22.1",
     "node-emoji": "^1.8.1",
     "node-fetch": "^2.1.1",
+    "ssh-config": "^1.1.3",
     "telemetry-github": "https://github.com/shana/telemetry/releases/download/0.3.2/telemetry-github-v0.3.2.tgz",
     "vscode": "^1.1.18",
     "ws": "^6.0.0"

--- a/src/common/ssh.ts
+++ b/src/common/ssh.ts
@@ -1,0 +1,65 @@
+import { parse as parseConfig } from 'ssh-config';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import Logger from './logger';
+
+const SSH_URL_REGEXP = /^(?:([^@:]+)@)?([^:/]+):?(.+)$/;
+const parse = (url: string): Config => {
+	const match = SSH_URL_REGEXP.exec(url);
+	if (!match) { return null; }
+	const [, User, Host, path] = match;
+	return {User, Host, path};
+};
+
+const defaultResolver = chainResolvers(
+	baseResolver,
+	resolverFromConfigFile(),
+);
+
+let testResolver = null;
+export const _test_setSSHConfig = (config?: string) =>
+	testResolver = config
+		? chainResolvers(baseResolver, resolverFromConfig(config))
+		: null;
+
+export const resolve = (url: string, resolveConfig=testResolver || defaultResolver) => {
+	const config = parse(url);
+	return config && resolveConfig(config);
+};
+
+interface Config {
+	Host: string;
+	[param: string]: string;
+}
+
+type ConfigResolver = (config: Config) => Config;
+function baseResolver(config: Config) {
+	return {
+		...config,
+		HostName: config.Host,
+	};
+}
+
+function resolverFromConfigFile(configPath=join(homedir(), '.ssh', 'config')): ConfigResolver {
+	try {
+		const config = readFileSync(configPath).toString();
+		return resolverFromConfig(config);
+	} catch (error) {
+		Logger.appendLine(`${configPath}: ${error.message}`);
+	}
+}
+
+export function resolverFromConfig(text: string): ConfigResolver {
+	const config = parseConfig(text);
+	return h => config.compute(h.Host);
+}
+
+function chainResolvers(...chain: ConfigResolver[]): ConfigResolver {
+	const resolvers = chain.filter(x => !!x);
+	return  (config: Config) => resolvers
+		.reduce((resolved, next) => ({
+			...resolved,
+			...next(resolved),
+		}), config);
+}

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -26,7 +26,7 @@ const testRemote = remote => describe(`with ${remote.uri}`, () => {
 		assert.equal(protocol.repositoryName, remote.expectedRepositoryName));
 });
 
-describe.only('Protocol', () => {
+describe('Protocol', () => {
 	describe('with HTTP and HTTPS remotes', () =>
 		[
 			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6922,6 +6922,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+ssh-config@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ssh-config/-/ssh-config-1.1.3.tgz#2b19630af85b1666688b9d68f6e4218900f81f8c"
+  integrity sha1-KxljCvhbFmZoi51o9uQhiQD4H4w=
+
 sshpk@^1.7.0:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"


### PR DESCRIPTION
Fixes #607 

I slightly changed our protocol test suite. It was a little painful to track down which cases were failing, so I made the generated tests more granular and descriptive.

I also updated our test profile in `launch.json` to match what `npm test` does. It's odd to me that they didn't match? Am I the only person who's tried to run the tests this way, or is something misconfigured on my end?