### PR TITLE
Fix NPE

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -1114,7 +1114,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			}
 			return remoteQuickPick;
 		});
-		if (!defaultUpstreamWasARemote) {
+		if (!defaultUpstreamWasARemote && defaultUpstream) {
 			picks.unshift(defaultUpstream);
 		}
 


### PR DESCRIPTION
`defaultUpstreamWasARemote` is always `false` when `defaultUpstream` is undefined.