### PR TITLE
Use description for file name and pr description.

### DIFF
--- a/src/view/prChangesTreeDataProvider.ts
+++ b/src/view/prChangesTreeDataProvider.ts
@@ -24,7 +24,10 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 
 	constructor(private context: vscode.ExtensionContext) {
 		super(() => this.dispose());
-		this.context.subscriptions.push(vscode.window.registerTreeDataProvider<TreeNode>('prStatus', this));
+		this.context.subscriptions.push(vscode.window.createTreeView('prStatus', {
+			treeDataProvider: this,
+			showCollapseAll: true
+		}));
 	}
 
 	refresh() {

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -18,6 +18,7 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 	get onDidChange(): vscode.Event<vscode.Uri> { return this._onDidChange.event; }
 	private _disposables: vscode.Disposable[];
 	private _childrenDisposables: vscode.Disposable[];
+	private _view: vscode.TreeView<any>;
 
 	constructor(
 		onShouldReload: vscode.Event<any>,
@@ -37,7 +38,12 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 			this._onDidChangeTreeData.fire(node);
 		}));
 
-		this._disposables.push(vscode.window.registerTreeDataProvider<TreeNode>('pr', this));
+		this._view = vscode.window.createTreeView('pr', {
+			treeDataProvider: this,
+			showCollapseAll: true
+		});
+
+		this._disposables.push(this._view);
 		this._disposables.push(onShouldReload(e => {
 			this._onDidChangeTreeData.fire();
 		}));

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -31,7 +31,7 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	) {
 		super();
 		this.label = path.basename(fileName);
-		this.description = path.dirname(fileName);
+		this.description = path.relative('.', path.dirname(fileName));
 		this.iconPath = Resource.getFileStatusUri(this);
 
 		this.command = {
@@ -78,7 +78,7 @@ export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 		super();
 		this.contextValue = 'filechange';
 		this.label = path.basename(fileName);
-		this.description = path.dirname(fileName);
+		this.description = path.relative('.', path.dirname(fileName));
 		this.iconPath = Resource.getFileStatusUri(this);
 		this.resourceUri = toFileChangeNodeUri(this.filePath, comments.length > 0);
 
@@ -148,7 +148,7 @@ export class GitFileChangeNode extends TreeNode implements vscode.TreeItem {
 		super();
 		this.contextValue = 'filechange';
 		this.label = path.basename(fileName);
-		this.description = path.dirname(fileName);
+		this.description = path.relative('.', path.dirname(fileName));
 		this.iconPath = Resource.getFileStatusUri(this);
 		this.resourceUri = toFileChangeNodeUri(this.filePath, comments.length > 0);
 

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { DiffHunk, DiffChangeType } from '../../common/diffHunk';
 import { GitChangeType } from '../../common/file';
 import { Resource } from '../../common/resources';
@@ -18,6 +19,7 @@ import { toFileChangeNodeUri } from '../../common/uri';
  */
 export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
+	public description: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
 	public command: vscode.Command;
 
@@ -28,7 +30,8 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 		public readonly blobUrl: string
 	) {
 		super();
-		this.label = fileName;
+		this.label = path.basename(fileName);
+		this.description = path.dirname(fileName);
 		this.iconPath = Resource.getFileStatusUri(this);
 
 		this.command = {
@@ -50,6 +53,7 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
  */
 export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
+	public description: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
 	public resourceUri: vscode.Uri;
 	public parentSha: string;
@@ -73,7 +77,8 @@ export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 	) {
 		super();
 		this.contextValue = 'filechange';
-		this.label = fileName;
+		this.label = path.basename(fileName);
+		this.description = path.dirname(fileName);
 		this.iconPath = Resource.getFileStatusUri(this);
 		this.resourceUri = toFileChangeNodeUri(this.filePath, comments.length > 0);
 
@@ -121,6 +126,7 @@ export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
  */
 export class GitFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
+	public description: string;
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri };
 	public resourceUri: vscode.Uri;
 	public parentSha: string;
@@ -141,7 +147,8 @@ export class GitFileChangeNode extends TreeNode implements vscode.TreeItem {
 	) {
 		super();
 		this.contextValue = 'filechange';
-		this.label = fileName;
+		this.label = path.basename(fileName);
+		this.description = path.dirname(fileName);
 		this.iconPath = Resource.getFileStatusUri(this);
 		this.resourceUri = toFileChangeNodeUri(this.filePath, comments.length > 0);
 

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -319,12 +319,14 @@ export class PRNode extends TreeNode {
 		const labelPrefix = (currentBranchIsForThisPR ? '✓ ' : '');
 		const tooltipPrefix = (currentBranchIsForThisPR ? 'Current Branch * ' : '');
 		const formattedPRNumber = prNumber.toString();
-		const label = `${labelPrefix}${title} (#${formattedPRNumber})`;
-		const tooltip = `${tooltipPrefix}${title} (#${formattedPRNumber}) by ${login}`;
+		const label = `${labelPrefix}${title}`;
+		const tooltip = `${tooltipPrefix}${title} (#${formattedPRNumber}) by @${login}`;
+		const description = `#${formattedPRNumber} by @${login}`;
 
 		return {
 			label,
 			tooltip,
+			description,
 			collapsibleState: 1,
 			contextValue: 'pullrequest' + (this._isLocal ? ':local' : '') + (currentBranchIsForThisPR ? ':active' : ':nonactive'),
 			iconPath: this.pullRequestModel.userAvatarUri


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/876920/49603206-75d5c580-f93f-11e8-82ae-a9c01141071c.png)

VSCode 1.30 now supports builtin collapse action and inline description for tree items, now finally we can move the folder name and pull request secondary information away from the label.
