### PR TITLE
Remove extra margins on non-header anchors and spans

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -108,7 +108,9 @@ body .comment-container .review-comment-header {
 	margin-right: 0;
 }
 
-body .comment-container .review-comment-header > span, a {
+body .comment-container .review-comment-header > span,
+body .comment-container .review-comment-header > a,
+body .commit .commit-message > a {
 	margin-right: 4px;
 }
 
@@ -120,7 +122,7 @@ body .comment-container .comment-body > p {
 	margin-top: 0;
 }
 
-body .comment-container  .comment-body > p:last-child {
+body .comment-container .comment-body > p:last-child {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/642

The previous CSS rule was applying the `4px` margin to all `<a>` elements instead of just the ones under the comment header. In addition I also had to add the margin for the commit message.