### PR TITLE
Remove check for upstream when handling git state changes

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -98,11 +98,6 @@ export class ReviewManager implements vscode.DecorationProvider {
 				return;
 			}
 
-			if (newHead && !newHead.upstream) {
-				// if newhead has no upstream, we won't get any meaningful pull request info from that.
-				return;
-			}
-
 			let sameUpstream;
 
 			if (!oldHead || !newHead) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/727

We should still call the validateState method when switching to a different local branch that doesn't have an upstream.