### PR TITLE
Improve error handling and reporting in auth flow.

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -168,7 +168,8 @@ export async function promiseFromEvent<T, U>(
 	return new Promise<U>((resolve, reject) =>
 		subscription = event((value: T) => {
 			try {
-				adapter(value, resolve, reject);
+				Promise.resolve(adapter(value, resolve, reject))
+					.catch(reject);
 			} catch(error) {
 				reject(error);
 			}

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -106,6 +106,22 @@ describe('utils', () => {
 				assert(!hasListeners(emitter), 'should unsubscribe');
 			});
 
+			it('should return a promise that rejects if the adapter returns a rejecting Promise', async () => {
+				const emitter = new EventEmitter<string>();
+				const promise = utils.promiseFromEvent(
+					emitter.event,
+					async () => { throw new Error('kaboom'); }
+				);
+				assert(hasListeners(emitter), 'should subscribe');
+				emitter.fire('hello');
+				await promise
+					.then(
+						() => { throw new Error('promise should have rejected'); },
+						e => assert.equal(e.message, 'kaboom')
+					);
+				assert(!hasListeners(emitter), 'should unsubscribe');
+			});
+
 			const door: utils.PromiseAdapter<string, boolean> =
 				(password, resolve, reject) =>
 					password === 'sesame'


### PR DESCRIPTION
I was under the impression that `promiseFromEvent` would catch any failures bubbling from `verifyToken` and turn them into exceptions, but since `verifyToken` was async, this wasn't true. Now it is.

Orthogonally, throw a descriptive error if verification fails to return status code 200. 