### PR TITLE
Strip unknown HTML tags (including comments)

### DIFF
--- a/preview-src/mdRenderer.ts
+++ b/preview-src/mdRenderer.ts
@@ -19,7 +19,7 @@ const md = MarkdownIt({
 .use(Sanitizer, {
 	imageClass: '',
 	removeUnbalanced: false,
-	removeUnknown: false
+	removeUnknown: true
 });
 
 export default md;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/689

I couldn't get the [markdown-it-inline-comments](https://www.npmjs.com/package/markdown-it-inline-comments) plugin to work nicely with the sanitizer plugin. This just configures the sanitizer to strip out unknown HTML tags, which includes comments.

I think this solution is the most appropriate because GitHub also does not render invalid HTML tags (currently the extension renders invalid HTML tags).

### Example
```md
<!-- This is a comment -->

<invalid></invalid>
Fixes #311
![screen shot 2018-11-07 at 11 23 44 am](https://user-images.githubusercontent.com/3672607/48155338-a44c7c00-e27f-11e8-9b35-768fe51ce21b.png)

```

#### GitHub
<img width="774" alt="screen shot 2018-11-26 at 10 31 13 am" src="https://user-images.githubusercontent.com/9157833/49024038-91361900-f166-11e8-9360-43d0036c27c2.png">

#### VS Code
<img width="626" alt="screen shot 2018-11-26 at 10 31 26 am" src="https://user-images.githubusercontent.com/9157833/49024048-95623680-f166-11e8-866b-d22e2f74e87c.png">
