### PR TITLE
allow mentions api call to fail partially

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -140,6 +140,7 @@ export interface TimelineEventsResponse {
 			}
 		}
 	};
+	rateLimit: RateLimit;
 }
 
 export interface PendingReviewIdResponse {
@@ -148,6 +149,7 @@ export interface PendingReviewIdResponse {
 			nodes: Review[];
 		}
 	};
+	rateLimit: RateLimit;
 }
 
 export interface PullRequestCommentsResponse {
@@ -164,6 +166,7 @@ export interface PullRequestCommentsResponse {
 			}
 		}
 	};
+	rateLimit: RateLimit;
 }
 
 export interface MentionableUsersResponse {
@@ -183,6 +186,7 @@ export interface MentionableUsersResponse {
 			};
 		}
 	};
+	rateLimit: RateLimit;
 }
 
 export interface AddCommentResponse {
@@ -254,4 +258,15 @@ export interface PullRequestResponse {
 			id: string;
 		}
 	};
+	rateLimit: RateLimit;
+}
+
+export interface QueryWithRateLimit {
+	rateLimit: RateLimit;
+}
+export interface RateLimit {
+	limit: number;
+	cost: number;
+	remaining: number;
+	resetAt: string;
 }

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -269,12 +269,12 @@ export class PullRequestManager {
 					await Promise.all([prRelatedUsersPromise, fileRelatedUsersNamesPromise, getMentionableUsersPromise]);
 
 					cachedUsers = [];
-					let prRelatedUsersMap: { [key: string]: boolean } = {};
+					let prRelatedUsersMap: { [key: string]: { login: string; name?: string; } } = {};
 					Logger.debug('prepare user suggestions', PullRequestManager.ID);
 
 					prRelatedusers.forEach(user => {
 						if (!prRelatedUsersMap[user.login]) {
-							prRelatedUsersMap[user.login] = true;
+							prRelatedUsersMap[user.login] = user;
 						}
 					});
 
@@ -303,6 +303,19 @@ export class PullRequestManager {
 								});
 							}
 						});
+					}
+
+					for (let user in prRelatedUsersMap) {
+						if (!secondMap[user]) {
+							// if the mentionable api call fails partially, we should still populate related users from timeline events into the completion list
+							cachedUsers.push({
+								label: `@${prRelatedUsersMap[user].login}`,
+								insertText: `${prRelatedUsersMap[user].login}`,
+								filterText: `${prRelatedUsersMap[user].login}` + (prRelatedUsersMap[user].name && prRelatedUsersMap[user].name !== prRelatedUsersMap[user].login ? `_${prRelatedUsersMap[user].name.toLowerCase().replace(' ', '_')}` : ''),
+								sortText: `0_${prRelatedUsersMap[user].login}`,
+								detail: `${prRelatedUsersMap[user].name}`
+							});
+						}
 					}
 
 					Logger.debug('done', PullRequestManager.ID);

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -106,6 +106,12 @@ query TimelineEvents($owner: String!, $name: String!, $number: Int!, $last: Int 
 			}
 		}
 	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
+	}
 }
 
 fragment ReviewComment on PullRequestReviewComment {
@@ -141,6 +147,12 @@ query GetPendingReviewId($pullRequestId: ID!, $author: String!) {
 			reviews(first: 1, author: $author, states: [PENDING]) { nodes { id } }
 		}
 	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
+	}
 }
 
 query PullRequestComments($owner:String!, $name:String!, $number:Int!, $first:Int=100) {
@@ -154,6 +166,12 @@ query PullRequestComments($owner:String!, $name:String!, $number:Int!, $first:In
 				}
 			}
 		}
+	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
 	}
 }
 
@@ -201,6 +219,12 @@ query PullRequest($owner: String!, $name: String!, $number: Int!) {
 			mergeable
 			id
 		}
+	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
 	}
 }
 
@@ -266,5 +290,11 @@ query GetMentionableUsers($owner: String!, $name: String!, $first: Int!, $after:
 				endCursor
 			}
 		}
+	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
 	}
 }


### PR DESCRIPTION
I failed to see mentions in VSCode repo, probably because in Microsoft org there are always too many mentionable users and the api call fails unpredictably, and when it fails, its error message is not operational

```
GitHubRepository> Unable to fetch mentionable users: Error: GraphQL error: Something went wrong while executing your query. Please include `4798:2E6F:A16534:C78174:5C523C7A` when reporting this issue.
```

While fetching all pages of mentionable users, we should return mentionable users we receice already instead of return empty result.

Since the mentionable users we get from GitHub is not longer complete, we should now inject Timeline Event related users' alias into the completion list if they are there yet.