### PR TITLE
Remove IPullRequestManager and IPullRequestModel interfaces

### DIFF
--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -6,8 +6,8 @@
 'use strict';
 
 import { Uri, UriHandler, EventEmitter } from 'vscode';
-import { IPullRequestModel } from '../github/interface';
 import { GitChangeType } from './file';
+import { PullRequestModel } from '../github/pullRequestModel';
 
 export interface ReviewUriParams {
 	path: string;
@@ -94,7 +94,7 @@ export function fromFileChangeNodeUri(uri: Uri): FileChangeNodeUriParams {
 	}
 }
 
-export function toPRUri(uri: Uri, pullRequestModel: IPullRequestModel, baseCommit: string, headCommit: string, fileName: string, base: boolean, status: GitChangeType): Uri {
+export function toPRUri(uri: Uri, pullRequestModel: PullRequestModel, baseCommit: string, headCommit: string, fileName: string, base: boolean, status: GitChangeType): Uri {
 	const params: PRUriParams = {
 		baseCommit: baseCommit,
 		headCommit: headCommit,

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -3,14 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import * as Github from '@octokit/rest';
-import { Comment } from '../common/comment';
-import { GitHubRef } from '../common/githubRef';
-import { TimelineEvent } from '../common/timelineEvent';
-import { Remote } from '../common/remote';
-import { Repository, Branch } from '../typings/git';
-import { PullRequestsCreateParams } from '@octokit/rest';
 
 export enum PRType {
 	RequestReview = 0,
@@ -81,32 +74,6 @@ export interface IRawFileChange {
 	patch: string;
 }
 
-export interface IPullRequestModel {
-	remote: Remote;
-	prNumber: number;
-	title: string;
-	html_url: string;
-	state: PullRequestStateEnum;
-	commentCount: number;
-	commitCount: number;
-	author: IAccount;
-	assignee: IAccount;
-	createdAt: string;
-	updatedAt: string;
-	isOpen: boolean;
-	isMerged: boolean;
-	head?: GitHubRef;
-	base?: GitHubRef;
-	mergeBase?: string;
-	localBranchName?: string;
-	userAvatar: string;
-	userAvatarUri: vscode.Uri;
-	body: string;
-	labels: string[];
-	update(prItem: Github.PullRequestsGetResponse): void;
-	equals(other: IPullRequestModel): boolean;
-}
-
 export interface IPullRequestsPagingOptions {
 	fetchNextPage: boolean;
 }
@@ -118,64 +85,6 @@ export interface IGitHubRepository {
 export interface IPullRequestEditData {
 	body?: string;
 	title?: string;
-}
-
-export interface IPullRequestManager {
-	activePullRequest?: IPullRequestModel;
-	repository: Repository;
-	readonly onDidChangeActivePullRequest: vscode.Event<void>;
-	getLocalPullRequests(): Promise<IPullRequestModel[]>;
-	deleteLocalPullRequest(pullRequest: IPullRequestModel, force?: boolean): Promise<void>;
-	getPullRequests(type: PRType, options?: IPullRequestsPagingOptions): Promise<[IPullRequestModel[], boolean]>;
-	getMetadata(remote: string): Promise<any>;
-	getGitHubRemotes(): Remote[];
-	mayHaveMorePages(): boolean;
-	getPullRequestComments(pullRequest: IPullRequestModel): Promise<Comment[]>;
-	getPullRequestCommits(pullRequest: IPullRequestModel): Promise<Github.PullRequestsGetCommitsResponseItem[]>;
-	getCommitChangedFiles(pullRequest: IPullRequestModel, commit: Github.PullRequestsGetCommitsResponseItem): Promise<Github.ReposGetCommitResponseFilesItem[]>;
-	getReviewComments(pullRequest: IPullRequestModel, reviewId: number): Promise<Github.PullRequestsCreateCommentResponse[]>;
-	getTimelineEvents(pullRequest: IPullRequestModel): Promise<TimelineEvent[]>;
-	getIssueComments(pullRequest: IPullRequestModel): Promise<Github.IssuesGetCommentsResponseItem[]>;
-	createIssueComment(pullRequest: IPullRequestModel, text: string): Promise<Github.IssuesCreateCommentResponse>;
-	createCommentReply(pullRequest: IPullRequestModel, body: string, reply_to: string): Promise<Comment>;
-	createComment(pullRequest: IPullRequestModel, body: string, path: string, position: number): Promise<Comment>;
-	getPullRequestDefaults(): Promise<PullRequestsCreateParams>;
-	createPullRequest(params: PullRequestsCreateParams): Promise<IPullRequestModel>;
-	mergePullRequest(pullRequest: IPullRequestModel): Promise<any>;
-	editReviewComment(pullRequest: IPullRequestModel, commentId: string, text: string): Promise<Comment>;
-	editIssueComment(pullRequest: IPullRequestModel, commentId: string, text: string): Promise<Comment>;
-	deleteIssueComment(pullRequest: IPullRequestModel, commentId: string): Promise<void>;
-	deleteReviewComment(pullRequest: IPullRequestModel, commentId: string): Promise<void>;
-	canEditPullRequest(pullRequest: IPullRequestModel): boolean;
-	editPullRequest(pullRequest: IPullRequestModel, toEdit: IPullRequestEditData): Promise<Github.PullRequestsUpdateResponse>;
-	closePullRequest(pullRequest: IPullRequestModel): Promise<any>;
-	approvePullRequest(pullRequest: IPullRequestModel, message?: string): Promise<any>;
-	requestChanges(pullRequest: IPullRequestModel, message?: string): Promise<any>;
-	getPullRequestFileChangesInfo(pullRequest: IPullRequestModel): Promise<IRawFileChange[]>;
-	getPullRequestRepositoryDefaultBranch(pullRequest: IPullRequestModel): Promise<string>;
-	getStatusChecks(pullRequest: IPullRequestModel): Promise<Github.ReposGetCombinedStatusForRefResponse>;
-
-	/**
-	 * Fullfill information for a pull request which we can't fetch with one single api call.
-	 * 1. base. This property might not exist in search results
-	 * 2. head. This property might not exist in search results
-	 * 3. merge base. This is necessary as base might not be the commit that files in Pull Request are being compared to.
-	 * @param pullRequest
-	 */
-	fullfillPullRequestMissingInfo(pullRequest: IPullRequestModel): Promise<void>;
-	updateRepositories(): Promise<void>;
-	authenticate(): Promise<boolean>;
-
-	/**
-	 * git related APIs
-	 */
-
-	resolvePullRequest(owner: string, repositoryName: string, pullReuqestNumber: number): Promise<IPullRequestModel>;
-	getMatchingPullRequestMetadataForBranch();
-	checkoutExistingPullRequestBranch(pullRequest: IPullRequestModel): Promise<boolean>;
-	getBranch(remote: Remote, branchName: string): Promise<Branch>;
-	checkout(branchName: string): Promise<void>;
-	fetchAndCheckout(pullRequest: IPullRequestModel): Promise<void>;
 }
 
 export interface ITelemetry {

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -7,9 +7,9 @@ import * as vscode from 'vscode';
 import { GitHubRef } from '../common/githubRef';
 import { Remote } from '../common/remote';
 import { GitHubRepository } from './githubRepository';
-import { IAccount, IPullRequestModel, PullRequest, PullRequestStateEnum } from './interface';
+import { IAccount, PullRequest, PullRequestStateEnum } from './interface';
 
-export class PullRequestModel implements IPullRequestModel {
+export class PullRequestModel {
 	public prNumber: number;
 	public title: string;
 	public html_url: string;
@@ -22,6 +22,7 @@ export class PullRequestModel implements IPullRequestModel {
 	public updatedAt: string;
 	public localBranchName?: string;
 	public labels: string[];
+	public mergeBase?: string;
 
 	public get isOpen(): boolean {
 		return this.state === PullRequestStateEnum.Open;
@@ -106,7 +107,7 @@ export class PullRequestModel implements IPullRequestModel {
 		this.base = new GitHubRef(prItem.base.ref, prItem.base.label, prItem.base.sha, prItem.base.repo.clone_url);
 	}
 
-	equals(other: IPullRequestModel): boolean {
+	equals(other: PullRequestModel): boolean {
 		if (!other) {
 			return false;
 		}

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -7,13 +7,15 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as Github from '@octokit/rest';
-import { IPullRequestManager, IPullRequestModel, MergePullRequest, PullRequestStateEnum } from './interface';
+import { MergePullRequest, PullRequestStateEnum } from './interface';
 import { onDidUpdatePR } from '../commands';
 import { formatError } from '../common/utils';
 import { GitErrorCodes } from '../typings/git';
 import { Comment } from '../common/comment';
 import { writeFile, unlink } from 'fs';
 import Logger from '../common/logger';
+import { PullRequestManager } from './pullRequestManager';
+import { PullRequestModel } from './pullRequestModel';
 
 interface IRequestMessage<T> {
 	req: string;
@@ -38,12 +40,12 @@ export class PullRequestOverviewPanel {
 	private readonly _panel: vscode.WebviewPanel;
 	private readonly _extensionPath: string;
 	private _disposables: vscode.Disposable[] = [];
-	private _pullRequest: IPullRequestModel;
-	private _pullRequestManager: IPullRequestManager;
+	private _pullRequest: PullRequestModel;
+	private _pullRequestManager: PullRequestManager;
 	private _initialized: boolean;
 	private _scrollPosition = { x: 0, y: 0 };
 
-	public static createOrShow(extensionPath: string, pullRequestManager: IPullRequestManager, pullRequestModel: IPullRequestModel, toTheSide: Boolean = false) {
+	public static createOrShow(extensionPath: string, pullRequestManager: PullRequestManager, pullRequestModel: PullRequestModel, toTheSide: Boolean = false) {
 		let activeColumn = toTheSide ?
 							vscode.ViewColumn.Beside :
 							vscode.window.activeTextEditor ?
@@ -68,7 +70,7 @@ export class PullRequestOverviewPanel {
 		}
 	}
 
-	private constructor(extensionPath: string, column: vscode.ViewColumn, title: string, pullRequestManager: IPullRequestManager) {
+	private constructor(extensionPath: string, column: vscode.ViewColumn, title: string, pullRequestManager: PullRequestManager) {
 		this._extensionPath = extensionPath;
 		this._pullRequestManager = pullRequestManager;
 
@@ -128,7 +130,7 @@ export class PullRequestOverviewPanel {
 		}
 	}
 
-	public async update(pullRequestModel: IPullRequestModel): Promise<void> {
+	public async update(pullRequestModel: PullRequestModel): Promise<void> {
 		this._postMessage({
 			command: 'set-scroll',
 			scrollPosition: this._scrollPosition,

--- a/src/view/prChangesTreeDataProvider.ts
+++ b/src/view/prChangesTreeDataProvider.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IPullRequestModel, IPullRequestManager } from '../github/interface';
 import { GitFileChangeNode, RemoteFileChangeNode } from './treeNodes/fileChangeNode';
 import { DescriptionNode } from './treeNodes/descriptionNode';
 import { TreeNode } from './treeNodes/treeNode';
 import { FilesCategoryNode } from './treeNodes/filesCategoryNode';
 import { CommitsNode } from './treeNodes/commitsCategoryNode';
 import { Comment } from '../common/comment';
+import { PullRequestManager } from '../github/pullRequestManager';
+import { PullRequestModel } from '../github/pullRequestModel';
 
 export class PullRequestChangesTreeDataProvider extends vscode.Disposable implements vscode.TreeDataProvider<TreeNode> {
 	private _onDidChangeTreeData = new vscode.EventEmitter<GitFileChangeNode | DescriptionNode>();
@@ -19,8 +20,8 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 
 	private _localFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[] = [];
 	private _comments: Comment[] = [];
-	private _pullrequest: IPullRequestModel = null;
-	private _pullRequestManager: IPullRequestManager;
+	private _pullrequest: PullRequestModel = null;
+	private _pullRequestManager: PullRequestManager;
 
 	constructor(private context: vscode.ExtensionContext) {
 		super(() => this.dispose());
@@ -34,7 +35,7 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 		this._onDidChangeTreeData.fire();
 	}
 
-	async showPullRequestFileChanges(pullRequestManager: IPullRequestManager, pullrequest: IPullRequestModel, fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[], comments: Comment[]) {
+	async showPullRequestFileChanges(pullRequestManager: PullRequestManager, pullrequest: PullRequestModel, fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[], comments: Comment[]) {
 		this._pullRequestManager = pullRequestManager;
 		this._pullrequest = pullrequest;
 		this._comments = comments;

--- a/src/view/prDocumentCommentProvider.ts
+++ b/src/view/prDocumentCommentProvider.ts
@@ -5,8 +5,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { IPullRequestModel } from '../github/interface';
 import { fromPRUri } from '../common/uri';
+import { PullRequestModel } from '../github/pullRequestModel';
 
 export class PRDocumentCommentProvider implements vscode.DocumentCommentProvider {
 	private _onDidChangeCommentThreads: vscode.EventEmitter<vscode.CommentThreadChangedEvent> = new vscode.EventEmitter<vscode.CommentThreadChangedEvent>();
@@ -16,7 +16,7 @@ export class PRDocumentCommentProvider implements vscode.DocumentCommentProvider
 
 	constructor() {}
 
-	public registerDocumentCommentProvider(pullRequestModel: IPullRequestModel, provider: vscode.DocumentCommentProvider) {
+	public registerDocumentCommentProvider(pullRequestModel: PullRequestModel, provider: vscode.DocumentCommentProvider) {
 		this._prDocumentCommentProviders[pullRequestModel.prNumber] = provider;
 		const changeListener = provider.onDidChangeCommentThreads(e => {
 			this._onDidChangeCommentThreads.fire(e);

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -6,10 +6,11 @@
 import * as vscode from 'vscode';
 import { TreeNode } from './treeNodes/treeNode';
 import { PRCategoryActionNode, CategoryTreeNode, PRCategoryActionType } from './treeNodes/categoryNode';
-import { IPullRequestManager, PRType, ITelemetry } from '../github/interface';
+import { PRType, ITelemetry } from '../github/interface';
 import { fromFileChangeNodeUri } from '../common/uri';
 import { getInMemPRContentProvider } from './inMemPRContentProvider';
 import { getPRDocumentCommentProvider } from './prDocumentCommentProvider';
+import { PullRequestManager } from '../github/pullRequestManager';
 
 export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<TreeNode>, vscode.DecorationProvider, vscode.Disposable {
 	private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode>();
@@ -22,7 +23,7 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 
 	constructor(
 		onShouldReload: vscode.Event<any>,
-		private _prManager: IPullRequestManager,
+		private _prManager: PullRequestManager,
 		private _telemetry: ITelemetry
 	) {
 		this._disposables = [];

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -11,7 +11,7 @@ import { toReviewUri, fromReviewUri, fromPRUri, ReviewUriParams } from '../commo
 import { groupBy, formatError } from '../common/utils';
 import { Comment } from '../common/comment';
 import { GitChangeType, InMemFileChange } from '../common/file';
-import { IPullRequestModel, IPullRequestManager, ITelemetry } from '../github/interface';
+import { ITelemetry } from '../github/interface';
 import { Repository, GitErrorCodes, Branch } from '../typings/git';
 import { PullRequestChangesTreeDataProvider } from './prChangesTreeDataProvider';
 import { GitContentProvider } from './gitContentProvider';
@@ -23,6 +23,8 @@ import { providePRDocumentComments, PRNode } from './treeNodes/pullRequestNode';
 import { PullRequestOverviewPanel } from '../github/pullRequestOverview';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
 import { RemoteQuickPickItem } from './quickpick';
+import { PullRequestManager } from '../github/pullRequestManager';
+import { PullRequestModel } from '../github/pullRequestModel';
 
 export class ReviewManager implements vscode.DecorationProvider {
 	public static ID = 'Review';
@@ -67,7 +69,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		private _context: vscode.ExtensionContext,
 		onShouldReload: vscode.Event<any>,
 		private _repository: Repository,
-		private _prManager: IPullRequestManager,
+		private _prManager: PullRequestManager,
 		private _telemetry: ITelemetry
 	) {
 		this._documentCommentProvider = null;
@@ -594,7 +596,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		return Promise.resolve(null);
 	}
 
-	private async getPullRequestData(pr: IPullRequestModel): Promise<void> {
+	private async getPullRequestData(pr: PullRequestModel): Promise<void> {
 		try {
 			this._comments = await this._prManager.getPullRequestComments(pr);
 			let activeComments = this._comments.filter(comment => comment.position);
@@ -1024,7 +1026,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		return null;
 	}
 
-	public async switch(pr: IPullRequestModel): Promise<void> {
+	public async switch(pr: PullRequestModel): Promise<void> {
 		Logger.appendLine(`Review> switch to Pull Request #${pr.prNumber} - start`);
 		this.switchingToReviewMode = true;
 		await this._prManager.fullfillPullRequestMissingInfo(pr);

--- a/src/view/treeNodes/categoryNode.ts
+++ b/src/view/treeNodes/categoryNode.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IPullRequestManager, IPullRequestModel, PRType, ITelemetry } from '../../github/interface';
+import { PRType, ITelemetry } from '../../github/interface';
 import { PRNode } from './pullRequestNode';
 import { TreeNode } from './treeNode';
 import { formatError } from '../../common/utils';
 import { AuthenticationError } from '../../common/authentication';
+import { PullRequestManager } from '../../github/pullRequestManager';
+import { PullRequestModel } from '../../github/pullRequestModel';
 
 export enum PRCategoryActionType {
 	Empty,
@@ -67,12 +69,12 @@ interface PageInformation {
 export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 	public readonly label: string;
 	public collapsibleState: vscode.TreeItemCollapsibleState;
-	public prs: IPullRequestModel[];
+	public prs: PullRequestModel[];
 	public fetchNextPage: boolean = false;
 	public repositoryPageInformation: Map<string, PageInformation> = new Map<string, PageInformation>();
 
 	constructor(
-		private _prManager: IPullRequestManager,
+		private _prManager: PullRequestManager,
 		private _telemetry: ITelemetry,
 		private _type: PRType
 	) {

--- a/src/view/treeNodes/commitNode.ts
+++ b/src/view/treeNodes/commitNode.ts
@@ -5,13 +5,14 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { IPullRequestModel, IPullRequestManager } from '../../github/interface';
 import { PullRequestsGetCommitsResponseItem } from '@octokit/rest';
 import { TreeNode } from './treeNode';
 import { GitFileChangeNode } from './fileChangeNode';
 import { toReviewUri } from '../../common/uri';
 import { getGitChangeType } from '../../common/diffHunk';
 import { Comment } from '../../common/comment';
+import { PullRequestManager } from '../../github/pullRequestManager';
+import { PullRequestModel } from '../../github/pullRequestModel';
 
 export class CommitNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
@@ -19,8 +20,8 @@ export class CommitNode extends TreeNode implements vscode.TreeItem {
 	public iconPath: vscode.Uri | undefined;
 
 	constructor(
-		private readonly pullRequestManager: IPullRequestManager,
-		private readonly pullRequest: IPullRequestModel,
+		private readonly pullRequestManager: PullRequestManager,
+		private readonly pullRequest: PullRequestModel,
 		private readonly commit: PullRequestsGetCommitsResponseItem,
 		private readonly comments: Comment[]
 	) {

--- a/src/view/treeNodes/commitsCategoryNode.ts
+++ b/src/view/treeNodes/commitsCategoryNode.ts
@@ -4,19 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IPullRequestModel, IPullRequestManager } from '../../github/interface';
 import { TreeNode } from './treeNode';
 import { CommitNode } from './commitNode';
 import { Comment } from '../../common/comment';
+import { PullRequestManager } from '../../github/pullRequestManager';
+import { PullRequestModel } from '../../github/pullRequestModel';
 
 export class CommitsNode extends TreeNode implements vscode.TreeItem {
 	public label: string = 'Commits';
 	public collapsibleState: vscode.TreeItemCollapsibleState;
-	private _prManager: IPullRequestManager;
-	private _pr: IPullRequestModel;
+	private _prManager: PullRequestManager;
+	private _pr: PullRequestModel;
 	private _comments: Comment[];
 
-	constructor(prManager: IPullRequestManager, pr: IPullRequestModel, comments: Comment[]) {
+	constructor(prManager: PullRequestManager, pr: PullRequestModel, comments: Comment[]) {
 		super();
 		this._pr = pr;
 		this._prManager = prManager;

--- a/src/view/treeNodes/descriptionNode.ts
+++ b/src/view/treeNodes/descriptionNode.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IPullRequestModel } from '../../github/interface';
 import { TreeNode } from './treeNode';
+import { PullRequestModel } from '../../github/pullRequestModel';
 
 export class DescriptionNode extends TreeNode implements vscode.TreeItem {
 	public command?: vscode.Command;
 	public contextValue?: string;
 
-	constructor(public label: string, public iconPath: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri }, public pullRequestModel: IPullRequestModel) {
+	constructor(public label: string, public iconPath: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri }, public pullRequestModel: PullRequestModel) {
 		super();
 
 		this.command = {

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -7,11 +7,11 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { DiffHunk, DiffChangeType } from '../../common/diffHunk';
 import { GitChangeType } from '../../common/file';
-import { IPullRequestModel } from '../../github/interface';
 import { TreeNode } from './treeNode';
 import { Comment } from '../../common/comment';
 import { getDiffLineByPosition, getZeroBased } from '../../common/diffPositionMapping';
 import { toFileChangeNodeUri } from '../../common/uri';
+import { PullRequestModel } from '../../github/pullRequestModel';
 
 /**
  * File change node whose content can not be resolved locally and we direct users to GitHub.
@@ -24,7 +24,7 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public resourceUri: vscode.Uri;
 
 	constructor(
-		public readonly pullRequest: IPullRequestModel,
+		public readonly pullRequest: PullRequestModel,
 		public readonly status: GitChangeType,
 		public readonly fileName: string,
 		public readonly blobUrl: string
@@ -63,7 +63,7 @@ export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public opts: vscode.TextDocumentShowOptions;
 
 	constructor(
-		public readonly pullRequest: IPullRequestModel,
+		public readonly pullRequest: PullRequestModel,
 		public readonly status: GitChangeType,
 		public readonly fileName: string,
 		public readonly previousFileName: string | undefined,
@@ -131,7 +131,7 @@ export class GitFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public opts: vscode.TextDocumentShowOptions;
 
 	constructor(
-		public readonly pullRequest: IPullRequestModel,
+		public readonly pullRequest: PullRequestModel,
 		public readonly status: GitChangeType,
 		public readonly fileName: string,
 		public readonly blobUrl: string,

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -12,13 +12,14 @@ import Logger from '../../common/logger';
 import { Resource } from '../../common/resources';
 import { fromPRUri, toPRUri } from '../../common/uri';
 import { groupBy, formatError } from '../../common/utils';
-import { IPullRequestManager, IPullRequestModel } from '../../github/interface';
 import { DescriptionNode } from './descriptionNode';
 import { RemoteFileChangeNode, InMemFileChangeNode } from './fileChangeNode';
 import { TreeNode } from './treeNode';
 import { getInMemPRContentProvider } from '../inMemPRContentProvider';
 import { Comment } from '../../common/comment';
 import { getPRDocumentCommentProvider } from '../prDocumentCommentProvider';
+import { PullRequestManager } from '../../github/pullRequestManager';
+import { PullRequestModel } from '../../github/pullRequestModel';
 
 export function providePRDocumentComments(
 	document: vscode.TextDocument,
@@ -217,8 +218,8 @@ export class PRNode extends TreeNode {
 	private _inMemPRContentProvider: vscode.Disposable;
 
 	constructor(
-		private _prManager: IPullRequestManager,
-		public pullRequestModel: IPullRequestModel,
+		private _prManager: PullRequestManager,
+		public pullRequestModel: PullRequestModel,
 		private _isLocal: boolean
 	) {
 		super();


### PR DESCRIPTION
There is only one PullRequestManager implementation, and one PullRequestModel. So these don't really add a layer of abstraction but do take work to maintain. This PR removes them and uses the classes directly