### PR TITLE
Do not fail if scopes fail to validate

### DIFF
--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -193,19 +193,15 @@ export class GitHubServer {
 
 		return new Promise<IHostConfiguration>((resolve, _) => {
 			const get = https.request(options, res => {
-				let hostConfig: IHostConfiguration | undefined;
 				try {
 					if (res.statusCode === 200) {
 						const scopes = res.headers['x-oauth-scopes'] as string;
-						if (GitHubManager.validateScopes(this.hostUri, scopes)) {
-							this.hostConfiguration.token = token;
-							hostConfig = this.hostConfiguration;
-						}
+						GitHubManager.validateScopes(this.hostUri, scopes);
+						resolve(this.hostConfiguration);
 					}
 				} catch (e) {
 					Logger.appendLine(`validate() error ${e}`);
 				}
-				resolve(hostConfig);
 			});
 
 			get.end();


### PR DESCRIPTION
Also add some logging so we can see what's going on for some GHE users (#662, #777).

I suspect we're hitting a proxy server, but they may also be getting tokens without the scopes we want. Stop failing in this case—a partially working token is better than failing outright all the time, presumably.

Fixes #662
Fixes #777 