### PR TITLE
Display the PR changed files in a tree, closes #653.

### DIFF
--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -191,13 +191,13 @@ export interface IPullRequestManager {
 	getPullRequestRepositoryDefaultBranch(pullRequest: IPullRequestModel): Promise<string>;
 
 	/**
-	 * Fullfill information for a pull request which we can't fetch with one single api call.
+	 * Fulfill information for a pull request which we can't fetch with one single api call.
 	 * 1. base. This property might not exist in search results
 	 * 2. head. This property might not exist in search results
 	 * 3. merge base. This is necessary as base might not be the commit that files in Pull Request are being compared to.
 	 * @param pullRequest
 	 */
-	fullfillPullRequestMissingInfo(pullRequest: IPullRequestModel): Promise<void>;
+	fulfillPullRequestMissingInfo(pullRequest: IPullRequestModel): Promise<void>;
 	updateRepositories(): Promise<void>;
 	authenticate(): Promise<boolean>;
 

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -578,7 +578,7 @@ export class PullRequestManager implements IPullRequestManager {
 		return branch;
 	}
 
-	async fullfillPullRequestMissingInfo(pullRequest: IPullRequestModel): Promise<void> {
+	async fulfillPullRequestMissingInfo(pullRequest: IPullRequestModel): Promise<void> {
 		try {
 			const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -558,7 +558,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			let outdatedComments = this._comments.filter(comment => !comment.position);
 
 			const data = await this._prManager.getPullRequestChangedFiles(pr);
-			await this._prManager.fullfillPullRequestMissingInfo(pr);
+			await this._prManager.fulfillPullRequestMissingInfo(pr);
 			let headSha = pr.head.sha;
 			let mergeBase = pr.mergeBase;
 
@@ -983,7 +983,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 
 	public async switch(pr: IPullRequestModel): Promise<void> {
 		Logger.appendLine(`Review> switch to Pull Request #${pr.prNumber}`);
-		await this._prManager.fullfillPullRequestMissingInfo(pr);
+		await this._prManager.fulfillPullRequestMissingInfo(pr);
 
 		if (this._repository.state.workingTreeChanges.length > 0) {
 			vscode.window.showErrorMessage('Your local changes would be overwritten by checkout, please commit your changes or stash them before you switch branches');

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -234,7 +234,7 @@ export class PRNode extends TreeNode {
 
 			const comments = await this._prManager.getPullRequestComments(this.pullRequestModel);
 			const data = await this._prManager.getPullRequestChangedFiles(this.pullRequestModel);
-			await this._prManager.fullfillPullRequestMissingInfo(this.pullRequestModel);
+			await this._prManager.fulfillPullRequestMissingInfo(this.pullRequestModel);
 			let mergeBase = this.pullRequestModel.mergeBase;
 			const rawChanges = await parseDiff(data, this._prManager.repository, mergeBase);
 			let fileChanges = rawChanges.map(change => {


### PR DESCRIPTION
This PR is a naive implementation of `Option 3` presented [here](https://github.com/Microsoft/vscode-pull-request-github/issues/653#issuecomment-434868164), in case anyone wanted to see what it might look like:

<img width="303" alt="screen shot 2018-11-01 at 4 12 18 pm" src="https://user-images.githubusercontent.com/8648231/47847510-7683b500-ddf1-11e8-82bf-271a197e551f.png">

**Note:** The ordering matches that shown on GitHub's PR `Files changed` tab.

Regarding the `Expand / Collapse All` functionality, despite being able to recursively visit all child tree nodes and update the `vscode.TreeItemCollapsibleState` for collapsible nodes, I was not certain how to tell the tree view to refresh the nodes (i.e., like they do in response to mouse click events). Any suggestions would be appreciated.