### PR TITLE
Logging for fetching merge base.

### DIFF
--- a/src/github/pullRequestGitHelper.ts
+++ b/src/github/pullRequestGitHelper.ts
@@ -251,12 +251,15 @@ export class PullRequestGitHelper {
 
 	static async getPullRequestMergeBase(repository: Repository, remote: Remote, pullRequest: IPullRequestModel): Promise<string> {
 		try {
+			Logger.appendLine(`Get merge base of ${pullRequest.base.sha}, ${pullRequest.head.sha}`, PullRequestGitHelper.ID);
 			return await repository.getMergeBase(pullRequest.base.sha, pullRequest.head.sha);
 		} catch (err) {
+			Logger.appendLine(`Get merge base of ${pullRequest.base.sha}, ${pullRequest.head.sha} failed, start fetching from remote`, PullRequestGitHelper.ID);
 			const pullrequestHeadRef = `refs/pull/${pullRequest.prNumber}/head`;
 			await repository.fetch(remote.remoteName, pullrequestHeadRef);
 			await repository.fetch(remote.remoteName, pullRequest.base.ref);
 
+			Logger.appendLine(`Get merge base of ${pullRequest.base.sha}, ${pullRequest.head.sha} again`, PullRequestGitHelper.ID);
 			return await repository.getMergeBase(pullRequest.base.sha, pullRequest.head.sha);
 		}
 	}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -779,6 +779,7 @@ export class PullRequestManager implements IPullRequestManager {
 
 	async fullfillPullRequestMissingInfo(pullRequest: IPullRequestModel): Promise<void> {
 		try {
+			Logger.debug(`Fullfill pull request missing info - start`, PullRequestManager.ID);
 			const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
 
 			if (!pullRequest.base) {
@@ -794,6 +795,7 @@ export class PullRequestManager implements IPullRequestManager {
 		} catch (e) {
 			vscode.window.showErrorMessage(`Fetching Pull Request merge base failed: ${formatError(e)}`);
 		}
+		Logger.debug(`Fullfill pull request missing info - done`, PullRequestManager.ID);
 	}
 
 	//#region Git related APIs


### PR DESCRIPTION
Added more logging for fetching merge base.

It turns out that fetching merge base is one of the most costly process for viewing pull request.