### PR TITLE
Re-fetch pull request when updating overview page

### DIFF
--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -89,6 +89,8 @@ export function renderStatusChecks(statusInfo: any) {
 	if (!statusInfo.statuses.length) {
 		statusContainer.classList.add('hidden');
 		return;
+	} else {
+		statusContainer.classList.remove('hidden');
 	}
 
 	statusContainer.open = statusInfo.state !== 'success';

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -132,37 +132,39 @@ export class PullRequestOverviewPanel {
 
 		if (!pullRequestModel.equals(this._pullRequest) || !this._initialized) {
 			this._panel.webview.html = this.getHtmlForWebview(pullRequestModel.prNumber.toString());
-			this._pullRequest = pullRequestModel;
 			this._initialized = true;
-			this._panel.title = `Pull Request #${pullRequestModel.prNumber.toString()}`;
-
-			const isCurrentlyCheckedOut = pullRequestModel.equals(this._pullRequestManager.activePullRequest);
-			const canEdit = this._pullRequestManager.canEditPullRequest(this._pullRequest);
 
 			Promise.all(
 				[
+					this._pullRequestManager.resolvePullRequest(pullRequestModel.remote.owner, pullRequestModel.remote.repositoryName, pullRequestModel.prNumber),
 					this._pullRequestManager.getTimelineEvents(pullRequestModel),
 					this._pullRequestManager.getPullRequestRepositoryDefaultBranch(pullRequestModel),
 					this._pullRequestManager.getStatusChecks(pullRequestModel)
 				]
 			).then(result => {
-				const [timelineEvents, defaultBranch, status] = result;
+				const [pullRequest, timelineEvents, defaultBranch, status] = result;
+				this._pullRequest = pullRequest;
+				this._panel.title = `Pull Request #${pullRequestModel.prNumber.toString()}`;
+
+				const isCurrentlyCheckedOut = pullRequestModel.equals(this._pullRequestManager.activePullRequest);
+				const canEdit = this._pullRequestManager.canEditPullRequest(this._pullRequest);
+
 				this._postMessage({
 					command: 'pr.initialize',
 					pullrequest: {
-						number: pullRequestModel.prNumber,
-						title: pullRequestModel.title,
-						url: pullRequestModel.html_url,
-						createdAt: pullRequestModel.createdAt,
-						body: pullRequestModel.body,
-						labels: pullRequestModel.labels,
-						author: pullRequestModel.author,
-						state: pullRequestModel.state,
+						number: this._pullRequest.prNumber,
+						title: this._pullRequest.title,
+						url: this._pullRequest.html_url,
+						createdAt: this._pullRequest.createdAt,
+						body: this._pullRequest.body,
+						labels: this._pullRequest.labels,
+						author: this._pullRequest.author,
+						state: this._pullRequest.state,
 						events: timelineEvents,
 						isCurrentlyCheckedOut: isCurrentlyCheckedOut,
-						base: pullRequestModel.base && pullRequestModel.base.label || 'UNKNOWN',
-						head: pullRequestModel.head && pullRequestModel.head.label || 'UNKNOWN',
-						commitsCount: pullRequestModel.commitCount,
+						base: this._pullRequest.base && this._pullRequest.base.label || 'UNKNOWN',
+						head: this._pullRequest.head && this._pullRequest.head.label || 'UNKNOWN',
+						commitsCount: this._pullRequest.commitCount,
 						repositoryDefaultBranch: defaultBranch,
 						canEdit: canEdit,
 						status: status
@@ -465,7 +467,7 @@ export class PullRequestOverviewPanel {
 				<script nonce="${nonce}" src="${scriptUri}"></script>
 				<div id="title" class="title"></div>
 				<div id="timeline-events" class="discussion" aria-live="polite"></div>
-				<details id="status-checks"></details>
+				<details id="status-checks" class="hidden"></details>
 				<div id="comment-form" class="comment-form"></div>
 			</body>
 			</html>`;


### PR DESCRIPTION
Whenever the description page is updated, the timeline event data, review data, etc are re-fetched, but the pull request object itself is passed. This is a simple fix to make sure the object is up to date by also fetching it again.

I think ideally though, we would ensure that the passed object isn't stale. The PR object is either from the tree node if the description page is opened from the tree, or from the `activePullRequest` stored on the PR manager if the page is being opened from the command palette. Both of these data sources easily become state. Whenever a user locally edits the title/description, these don't get updated. Same for whenever a user runs the "Refresh Pull Request" command. Refresh is triggered on the pull request node, which causes its `getTreeItem` and `getChildren` methods to be called. In `getChildren`, all of the changed file data etc. is dynamically fetched, so this gets updated. But `getTreeItem` just returns the same data the node was constructed from. I don't think we always want to fetch the PR there, since this would un-batch our initial fetching of PRs, but maybe we could scope this to only refresh cases. I'll spend some more time on refresh but I think this fix is straightforward and good to have for now.

Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/728