### PR TITLE
WIP: Initial code to implement check run annotations

### DIFF
--- a/src/common/checkRun.ts
+++ b/src/common/checkRun.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as Github from '@octokit/rest';
+
+export interface CheckRunWithAnnotations {
+	checkRun: Github.ChecksListForRefResponseCheckRunsItem;
+	annotations: Github.ChecksListAnnotationsResponseItem[];
+}

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -11,6 +11,7 @@ import { TimelineEvent } from '../common/timelineEvent';
 import { Remote } from '../common/remote';
 import { Repository, Branch } from '../typings/git';
 import { PullRequestsCreateParams } from '@octokit/rest';
+import { CheckRunWithAnnotations } from '../common/checkRun';
 
 export enum PRType {
 	RequestReview = 0,
@@ -131,6 +132,8 @@ export interface IPullRequestManager {
 	getGitHubRemotes(): Remote[];
 	mayHaveMorePages(): boolean;
 	getPullRequestComments(pullRequest: IPullRequestModel): Promise<Comment[]>;
+	getPullRequestCheckRuns(pullRequest: IPullRequestModel): Promise<Github.ChecksListForRefResponse>;
+	getCheckRunsWithAnnotations(pullRequest: IPullRequestModel, checks: Github.ChecksListForRefResponse): Promise<CheckRunWithAnnotations[]>;
 	getPullRequestCommits(pullRequest: IPullRequestModel): Promise<Github.PullRequestsGetCommitsResponseItem[]>;
 	getCommitChangedFiles(pullRequest: IPullRequestModel, commit: Github.PullRequestsGetCommitsResponseItem): Promise<Github.ReposGetCommitResponseFilesItem[]>;
 	getReviewComments(pullRequest: IPullRequestModel, reviewId: number): Promise<Github.PullRequestsCreateCommentResponse[]>;

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -23,6 +23,7 @@ import { providePRDocumentComments, PRNode } from './treeNodes/pullRequestNode';
 import { PullRequestOverviewPanel } from '../github/pullRequestOverview';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
 import { RemoteQuickPickItem } from './quickpick';
+import { CheckRunWithAnnotations } from '../common/checkRun';
 
 export class ReviewManager implements vscode.DecorationProvider {
 	private static _instance: ReviewManager;
@@ -32,6 +33,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 
 	private _comments: Comment[] = [];
 	private _localFileChanges: (GitFileChangeNode)[] = [];
+	private _checkRuns: (CheckRunWithAnnotations)[] = [];
 	private _obsoleteFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[] = [];
 	private _lastCommitSha: string;
 	private _updateMessageShown: boolean = false;
@@ -856,7 +858,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 				}
 
 				if (document.uri.scheme === 'pr') {
-					return providePRDocumentComments(document, this._prNumber, this._localFileChanges);
+					return providePRDocumentComments(document, this._prNumber, this._localFileChanges, this._checkRuns);
 				}
 
 				if (document.uri.scheme === 'review') {


### PR DESCRIPTION
Hi 👋 

I'm a @github employee working at the ecosystem-primitives department. We own the checks API and I'm the guy that added typing definitions to octokit.

I love VSCode and I just started using this extension this week and I thought that it would be cool to have check runs and check run annotations supported so, this is my attempt to make it possible.

This is my first contribution to a VSCode exception (except for this simple one I made yesterday https://marketplace.visualstudio.com/items?itemName=gimenete.github-linker ). Any guidance will be welcome. I first want to know if I'm in the right path and that this is something that you are willing to merge at some point.

Thanks!

Here's a screenshot of a PR I'm using to test

![screen shot 2018-12-20 at 20 28 19](https://user-images.githubusercontent.com/50486/50309658-f0eebe00-049f-11e9-92c5-6b4f125a4e17.png)

Here's how it is shown in VSCode with the changes of this PR:

![screen shot 2018-12-20 at 20 27 59](https://user-images.githubusercontent.com/50486/50309664-f3511800-049f-11e9-8e3d-27e5cbf1b964.png)
