### PR TITLE
Add typings for graphql responses

### DIFF
--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -26,5 +26,5 @@ export interface Comment {
 	createdAt: string;
 	htmlUrl: string;
 	isDraft?: boolean;
-	nodeId?: string;
+	graphNodeId: string;
 }

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -51,7 +51,7 @@ export class GitHubRepository implements IGitHubRepository {
 		return !!(this.hub && this.hub.graphql);
 	}
 
-	query = async <T = any>(query: QueryOptions): Promise<ApolloQueryResult<T>> => {
+	query = async <T>(query: QueryOptions): Promise<ApolloQueryResult<T>> => {
 		const gql = this.hub && this.hub.graphql;
 		if (!gql) {
 			Logger.debug(`Not available for query: ${query}`, GRAPHQL_COMPONENT_ID);
@@ -64,7 +64,7 @@ export class GitHubRepository implements IGitHubRepository {
 		return rsp;
 	}
 
-	mutate = async <T = any>(mutation: MutationOptions): Promise<ApolloQueryResult<T>> => {
+	mutate = async <T>(mutation: MutationOptions): Promise<ApolloQueryResult<T>> => {
 		const gql = this.hub && this.hub.graphql;
 		if (!gql) {
 			Logger.debug(`Not available for query: ${mutation}`, GRAPHQL_COMPONENT_ID);

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface MergedEvent {
+	id: string;
+	actor: {
+		login: string;
+		avatarUrl: string;
+		url: string;
+	};
+	createdAt: string;
+	mergeRef: {
+		name: string;
+	};
+}
+
+export interface IssueComment {
+	id: string;
+	databaseId: number;
+	authorAssocation: string;
+	author: {
+		login: string;
+		avatarUrl: string;
+		url: string;
+	};
+	url: string;
+	body: string;
+	updatedAt: string;
+	createdAt: string;
+	viewerCanUpdate: boolean;
+	viewerCanReact: boolean;
+	viewerCanDelete: boolean;
+}
+
+export interface ReviewComment {
+	id: string;
+	databaseId: number;
+	url: string;
+	author?: {
+		login: string;
+		avatarUrl: string;
+		url: string;
+	};
+	path: string;
+	originalPosition: number;
+	body: string;
+	diffHunk: string;
+	position: number;
+	state: string;
+	pullRequestReview: {
+		databaseId: number;
+	};
+	commit: {
+		oid: string;
+	};
+	originalCommit: {
+		oid: string;
+	};
+	createdAt: string;
+	viewerCanUpdate: boolean;
+	viewerCanDelete: boolean;
+}
+
+export interface Commit {
+	id: string;
+	author: {
+		user: {
+			login: string;
+			avatarUrl: string;
+			url: string;
+		}
+	};
+	committer: {
+		avatarUrl: string;
+		name: string;
+	};
+	url: string;
+	oid: string;
+	message: string;
+}
+
+export interface AssignedEvent {
+	actor: {
+		login: string;
+		avatarUrl: string;
+		url: string;
+	};
+	user: {
+		login: string;
+		avatarUrl: string;
+		url: string;
+	};
+}
+
+export interface Review {
+	id: string;
+	databaseId: number;
+	authorAssocation: string;
+	author: {
+		login: string;
+		avatarUrl: string;
+		url: string;
+	};
+	state: string;
+	body: string;
+	submittedAt: string;
+	updatedAt: string;
+	createdAt: string;
+}
+
+export interface TimelineEventsResponse {
+	repository: {
+		pullRequest: {
+			timeline: {
+				edges: [
+					{
+						node: (MergedEvent | Review | IssueComment | Commit | AssignedEvent)[];
+					}
+				]
+			}
+		}
+	};
+}
+
+export interface PendingReviewIdResponse {
+	node: {
+		reviews: {
+			nodes: Review[];
+		}
+	};
+}
+
+export interface PullRequestCommentsResponse {
+	repository: {
+		pullRequest: {
+			reviews: {
+				nodes: [
+					{
+						comments: {
+							nodes: ReviewComment[];
+						}
+					}
+				]
+			}
+		}
+	};
+}
+
+export interface AddCommentResponse {
+	addPullRequestReviewComment: {
+		comment: ReviewComment;
+	};
+}
+
+export interface SubmitReviewResponse {
+	submitPullRequestReview: {
+		pullRequestReview: {
+			comments: {
+				nodes: ReviewComment[];
+			}
+		}
+	};
+}
+
+export interface DeleteReviewResponse {
+	deletePullRequestReview: {
+		pullRequestReview: {
+			comments: {
+				nodes: ReviewComment[];
+			}
+		}
+	};
+}

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -28,9 +28,6 @@ export interface IAccount {
 	login: string;
 	avatarUrl: string;
 	url: string;
-	type: string;
-	isUser?: boolean;
-	isEnterprise?: boolean;
 }
 
 export interface MergePullRequest {

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -18,6 +18,7 @@ import { formatError, uniqBy, Predicate, groupBy } from '../common/utils';
 import { Repository, RefType, UpstreamRef, Branch } from '../typings/git';
 import Logger from '../common/logger';
 import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, parseGraphQLComment } from './utils';
+import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse } from './graphql';
 const queries = require('./queries.gql');
 
 interface PageInformation {
@@ -371,7 +372,7 @@ export class PullRequestManager {
 	private async getAllPullRequestReviewComments(pullRequest: PullRequestModel): Promise<Comment[]> {
 		const { remote, query } = await pullRequest.githubRepository.ensure();
 		try {
-			const { data } = await query({
+			const { data } = await query<PullRequestCommentsResponse>({
 				query: queries.PullRequestComments,
 				variables: {
 					owner: remote.owner,
@@ -448,7 +449,7 @@ export class PullRequestManager {
 
 		let ret = [];
 		if (pullRequest.githubRepository.supportsGraphQl()) {
-			const { data } = await query({
+			const { data } = await query<TimelineEventsResponse>({
 				query: queries.TimelineEvents,
 				variables: {
 					owner: remote.owner,
@@ -503,7 +504,7 @@ export class PullRequestManager {
 	async createCommentReply(pullRequest: PullRequestModel, body: string, reply_to: Comment): Promise<Comment> {
 		const pendingReviewId = await this.getPendingReviewId(pullRequest);
 		if (pendingReviewId) {
-			return this.addCommentToPendingReview(pullRequest, pendingReviewId, body, { inReplyTo: reply_to.nodeId });
+			return this.addCommentToPendingReview(pullRequest, pendingReviewId, body, { inReplyTo: reply_to.graphNodeId });
 		}
 
 		const { octokit, remote } = await pullRequest.githubRepository.ensure();
@@ -526,7 +527,7 @@ export class PullRequestManager {
 	async deleteReview(pullRequest: PullRequestModel): Promise<Comment[]> {
 		const pendingReviewId = await this.getPendingReviewId(pullRequest);
 		const { mutate } = await pullRequest.githubRepository.ensure();
-		const { data } = await mutate<any>({
+		const { data } = await mutate<DeleteReviewResponse>({
 			mutation: queries.DeleteReview,
 			variables: {
 				input: { pullRequestReviewId: pendingReviewId }
@@ -563,7 +564,7 @@ export class PullRequestManager {
 		const { query, octokit } = await pullRequest.githubRepository.ensure();
 		const { currentUser = '' } = octokit as any;
 		try {
-			const { data } = await query({
+			const { data } = await query<PendingReviewIdResponse>({
 				query: queries.GetPendingReviewId,
 				variables: {
 					pullRequestId: (pullRequest as PullRequestModel).prItem.nodeId,
@@ -578,7 +579,7 @@ export class PullRequestManager {
 
 	async addCommentToPendingReview(pullRequest: PullRequestModel, reviewId: string, body: string, position: NewCommentPosition | ReplyCommentPosition): Promise<Comment> {
 		const { mutate } = await pullRequest.githubRepository.ensure();
-		const { data } = await mutate({
+		const { data } = await mutate<AddCommentResponse>({
 			mutation: queries.AddComment,
 			variables: {
 				input: {
@@ -872,7 +873,7 @@ export class PullRequestManager {
 		const { mutate } = await pullRequest.githubRepository.ensure();
 
 		if (pendingReviewId) {
-			const { data } = await mutate({
+			const { data } = await mutate<SubmitReviewResponse>({
 				mutation: queries.SubmitReview,
 				variables: {
 					id: pendingReviewId

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -104,7 +104,11 @@ query TimelineEvents($owner: String!, $name: String!, $number: Int!, $last: Int 
 
 fragment ReviewComment on PullRequestReviewComment {
 	id databaseId url
-	author { login avatarUrl }
+	author {
+		login
+		avatarUrl
+		url
+	}
 	path originalPosition
 	body
 	diffHunk
@@ -112,6 +116,10 @@ fragment ReviewComment on PullRequestReviewComment {
 	state
 	pullRequestReview { databaseId }
 	commit {
+		oid
+	}
+	createdAt
+	originalCommit {
 		oid
 	}
 	viewerCanUpdate

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -9,15 +9,13 @@ import { IAccount, PullRequest } from './interface';
 import { Comment } from '../common/comment';
 import { parseDiffHunk, DiffHunk } from '../common/diffHunk';
 import { EventType, TimelineEvent } from '../common/timelineEvent';
+import { ReviewComment } from './graphql';
 
 export function convertRESTUserToAccount(user: Octokit.PullRequestsGetAllResponseItemUser): IAccount {
 	return {
 		login: user.login,
 		url: user.html_url,
-		avatarUrl: user.avatar_url,
-		type: user.type,
-		isUser: user.type === 'User',
-		isEnterprise: user.type === 'Enterprise'
+		avatarUrl: user.avatar_url
 	};
 }
 
@@ -99,7 +97,8 @@ export function convertIssuesCreateCommentResponseToComment(comment: Octokit.Iss
 		user: convertRESTUserToAccount(comment.user),
 		body: comment.body,
 		createdAt: comment.created_at,
-		htmlUrl: comment.html_url
+		htmlUrl: comment.html_url,
+		graphNodeId: comment.node_id
 	};
 }
 
@@ -118,7 +117,7 @@ export function convertPullRequestsGetCommentsResponseItemToComment(comment: Oct
 		body: comment.body,
 		createdAt: comment.created_at,
 		htmlUrl: comment.html_url,
-		nodeId: comment.node_id
+		graphNodeId: comment.node_id
 	};
 
 	let diffHunks = parseCommentDiffHunk(ret);
@@ -148,20 +147,31 @@ export function convertGraphQLEventType(text: string) {
 	}
 }
 
-export function parseGraphQLComment(comment: any): Comment {
-	comment.canEdit = comment.viewerCanUpdate;
-	comment.canDelete = comment.viewerCanDelete;
-	comment.user = comment.author;
-	comment.id = comment.databaseId;
-	comment.htmlUrl = comment.url;
-	comment.commitId = comment.commit && comment.commit.oid;
-	comment.pullRequestReviewId = comment.pullRequestReview && comment.pullRequestReview.databaseId;
-	comment.isDraft = comment.state === 'PENDING';
+export function parseGraphQLComment(comment: ReviewComment): Comment {
+	const c: Comment = {
+		id: comment.databaseId,
+		url: comment.url,
+		body: comment.body,
+		path: comment.path,
+		canEdit: comment.viewerCanDelete,
+		canDelete: comment.viewerCanDelete,
+		pullRequestReviewId: comment.pullRequestReview && comment.pullRequestReview.databaseId,
+		diffHunk: comment.diffHunk,
+		position: comment.position,
+		commitId: comment.commit.oid,
+		originalPosition: comment.originalPosition,
+		originalCommitId: comment.originalCommit && comment.originalCommit.oid,
+		user: comment.author,
+		createdAt: comment.createdAt,
+		htmlUrl: comment.url,
+		graphNodeId: comment.id,
+		isDraft: comment.state === 'PENDING'
+	};
 
-	let diffHunks = parseCommentDiffHunk(comment);
-	comment.diffHunks = diffHunks;
+	const diffHunks = parseCommentDiffHunk(c);
+	c.diffHunks = diffHunks;
 
-	return comment;
+	return c;
 }
 
 export function parseGraphQLTimelineEvents(events: any[]): TimelineEvent[] {


### PR DESCRIPTION
The `nodeId` property tracking the graphql id of comments was missing for comments normalized from graphql responses, which is needed for replying to comments in a pending review. I fixed this and added typings for all of the graphql responses.

This may be a pain to maintain, it would be great if we could automatically generate it from the `gql` file, but I think it's very useful to have these responses be typed.