### PR TITLE
Adopt commit compare api for finding merge base

### DIFF
--- a/src/common/diffHunk.ts
+++ b/src/common/diffHunk.ts
@@ -11,6 +11,7 @@ import * as Github from '@octokit/rest';
 import { GitChangeType, SlimFileChange, InMemFileChange } from './file';
 import { Repository } from '../typings/git';
 import { Comment } from './comment';
+import { IRawFileChange } from '../github/interface';
 
 export enum DiffChangeType {
 	Context,
@@ -253,7 +254,7 @@ export function getGitChangeType(status: string): GitChangeType {
 	}
 }
 
-export async function parseDiff(reviews: any[], repository: Repository, parentCommit: string): Promise<(InMemFileChange | SlimFileChange)[]> {
+export async function parseDiff(reviews: IRawFileChange[], repository: Repository, parentCommit: string): Promise<(InMemFileChange | SlimFileChange)[]> {
 	let fileChanges: (InMemFileChange | SlimFileChange)[] = [];
 
 	for (let i = 0; i < reviews.length; i++) {

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -68,6 +68,19 @@ export type PullRequest = Pick<
 	| 'head'
 	| 'base'
 >;
+
+export interface IRawFileChange {
+	filename: string;
+	previous_filename?: string;
+	additions: number;
+	deletions: number;
+	changes: number;
+	status: string;
+	raw_url: string;
+	blob_url: string;
+	patch: string;
+}
+
 export interface IPullRequestModel {
 	remote: Remote;
 	prNumber: number;
@@ -138,7 +151,7 @@ export interface IPullRequestManager {
 	closePullRequest(pullRequest: IPullRequestModel): Promise<any>;
 	approvePullRequest(pullRequest: IPullRequestModel, message?: string): Promise<any>;
 	requestChanges(pullRequest: IPullRequestModel, message?: string): Promise<any>;
-	getPullRequestChangedFiles(pullRequest: IPullRequestModel): Promise<Github.PullRequestsGetFilesResponseItem[]>;
+	getPullRequestFileChangesInfo(pullRequest: IPullRequestModel): Promise<IRawFileChange[]>;
 	getPullRequestRepositoryDefaultBranch(pullRequest: IPullRequestModel): Promise<string>;
 	getStatusChecks(pullRequest: IPullRequestModel): Promise<Github.ReposGetCombinedStatusForRefResponse>;
 

--- a/src/github/pullRequestGitHelper.ts
+++ b/src/github/pullRequestGitHelper.ts
@@ -274,19 +274,4 @@ export class PullRequestGitHelper {
 		let prConfigKey = `branch.${branchName}.${PullRequestMetadataKey}`;
 		await repository.setConfig(prConfigKey, PullRequestGitHelper.buildPullRequestMetadata(pullRequest));
 	}
-
-	static async getPullRequestMergeBase(repository: Repository, remote: Remote, pullRequest: IPullRequestModel): Promise<string> {
-		try {
-			Logger.appendLine(`Get merge base of ${pullRequest.base.sha}, ${pullRequest.head.sha}`, PullRequestGitHelper.ID);
-			return await repository.getMergeBase(pullRequest.base.sha, pullRequest.head.sha);
-		} catch (err) {
-			Logger.appendLine(`Get merge base of ${pullRequest.base.sha}, ${pullRequest.head.sha} failed, start fetching from remote`, PullRequestGitHelper.ID);
-			const pullrequestHeadRef = `refs/pull/${pullRequest.prNumber}/head`;
-			await repository.fetch(remote.remoteName, pullrequestHeadRef);
-			await repository.fetch(remote.remoteName, pullRequest.base.ref);
-
-			Logger.appendLine(`Get merge base of ${pullRequest.base.sha}, ${pullRequest.head.sha} again`, PullRequestGitHelper.ID);
-			return await repository.getMergeBase(pullRequest.base.sha, pullRequest.head.sha);
-		}
-	}
 }

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -789,15 +789,6 @@ export class PullRequestManager implements IPullRequestManager {
 		Logger.debug(`Fetch file changes, base, head and merge base of PR #${pullRequest.prNumber} - enter`, PullRequestManager.ID);
 		const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
 
-		const { data } = await octokit.repos.compareCommits({
-			repo: remote.repositoryName,
-			owner: remote.owner,
-			base: `${pullRequest.base.repositoryCloneUrl.owner}:${pullRequest.base.ref}`,
-			head: `${pullRequest.head.repositoryCloneUrl.owner}:${pullRequest.head.ref}`
-		});
-
-		pullRequest.mergeBase = data.merge_base_commit.sha;
-
 		if (!pullRequest.base) {
 			const info = await octokit.pullRequests.get({
 				owner: remote.owner,
@@ -806,6 +797,15 @@ export class PullRequestManager implements IPullRequestManager {
 			});
 			pullRequest.update(info.data);
 		}
+
+		const { data } = await octokit.repos.compareCommits({
+			repo: remote.repositoryName,
+			owner: remote.owner,
+			base: `${pullRequest.base.repositoryCloneUrl.owner}:${pullRequest.base.ref}`,
+			head: `${pullRequest.head.repositoryCloneUrl.owner}:${pullRequest.head.ref}`
+		});
+
+		pullRequest.mergeBase = data.merge_base_commit.sha;
 
 		Logger.debug(`Fetch file changes and merge base of PR #${pullRequest.prNumber} - done`, PullRequestManager.ID);
 		return data.files;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -824,7 +824,16 @@ export class PullRequestManager implements IPullRequestManager {
 				pullRequest.update(data);
 			}
 
-			pullRequest.mergeBase = await PullRequestGitHelper.getPullRequestMergeBase(this.repository, remote, pullRequest);
+			if (!pullRequest.mergeBase) {
+				const { data } = await octokit.repos.compareCommits({
+					repo: remote.repositoryName,
+					owner: remote.owner,
+					base: `${pullRequest.base.repositoryCloneUrl.owner}:${pullRequest.base.ref}`,
+					head: `${pullRequest.head.repositoryCloneUrl.owner}:${pullRequest.head.ref}`
+				});
+
+				pullRequest.mergeBase = data.merge_base_commit.sha;
+			}
 		} catch (e) {
 			vscode.window.showErrorMessage(`Fetching Pull Request merge base failed: ${formatError(e)}`);
 		}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -10,7 +10,7 @@ import { Comment } from '../common/comment';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
 import { TimelineEvent, EventType, isReviewEvent, isCommitEvent } from '../common/timelineEvent';
 import { GitHubRepository, PULL_REQUEST_PAGE_SIZE } from './githubRepository';
-import { IPullRequestManager, IPullRequestModel, IPullRequestsPagingOptions, PRType, ReviewEvent, ITelemetry, IPullRequestEditData, PullRequest } from './interface';
+import { IPullRequestManager, IPullRequestModel, IPullRequestsPagingOptions, PRType, ReviewEvent, ITelemetry, IPullRequestEditData, PullRequest, IRawFileChange } from './interface';
 import { PullRequestGitHelper } from './pullRequestGitHelper';
 import { PullRequestModel } from './pullRequestModel';
 import { parserCommentDiffHunk } from '../common/diffHunk';
@@ -785,24 +785,30 @@ export class PullRequestManager implements IPullRequestManager {
 			});
 	}
 
-	async getPullRequestChangedFiles(pullRequest: IPullRequestModel): Promise<Github.PullRequestsGetFilesResponseItem[]> {
-		Logger.debug(`Fetch changed files of PR #${pullRequest.prNumber} - enter`, PullRequestManager.ID);
+	async getPullRequestFileChangesInfo(pullRequest: IPullRequestModel): Promise<IRawFileChange[]> {
+		Logger.debug(`Fetch file changes, base, head and merge base of PR #${pullRequest.prNumber} - enter`, PullRequestManager.ID);
 		const { octokit, remote } = await (pullRequest as PullRequestModel).githubRepository.ensure();
 
-		let response = await octokit.pullRequests.getFiles({
-			owner: remote.owner,
+		const { data } = await octokit.repos.compareCommits({
 			repo: remote.repositoryName,
-			number: pullRequest.prNumber,
-			per_page: 100
+			owner: remote.owner,
+			base: `${pullRequest.base.repositoryCloneUrl.owner}:${pullRequest.base.ref}`,
+			head: `${pullRequest.head.repositoryCloneUrl.owner}:${pullRequest.head.ref}`
 		});
-		let { data } = response;
 
-		while (response.headers.link && octokit.hasNextPage(response.headers)) {
-			response = await octokit.getNextPage(response.headers);
-			data = data.concat(response.data);
+		pullRequest.mergeBase = data.merge_base_commit.sha;
+
+		if (!pullRequest.base) {
+			const info = await octokit.pullRequests.get({
+				owner: remote.owner,
+				repo: remote.repositoryName,
+				number: pullRequest.prNumber
+			});
+			pullRequest.update(info.data);
 		}
-		Logger.debug(`Fetch changed files of PR #${pullRequest.prNumber} - done`, PullRequestManager.ID);
-		return data;
+
+		Logger.debug(`Fetch file changes and merge base of PR #${pullRequest.prNumber} - done`, PullRequestManager.ID);
+		return data.files;
 	}
 
 	async getPullRequestRepositoryDefaultBranch(pullRequest: IPullRequestModel): Promise<string> {

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -583,10 +583,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 			let activeComments = this._comments.filter(comment => comment.position);
 			let outdatedComments = this._comments.filter(comment => !comment.position);
 
-			const data = await this._prManager.getPullRequestChangedFiles(pr);
-			await this._prManager.fullfillPullRequestMissingInfo(pr);
-			let headSha = pr.head.sha;
-			let mergeBase = pr.mergeBase;
+			const data = await this._prManager.getPullRequestFileChangesInfo(pr);
+			const headSha = pr.head.sha;
+			const mergeBase = pr.mergeBase;
 
 			const contentChanges = await parseDiff(data, this._repository, mergeBase);
 			this._localFileChanges = [];

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -233,9 +233,8 @@ export class PRNode extends TreeNode {
 			}
 
 			const comments = await this._prManager.getPullRequestComments(this.pullRequestModel);
-			const data = await this._prManager.getPullRequestChangedFiles(this.pullRequestModel);
-			await this._prManager.fullfillPullRequestMissingInfo(this.pullRequestModel);
-			let mergeBase = this.pullRequestModel.mergeBase;
+			const data = await this._prManager.getPullRequestFileChangesInfo(this.pullRequestModel);
+			const mergeBase = this.pullRequestModel.mergeBase;
 			const rawChanges = await parseDiff(data, this._prManager.repository, mergeBase);
 			let fileChanges = rawChanges.map(change => {
 				if (change instanceof SlimFileChange) {


### PR DESCRIPTION
For VSCode repository, the time used for opening a pull request decreases from around 5s to 500ms on my Windows box in campus ;)

It's a huge save for large repository like VSCode as when you review other people's pull requests, most of the time you don't have their code locally (unless you do a checkout). It means we keep fetching pull request branches and master whenever we open a new PR node or do a refresh