### PR TITLE
Fix graphql ref response parsing

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -218,6 +218,19 @@ export interface DeleteReviewResponse {
 	};
 }
 
+export interface Ref {
+	name: string;
+	repository: {
+		owner: {
+			login: string;
+		}
+		url: string;
+	};
+	target: {
+		oid: string;
+	};
+}
+
 export interface PullRequestResponse {
 	repository: {
 		pullRequest: {
@@ -234,26 +247,8 @@ export interface PullRequestResponse {
 			}
 			createdAt: string;
 			updatedAt: string;
-			headRef?: {
-				name: string;
-				repository: {
-					nameWithOwner: string;
-					url: string;
-				}
-				target: {
-					oid: string;
-				}
-			}
-			baseRef?: {
-				name: string;
-				repository: {
-					nameWithOwner: string;
-					url: string;
-				}
-				target: {
-					oid: string
-				}
-			}
+			headRef?: Ref;
+			baseRef?: Ref;
 			merged: boolean;
 			mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
 			id: string;

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -176,7 +176,9 @@ query PullRequest($owner: String!, $name: String!, $number: Int!) {
 			headRef {
 				name
 				repository {
-					nameWithOwner
+					owner {
+						login
+					}
 					url
 				}
 				target {
@@ -186,7 +188,9 @@ query PullRequest($owner: String!, $name: String!, $number: Int!) {
 			baseRef {
 				name
 				repository {
-					nameWithOwner
+					owner {
+						login
+					}
 					url
 				}
 				target {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/876

The issue was that `ref` was being set to the repository name instead of the branch name, so trying to fetch that remote branch would fail.