### PR TITLE
add debug log level to help troubleshoot performance issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,16 @@
             }
           }
         },
+        "githubPullRequests.logLevel": {
+          "type": "string",
+          "enum": [
+            "info",
+            "debug",
+            "off"
+          ],
+          "default": "info",
+          "description": "Logging for GitHub Pull Request extension. The log is emitted to the output channel named as GitHub Pull Request."
+        },
         "telemetry.optout": {
           "type": "boolean",
           "default": false,

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,4 +1,72 @@
-import { window, OutputChannel } from 'vscode';
+import * as vscode from 'vscode';
 
-const Logger: OutputChannel = window.createOutputChannel('GitHub Pull Request');
+const enum LogLevel {
+	Info,
+	Debug,
+	Off
+}
+
+const SETTINGS_NAMESPACE = 'githubPullRequests';
+const LOG_LEVEL_SETTING = 'logLevel';
+
+class Log {
+	private _outputChannel: vscode.OutputChannel;
+	private _logLevel: LogLevel;
+	private _disposable: vscode.Disposable;
+
+	constructor() {
+		this._outputChannel = vscode.window.createOutputChannel('GitHub Pull Request');
+		this._disposable = vscode.workspace.onDidChangeConfiguration(() => {
+			this.getLogLevel();
+		});
+		this.getLogLevel();
+	}
+
+	public appendLine(message: string, component?: string) {
+		switch(this._logLevel) {
+			case LogLevel.Off:
+				return;
+			case LogLevel.Debug:
+				const hrtime = process.hrtime();
+				const timeStamp = `${hrtime[0]}s ${Math.floor(hrtime[1]/1000000)}ms`;
+				const info = component ? `${component}> ${message}`: `${message}`;
+				this._outputChannel.appendLine(`[Debug ${timeStamp}] ${info}`);
+				return;
+			case LogLevel.Info:
+			default:
+				this._outputChannel.appendLine(`[Info] ` + (component ? `${component}> ${message}`: `${message}`));
+				return;
+		}
+	}
+
+	public debug(message: string, component: string) {
+		if (this._logLevel === LogLevel.Debug) {
+			this.appendLine(message, component);
+		}
+	}
+
+	public dispose() {
+		if (this._disposable) {
+			this._disposable.dispose();
+		}
+	}
+
+	private getLogLevel() {
+		let logLevel = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE).get<string>(LOG_LEVEL_SETTING);
+		switch(logLevel) {
+			case 'debug':
+				this._logLevel = LogLevel.Debug;
+				break;
+			case 'off':
+				this._logLevel = LogLevel.Off;
+				break;
+			case 'info':
+			default:
+				this._logLevel = LogLevel.Info;
+				break;
+		}
+	}
+}
+
+const Logger = new Log();
 export default Logger;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ fetch.Promise = PolyfillPromise;
 let telemetry: ITelemetry;
 
 async function init(context: vscode.ExtensionContext, git: GitAPI, repository: Repository): Promise<void> {
+	context.subscriptions.push(Logger);
 	Logger.appendLine('Git repository found, initializing review manager and pr tree view.');
 
 	const configuration = new VSCodeConfiguration();


### PR DESCRIPTION
I often see Pull Request tree view and Checkout process on Windows are slower than macOS but have no clue which part is slowing down. Now adding a log level setting to help trouble shoot.

By default the log level is info, the same as before and the output would be
```
[Info] Looking for git repository
[Info] Git repository found, initializing review manager and pr tree view.
[Info] Found GitHub remote
```

Once it's being changed to debug

```
[Debug 438709s 711ms] Looking for git repository
[Debug 438709s 712ms] Git repository found, initializing review manager and pr tree view.
[Debug 438709s 731ms] Found GitHub remote
[Debug 438711s 367ms] Review> no matching pull request metadata found for current branch NewBranch
```

Please note we don't send this info to telemetry as it's for local troubleshooting and users can provide meaningful info if they opt in. Besides, we don't care about date time, only seconds and ms.