### PR TITLE
Handle git show failing when trying to display file content

### DIFF
--- a/src/github/pullRequestGitHelper.ts
+++ b/src/github/pullRequestGitHelper.ts
@@ -100,6 +100,12 @@ export class PullRequestGitHelper {
 		if (branchInfos && branchInfos.length) {
 			// let's immediately checkout to branchInfos[0].branch
 			await repository.checkout(branchInfos[0].branch!);
+			const branch = await repository.getBranch(branchInfos[0].branch!);
+			if (branch.behind !== undefined && branch.behind > 0 && branch.ahead === 0) {
+				Logger.debug(`Pull from upstream`, PullRequestGitHelper.ID);
+				await repository.pull();
+			}
+
 			return true;
 		} else {
 			return false;

--- a/src/view/gitContentProvider.ts
+++ b/src/view/gitContentProvider.ts
@@ -29,9 +29,13 @@ export class GitContentProvider implements vscode.TextDocumentContentProvider {
 		}
 
 		const absolutePath = pathLib.join(this.repository.rootUri.fsPath, path).replace(/\\/g, '/');
-		let content = await this.repository.show(commit, absolutePath);
-
-		if (!content) {
+		let content: string;
+		try {
+			content = await this.repository.show(commit, absolutePath);
+			if (!content) {
+				throw new Error();
+			}
+		} catch (_) {
 			content = await this._fallback(uri);
 			if (!content) {
 				// Content does not exist for the base or modified file for a file deletion or addition.

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -635,7 +635,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 
 			const data = await this._prManager.getPullRequestFileChangesInfo(pr);
 			const headSha = pr.head.sha;
-			const mergeBase = pr.mergeBase;
+			const mergeBase = pr.mergeBase || pr.base.sha;
 
 			const contentChanges = await parseDiff(data, this._repository, mergeBase!);
 			this._localFileChanges = [];
@@ -667,7 +667,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 					change.status === GitChangeType.DELETE ?
 						toReviewUri(uri, undefined, undefined, '', false, { base: false }) :
 						toDiffViewFileUri(uri, change.fileName, undefined, pr.head.sha, false, { base: false }),
-					toReviewUri(uri, change.fileName, undefined, change.status === GitChangeType.ADD ? '' : pr.base.sha, false, { base: true }),
+					toReviewUri(uri, change.fileName, undefined, change.status === GitChangeType.ADD ? '' : mergeBase, false, { base: true }),
 					isPartial,
 					diffHunks,
 					activeComments.filter(comment => comment.path === change.fileName),


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/914

`repository.show` will throw when the commit isn't local, so when the local branch is behind the remote it tracks. Add a try-catch for this and also add auto-pulling logic to switching to an existing branch that is behind its remote