### PR TITLE
Support copying commit hash from commit list

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,11 @@
         "category": "GitHub Pull Requests"
       },
       {
+        "command": "pr.copyCommitHash",
+        "title": "Copy Commit Hash",
+        "category": "GitHub Pull Requests"
+      },
+      {
         "command": "pr.openDiffView",
         "title": "Open Diff View",
         "category": "GitHub Pull Requests",
@@ -378,6 +383,10 @@
         {
           "command": "pr.openFileInGitHub",
           "when": "view =~ /(pr|prStatus)/ && viewItem =~ /filechange/"
+        },
+        {
+          "command": "pr.copyCommitHash",
+          "when": "view == prStatus && viewItem =~ /commit/"
         },
         {
           "command": "pr.openDescriptionToTheSide",

--- a/package.json
+++ b/package.json
@@ -340,6 +340,10 @@
         {
           "command": "pr.signinAndRefreshList",
           "when": "false"
+        },
+        {
+          "command": "pr.copyCommitHash",
+          "when": "false"
         }
       ],
       "view/title": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,6 +10,7 @@ import { ReviewManager } from './view/reviewManager';
 import { PullRequestOverviewPanel } from './github/pullRequestOverview';
 import { fromReviewUri, ReviewUriParams } from './common/uri';
 import { GitFileChangeNode, InMemFileChangeNode } from './view/treeNodes/fileChangeNode';
+import { CommitNode } from './view/treeNodes/commitNode';
 import { PRNode } from './view/treeNodes/pullRequestNode';
 import { ITelemetry, PullRequest } from './github/interface';
 import { formatError } from './common/utils';
@@ -130,6 +131,10 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openFileInGitHub', (e: GitFileChangeNode) => {
 		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(e.blobUrl!));
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('pr.copyCommitHash', (e: CommitNode) => {
+		vscode.window.showInformationMessage(e.sha);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffView', (fileChangeNode: GitFileChangeNode | InMemFileChangeNode) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -134,7 +134,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.copyCommitHash', (e: CommitNode) => {
-		vscode.window.showInformationMessage(e.sha);
+		vscode.env.clipboard.writeText(e.sha);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffView', (fileChangeNode: GitFileChangeNode | InMemFileChangeNode) => {

--- a/src/view/treeNodes/commitNode.ts
+++ b/src/view/treeNodes/commitNode.ts
@@ -16,8 +16,10 @@ import { PullRequestModel } from '../../github/pullRequestModel';
 
 export class CommitNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
+	public sha: string;
 	public collapsibleState: vscode.TreeItemCollapsibleState;
 	public iconPath: vscode.Uri | undefined;
+	public contextValue?: string;
 
 	constructor(
 		public parent: TreeNode | vscode.TreeView<TreeNode>,
@@ -28,8 +30,8 @@ export class CommitNode extends TreeNode implements vscode.TreeItem {
 	) {
 		super();
 		this.label = commit.commit.message;
+		this.sha = commit.sha;
 		this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-
 		let userIconUri: vscode.Uri | undefined;
 		try {
 			if (commit.author && commit.author.avatar_url) {
@@ -40,6 +42,7 @@ export class CommitNode extends TreeNode implements vscode.TreeItem {
 		}
 
 		this.iconPath = userIconUri;
+		this.contextValue = 'commit';
 	}
 
 	getTreeItem(): vscode.TreeItem {


### PR DESCRIPTION
Addresses #765, adds a context menu entry for commits in the commit list to copy the commit hash.

<img width="310" alt="screen shot 2019-01-30 at 12 22 23 am" src="https://user-images.githubusercontent.com/9157833/51967802-24b8ee00-2425-11e9-9cea-0f6062eceaa3.png">
