### PR TITLE
Make PR title element content editable

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -7,6 +7,10 @@ a:focus, input:focus, select:focus, textarea:focus, .title-text:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 }
 
+.title-text {
+	margin-right: 5px;
+}
+
  .title {
 	display: flex;
 	align-items: flex-start;

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-a:focus, input:focus, select:focus, textarea:focus {
+a:focus, input:focus, select:focus, textarea:focus, .title-text:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 }
 
@@ -11,6 +11,10 @@ a:focus, input:focus, select:focus, textarea:focus {
 	display: flex;
 	align-items: flex-start;
 	margin-top: 20px;
+}
+
+.title .pr-number {
+	margin-left: 5px;
 }
 
 .comment-body li div {


### PR DESCRIPTION
Instead of needing to click the pencil icon that appears on hover, let users directly click on and edit the title.

Currently the change gets sent on blur of the title, not sure if it would be expected to also support pressing something like enter.