### PR TITLE
Update styles and layout

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -78,7 +78,6 @@ body .comment-container.review {
 	background-color: var(--vscode-editor-background);
 }
 
-
 .review-comment-container {
 	width: 100%;
 	display: flex;
@@ -284,6 +283,13 @@ body button.checkedOut svg {
 
 .title-container {
 	width: 100%;
+	display: flex;
+	flex-flow: row-reverse;
+}
+
+.title-container .description-header {
+	align-self: flex-end;
+	margin-left: auto;
 }
 
 .comment-container {
@@ -292,6 +298,11 @@ body button.checkedOut svg {
 
 .details .comment-container {
 	border: 1px solid var(--border-color-primary);
+}
+
+.details .comment-container .comment-info {
+	display: flex;
+	align-items: center;
 }
 
 .description-content {
@@ -496,6 +507,7 @@ textarea:focus {
 }
 
 .editing-form {
+	width: 100%;
 	padding: 5px 0;
 	display: flex;
 	flex-direction: column;

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -313,7 +313,6 @@ body button.checkedOut svg {
 	display: flex;
 	align-items: center;
 	padding: 8px 0 12px;
-	margin-bottom: 12px;
 	border-bottom: 1px solid var(--border-color);
 }
 

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -3,6 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+:root {
+	--border-color-primary: var(--vscode-notifications-border);
+	--border-color-secondary: var(--vscode-notifications-background);
+ }
+
 a:focus, input:focus, select:focus, textarea:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 }
@@ -10,7 +15,7 @@ a:focus, input:focus, select:focus, textarea:focus {
  .title {
 	display: flex;
 	align-items: flex-start;
-	margin-top: 20px;
+	margin: 20px 0 12px;
 }
 
 .comment-body li div {
@@ -43,7 +48,7 @@ body a:hover {
 }
 
 body .comment-container .avatar-container {
-	margin-right: 12px;
+	margin-right: 8px;
 }
 
 body .comment-container .avatar-container a {
@@ -80,7 +85,13 @@ body .comment-container.review {
 	flex-direction: column;
 }
 
-body .comment-container .review-comment-header {
+.comment-container:not(.review-comment) > .review-comment-container {
+	border: 1px solid var(--border-color-primary);
+}
+
+body .comment-container .review-comment-header,
+.comment-container .comment-header {
+	position: relative;
 	display: flex;
 	width: 100%;
 	box-sizing: border-box;
@@ -88,13 +99,23 @@ body .comment-container .review-comment-header {
 	font-size: 12px;
 	color: var(--vscode-foreground);
 	align-items: center;
-	background: var(--vscode-list-inactiveSelectionBackground);
-	border: 1px solid var(--vscode-list-inactiveSelectionBackground);
+	border-bottom: 1px solid var(--border-color-primary);
 }
 
-.description-header {
-	float: right;
-	height: 32px;
+.comment-container:not(.review-comment) > .review-comment-container > .review-comment-header *,
+.comment-container .comment-header * {
+	position: relative;
+}
+
+/* This ignores the comments inside a diff reivew */
+.comment-container:not(.review-comment) > .review-comment-container > .review-comment-header::before,
+.comment-container .comment-header::before {
+	opacity: 0.6;
+	background: var(--border-color-secondary);
+}
+
+.comment-header .comment-actions {
+	margin-left: auto;
 }
 
 .review-comment-header .comment-actions {
@@ -158,13 +179,12 @@ body .commit .commit-message > a {
 
 body .comment-container .comment-body, .review-body {
 	padding: 10px;
-	border: 1px solid var(--vscode-list-inactiveSelectionBackground);
 	border-top: none;
 }
 
 body .comment-container .review-comment-container .review-comment-body {
 	padding: 0;
-	margin: 0 0 0 36px;
+	margin: 0 24px;
 	border: none;
 }
 
@@ -259,25 +279,31 @@ body button.checkedOut svg {
 	padding-top: 5px;
 	margin-left: auto;
 	display: flex;
+	align-self: start;
 }
 
 .title-container {
 	width: 100%;
 }
 
-.description-container {
-	padding: 12px;
-	border: 1px solid var(--vscode-list-inactiveSelectionBackground);
+.comment-container {
+	margin-top: 12px;
+}
+
+.details .comment-container {
+	border: 1px solid var(--border-color-primary);
+}
+
+.description-content {
+	padding: 8px 12px;
 }
 
 .subtitle {
 	display: flex;
 	align-items: center;
-	margin-top: 8px;
-	padding: 6px;
-	background: var(--vscode-list-inactiveSelectionBackground);
-	border: 1px solid var(--vscode-list-inactiveSelectionBackground);
-	border-bottom: none;
+	padding: 8px 0 12px;
+	margin-bottom: 12px;
+	border-bottom: 1px solid var(--border-color-primary);
 }
 
 .subtitle .avatar {
@@ -308,14 +334,28 @@ body .overview-title .button-group button {
 	margin-right: 12px;
 }
 
+.comment-container .labels {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	padding: 8px 12px 0 8px;
+}
+
+.comment-container .labels svg {
+	fill: var(--vscode-foreground);
+}
+
+.label:first-of-type{
+	margin-left: 8px;
+}
+
 .label {
 	padding: 4px 6px;
 	font-size: 12px;
 	font-weight: 600;
 	line-height: 15px;
 	border-radius: 2px;
-	margin-right: 8px;
-	margin-bottom: 8px;
+	margin: 4px;
 	background: var(--vscode-badge-background);
 	color: var(--vscode-badge-foreground);
 	box-shadow: inset 0 -1px 0 rgba(27,31,35,0.12);
@@ -355,7 +395,7 @@ body .overview-title .button-group button {
 }
 
 .commit .commit-message .avatar-container {
-	margin-right: 4px;
+	margin-right: 8px;
 	flex-shrink: 0;
 }
 
@@ -382,10 +422,9 @@ body .overview-title .button-group button {
 
 .comment-container {
 	position: relative;
-	padding-top: 20px;
 	width: 100%;
 	display: flex;
-	margin: 0;
+	flex-direction: column;
 }
 
 .comment-container[data-type="commit"] {
@@ -398,9 +437,9 @@ body .overview-title .button-group button {
 }
 
 .comment-body .review-comment {
-	padding: 3px;
+	padding: 4px;
 	box-sizing: border-box;
-	border-top: 1px solid var(--vscode-list-inactiveSelectionBackground);
+	border: none;
 }
 
 .review-comment-container .review-comment .review-comment-header {
@@ -410,7 +449,7 @@ body .overview-title .button-group button {
 
 .review-comment-container .review-comment .comment-body {
 	border: none;
-	padding: 4px 12px 8px 12px;
+	padding: 0 12px 8px 34px;
 }
 
 .comment-body .line {
@@ -639,7 +678,7 @@ code {
 	border-color: var(--vscode-panel-border);
 }
 
-.vscode-high-contrast .description-container {
+.vscode-high-contrast .comment-container {
 	border-color: var(--vscode-panel-border);
 }
 
@@ -668,8 +707,8 @@ code {
 }
 
 .review-comment-body .diff-container {
-	margin-top: 10px;
-	border: 1px solid var(--vscode-list-inactiveSelectionBackground);
+	margin: 24px 0;
+	border: 1px solid var(--border-color-primary);
 }
 
 .review-comment-body .diff-container .review-comment-container .comment-container {
@@ -677,7 +716,7 @@ code {
 }
 
 .review-comment-body .diff-container .review-comment-container .review-comment-header .avatar-container {
-	margin-right: 4px;
+	margin-right: 8px;
 }
 
 .review-comment-body .diff-container .review-comment-container .review-comment-header .avatar {
@@ -685,10 +724,29 @@ code {
 	height: 18px;
 }
 
+.diff {
+	border-bottom: 1px solid var(--border-color-primary);
+}
+
 .diff .diffHeader {
+	position: relative;
 	padding: 6px 12px;
 	line-height: 1.5;
-	background: var(--vscode-editorGroupHeader-tabsBackground);
+	border-bottom: 1px solid var(--border-color-primary);
+}
+
+
+.diff .diffHeader::before {
+	opacity: 0.4 !important;
+}
+
+.diff .diffHeader * {
+	position: relative;
+	z-index: 1;
+}
+
+.diff .diffHeader::before {
+	background: var(--border-color-secondary);
 }
 
 .diff .diffHeader .diffPath:hover {
@@ -715,11 +773,38 @@ code {
 	font-size: 12px;
 }
 
-.diff .diffLine.add {
+.diff .diffLine {
+	position: relative;
+}
+.diff .diffLine * {
+	z-index: 1;
+	position: relative;
+}
+
+/* Background with low opacity for comments and diffs */
+.comment-container .comment-header::before,
+.comment-container:not(.review-comment) > .review-comment-container > .review-comment-header::before, /* This ignores comment headers inside a diff review */
+.diff .diffHeader::before,
+.diff .diffLine::before {
+	content: " ";
+	z-index: 0;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	left: 0;
+	top: 0;
+}
+
+.diff .diffLine.add::before,
+.diff .diffLine.delete::before {
+	opacity: 0.8;
+}
+
+.diff .diffLine.add::before {
 	background-color: var(--vscode-diffEditor-insertedTextBackground);
 }
 
-.diff .diffLine.delete {
+.diff .diffLine.delete::before {
 	background-color: var(--vscode-diffEditor-removedTextBackground);
 }
 

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 :root {
-	--border-color-primary: var(--vscode-notifications-border);
-	--border-color-secondary: var(--vscode-notifications-background);
+	--border-color: var(--vscode-notifications-border);
+	--header-background: var(--vscode-notifications-background);
  }
 
 a:focus, input:focus, select:focus, textarea:focus {
@@ -85,7 +85,7 @@ body .comment-container.review {
 }
 
 .comment-container:not(.review-comment) > .review-comment-container {
-	border: 1px solid var(--border-color-primary);
+	border: 1px solid var(--border-color);
 }
 
 body .comment-container .review-comment-header,
@@ -98,7 +98,7 @@ body .comment-container .review-comment-header,
 	font-size: 12px;
 	color: var(--vscode-foreground);
 	align-items: center;
-	border-bottom: 1px solid var(--border-color-primary);
+	border-bottom: 1px solid var(--border-color);
 }
 
 .comment-container:not(.review-comment) > .review-comment-container > .review-comment-header *,
@@ -110,7 +110,7 @@ body .comment-container .review-comment-header,
 .comment-container:not(.review-comment) > .review-comment-container > .review-comment-header::before,
 .comment-container .comment-header::before {
 	opacity: 0.6;
-	background: var(--border-color-secondary);
+	background: var(--header-background);
 }
 
 .comment-header .comment-actions {
@@ -297,7 +297,7 @@ body button.checkedOut svg {
 }
 
 .details .comment-container {
-	border: 1px solid var(--border-color-primary);
+	border: 1px solid var(--border-color);
 }
 
 .details .comment-container .comment-info {
@@ -314,7 +314,7 @@ body button.checkedOut svg {
 	align-items: center;
 	padding: 8px 0 12px;
 	margin-bottom: 12px;
-	border-bottom: 1px solid var(--border-color-primary);
+	border-bottom: 1px solid var(--border-color);
 }
 
 .subtitle .avatar {
@@ -720,7 +720,7 @@ code {
 
 .review-comment-body .diff-container {
 	margin: 24px 0;
-	border: 1px solid var(--border-color-primary);
+	border: 1px solid var(--border-color);
 }
 
 .review-comment-body .diff-container .review-comment-container .comment-container {
@@ -737,14 +737,14 @@ code {
 }
 
 .diff {
-	border-bottom: 1px solid var(--border-color-primary);
+	border-bottom: 1px solid var(--border-color);
 }
 
 .diff .diffHeader {
 	position: relative;
 	padding: 6px 12px;
 	line-height: 1.5;
-	border-bottom: 1px solid var(--border-color-primary);
+	border-bottom: 1px solid var(--border-color);
 }
 
 
@@ -758,7 +758,7 @@ code {
 }
 
 .diff .diffHeader::before {
-	background: var(--border-color-secondary);
+	background: var(--header-background);
 }
 
 .diff .diffHeader .diffPath:hover {

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -776,9 +776,9 @@ code {
 .diff .diffHeader .outdatedLabel {
 	border: 1px solid rgba(27,31,35,.15);
 	box-shadow: none;
-	color: #586069;
+	color: var(--vscode-badge-foreground);
 	padding: 2px 4px;
-	background-color: #fff5b1;
+	background-color: var(--vscode-editorOverviewRuler-findMatchForeground);
 	margin-left: 5px;
 	border-radius: 2px;
 	line-height: 1;

--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -168,7 +168,7 @@ function renderDescription(pr: PullRequest): HTMLElement {
 
 	const commentHeader = document.createElement('div');
 	commentHeader.classList.add('comment-header');
-	commentHeader.innerHTML = `<div class="comment-info"><img class="avatar" src="${pr.author.avatarUrl}" alt=""> <span><a href="${pr.author.url}">${pr.author.login}</a> commented on <a href=${pr.url} class="timestamp">${dateFromNow(pr.createdAt)}</a></span></div>`;
+	commentHeader.innerHTML = `<div class="comment-info"><img class="avatar" src="${pr.author.avatarUrl}" alt=""> <span><a href="${pr.author.url}">${pr.author.login}</a> commented <a href=${pr.url} class="timestamp">${dateFromNow(pr.createdAt)}</a></span></div>`;
 
 	const commentBody = document.createElement('div');
 	commentBody.classList.add('description-content');

--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -117,9 +117,7 @@ function setTitleHTML(pr: PullRequest): void {
 				</div>
 				<div class="subtitle">
 					<div id="${ElementIds.Status}">${getStatus(pr.state)}</div>
-					<img class="avatar" src="${pr.author.avatarUrl}" alt="">
 					<span class="author"><a href="${pr.author.url}">${pr.author.login}</a> wants to merge changes from <code>${pr.head}</code> to <code>${pr.base}</code>.</span>
-					<span class="created-at">Created <a href=${pr.url} class="timestamp">${dateFromNow(pr.createdAt)}</a></span>
 				</div>
 			</div>
 		`;
@@ -139,13 +137,13 @@ function renderTitle(pr: PullRequest): HTMLElement {
 	titleHeader.classList.add('description-header');
 
 	const titleBody = document.createElement('div');
-	titleBody.innerHTML = `${pr.title} (<a href=${pr.url}>#${pr.number}</a>)`;
+	titleBody.innerHTML = `${pr.title} <a href=${pr.url}>#${pr.number}</a>`;
 
 	if (pr.canEdit) {
 		function updateTitle(text: string) {
 			pr.title = text;
 			updateState({ title: text });
-			titleBody.innerHTML = `${pr.title} (<a href=${pr.url}>#${pr.number}</a>)`;
+			titleBody.innerHTML = `${pr.title} <a href=${pr.url}>#${pr.number}</a>`;
 		}
 
 		const actionsBar = new ActionsBar(titleContainer, { body: pr.title, id: pr.number.toString() }, titleBody, messageHandler, updateTitle, 'pr.edit-title');
@@ -166,31 +164,36 @@ function renderTitle(pr: PullRequest): HTMLElement {
 
 function renderDescription(pr: PullRequest): HTMLElement {
 	const commentContainer = document.createElement('div');
-	commentContainer.classList.add('description-container');
+	commentContainer.classList.add('comment-container')
 
 	const commentHeader = document.createElement('div');
-	commentHeader.classList.add('description-header');
+	commentHeader.classList.add('comment-header');
+	commentHeader.innerHTML = `
+				<div class="avatar-container"><img class="avatar" src="${pr.author.avatarUrl}" alt=""></div> <a href="${pr.author.url}">${pr.author.login}</a> commented on <a href=${pr.url} class="timestamp">${dateFromNow(pr.createdAt)}</a>
+		`;
 
 	const commentBody = document.createElement('div');
+	commentBody.classList.add('description-content');
 	commentBody.innerHTML = pr.bodyHTML ?
 		pr.bodyHTML :
 		pr.body
 			? md.render(emoji.emojify(pr.body))
 			: '<p><i>No description provided.</i></p>';
 
-	if (pr.labels.length) {
-		const line = document.createElement('div');
-		line.classList.add('line');
+	commentContainer.appendChild(commentHeader);
 
-		line.innerHTML = `<svg class="octicon octicon-tag" viewBox="0 0 14 16" version="1.1" width="14" height="16">
+	if (pr.labels.length) {
+		const labels = document.createElement('div');
+		labels.classList.add('labels');
+
+		labels.innerHTML = `<svg class="octicon octicon-tag" viewBox="0 0 14 16" version="1.1" width="14" height="16">
 			<path fill-rule="evenodd" d="M7.685 1.72a2.49 2.49 0 0 0-1.76-.726H3.48A2.5 2.5 0 0 0 .994 3.48v2.456c0 .656.269 1.292.726 1.76l6.024 6.024a.99.99 0 0 0 1.402 0l4.563-4.563a.99.99 0 0 0 0-1.402L7.685 1.72zM2.366 7.048a1.54 1.54 0 0 1-.467-1.123V3.48c0-.874.716-1.58 1.58-1.58h2.456c.418 0 .825.159 1.123.467l6.104 6.094-4.702 4.702-6.094-6.114zm.626-4.066h1.989v1.989H2.982V2.982h.01z" />
 			</svg>
 			${pr.labels.map(label => `<span class="label">${label}</span>`).join('')}`;
 
-		commentContainer.appendChild(line);
+		commentContainer.appendChild(labels);
 	}
 
-	commentContainer.appendChild(commentHeader);
 	commentContainer.appendChild(commentBody);
 
 	if (pr.canEdit) {

--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -168,9 +168,7 @@ function renderDescription(pr: PullRequest): HTMLElement {
 
 	const commentHeader = document.createElement('div');
 	commentHeader.classList.add('comment-header');
-	commentHeader.innerHTML = `
-				<div class="avatar-container"><img class="avatar" src="${pr.author.avatarUrl}" alt=""></div> <a href="${pr.author.url}">${pr.author.login}</a> commented on <a href=${pr.url} class="timestamp">${dateFromNow(pr.createdAt)}</a>
-		`;
+	commentHeader.innerHTML = `<div class="comment-info"><img class="avatar" src="${pr.author.avatarUrl}" alt=""> <span><a href="${pr.author.url}">${pr.author.login}</a> commented on <a href=${pr.url} class="timestamp">${dateFromNow(pr.createdAt)}</a></span></div>`;
 
 	const commentBody = document.createElement('div');
 	commentBody.classList.add('description-content');

--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -490,7 +490,7 @@ export function renderCommit(timelineEvent: CommitEvent): HTMLElement {
 	sha.textContent = shaShort;
 
 	commentContainer.appendChild(commitMessage);
-	commentContainer.appendChild(sha);
+	commitMessage.appendChild(sha);
 
 	return commentContainer;
 }


### PR DESCRIPTION
Explored a few ways to update the styles so that the colors and spacing could work better (IMO). I had to re-arrange the order of a few classes in `preview-src/index.ts`, let me know if there are any issues in the way I did this. Here's a summary of the proposed changes :

- Moved the avatar in the title to the description header (this matches GitHub's style)
- Moved the created timestamp to the description header
- Updated the comment border and background color
- Fixed a bug in the buttons when re-sized smaller
- Fixed an alignment and color issue in the tag labels
- Made the diff background colors slightly less opaque to make them readable in other themes
- Updated "Outdated" label to be themeable
- Removed borders in diff comments to read better

## Before

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/35271042/51778802-86412b80-20b8-11e9-952a-af1899ea4f55.png">


## After

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/35271042/51778835-b7b9f700-20b8-11e9-889d-1ed48c62a210.png">