### PR TITLE
add comment-body class name for bodyHTML

### DIFF
--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -153,6 +153,7 @@ function renderDescription(pr: PullRequest): HTMLElement {
 	commentHeader.classList.add('description-header');
 
 	const commentBody = document.createElement('div');
+	commentBody.className = 'comment-body';
 	commentBody.innerHTML = pr.bodyHTML ?
 		pr.bodyHTML :
 		pr.body


### PR DESCRIPTION
I may delete the class name assignment when introducing `bodyHTML`, which leads to below wrong rendering

![image](https://user-images.githubusercontent.com/876920/52022256-e2d38a80-24ac-11e9-9644-187a32db0db6.png)
