### PR TITLE
Clear validation error message when succedded

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -1045,8 +1045,12 @@ export class ReviewManager implements vscode.DecorationProvider {
 					let remoteBranch = await this._prManager.getBranch(selectedRemote, value);
 					if (remoteBranch) {
 						inputBox.validationMessage = `Branch ${value} already exists in ${selectedRemote.owner}/${selectedRemote.repositoryName}`;
+					} else {
+						inputBox.validationMessage = null;
 					}
-				} catch (e) { }
+				} catch (e) {
+					inputBox.validationMessage = null;
+				}
 
 				inputBox.busy = false;
 			};


### PR DESCRIPTION
We didn't use `window.showInputBox` here as when using this API, you can't continue if the valdiation fails, however we should allow users to continue publihsing the branch even if there is already one upstream as it's possible that the branch upstream is also created by the user. 

To make it possible, here I used `createInputBox` to manually take over all error handling. But I forgot the clear the message when it succeeds ;(