### PR TITLE
Don't refresh webview when submitting a review

### DIFF
--- a/src/common/octokit.ts
+++ b/src/common/octokit.ts
@@ -18,6 +18,7 @@ declare namespace Github {
 	export type PullRequestsGetCommentsResponseItem = REST.PullRequestsGetCommentsResponseItem;
 	export type PullRequestsEditCommentResponse = REST.PullRequestsEditCommentResponse;
 	export type PullRequestsGetResponseHeadRepo = REST.PullRequestsGetResponseHeadRepo;
+	export type PullRequestsCreateReviewResponse = REST.PullRequestsCreateReviewResponse;
 }
 // Octokit.PullRequestsGetResponse | Octokit.PullRequestsGetAllResponseItem
 

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -129,7 +129,7 @@ export interface Review {
 		avatarUrl: string;
 		url: string;
 	};
-	state: string;
+	state: 'COMMENTED' | 'APPROVED' | 'CHANGES_REQUESTED' | 'PENDING';
 	body: string;
 	bodyHTML?: string;
 	submittedAt: string;
@@ -210,13 +210,15 @@ export interface EditCommentResponse {
 	};
 }
 
+export interface SubmittedReview extends Review {
+	comments: {
+		nodes: ReviewComment[];
+	};
+}
+
 export interface SubmitReviewResponse {
 	submitPullRequestReview: {
-		pullRequestReview: {
-			comments: {
-				nodes: ReviewComment[];
-			}
-		}
+		pullRequestReview: SubmittedReview;
 	};
 }
 

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -20,7 +20,7 @@ import { Repository, RefType, UpstreamRef } from '../git/api';
 import Logger from '../common/logger';
 import { EXTENSION_ID } from '../constants';
 import { fromPRUri } from '../common/uri';
-import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount } from './utils';
+import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount, convertRESTReviewEvent, parseGraphQLReviewEvent } from './utils';
 import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse, EditCommentResponse, DeleteReactionResponse, AddReactionResponse } from './graphql';
 const queries = require('./queries.gql');
 
@@ -1192,10 +1192,10 @@ export class PullRequestManager {
 			});
 	}
 
-	private async createReview(pullRequest: PullRequestModel, event: ReviewEvent, message?: string): Promise<void> {
+	private async createReview(pullRequest: PullRequestModel, event: ReviewEvent, message?: string): Promise<CommonReviewEvent> {
 		const { octokit, remote } = await pullRequest.githubRepository.ensure();
 
-		await octokit.pullRequests.createReview({
+		const { data } = await octokit.pullRequests.createReview({
 			owner: remote.owner,
 			repo: remote.repositoryName,
 			number: pullRequest.prNumber,
@@ -1203,10 +1203,10 @@ export class PullRequestManager {
 			body: message,
 		});
 
-		return;
+		return convertRESTReviewEvent(data);
 	}
 
-	public async submitReview(pullRequest: PullRequestModel, event?: ReviewEvent, body?: string): Promise<void> {
+	public async submitReview(pullRequest: PullRequestModel, event?: ReviewEvent, body?: string): Promise<CommonReviewEvent> {
 		const pendingReviewId = await this.getPendingReviewId(pullRequest);
 		const { mutate } = await pullRequest.githubRepository.ensure();
 
@@ -1222,13 +1222,14 @@ export class PullRequestManager {
 
 			const submittedComments = data!.submitPullRequestReview.pullRequestReview.comments.nodes.map(parseGraphQLComment);
 			_onDidSubmitReview.fire(submittedComments);
+			return parseGraphQLReviewEvent(data!.submitPullRequestReview.pullRequestReview);
 		} else {
-			Logger.appendLine(`Submitting review failed, no pending review for current pull request: ${pullRequest.prNumber}.`);
+			throw new Error(`Submitting review failed, no pending review for current pull request: ${pullRequest.prNumber}.`);
 		}
 	}
 
-	async requestChanges(pullRequest: PullRequestModel, message?: string): Promise<void> {
-		const action: Promise<void> = await this.getPendingReviewId(pullRequest)
+	async requestChanges(pullRequest: PullRequestModel, message?: string): Promise<CommonReviewEvent> {
+		const action: Promise<CommonReviewEvent> = await this.getPendingReviewId(pullRequest)
 			? this.submitReview(pullRequest, ReviewEvent.RequestChanges, message)
 			: this.createReview(pullRequest, ReviewEvent.RequestChanges, message);
 
@@ -1239,8 +1240,8 @@ export class PullRequestManager {
 			});
 	}
 
-	async approvePullRequest(pullRequest: PullRequestModel, message?: string): Promise<void> {
-		const action: Promise<void> = await this.getPendingReviewId(pullRequest)
+	async approvePullRequest(pullRequest: PullRequestModel, message?: string): Promise<CommonReviewEvent> {
+		const action: Promise<CommonReviewEvent> = await this.getPendingReviewId(pullRequest)
 			? this.submitReview(pullRequest, ReviewEvent.Approve, message)
 			: this.createReview(pullRequest, ReviewEvent.Approve, message);
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -18,7 +18,7 @@ import { DescriptionNode } from '../view/treeNodes/descriptionNode';
 import { TreeNode, Revealable } from '../view/treeNodes/treeNode';
 import { PullRequestManager } from './pullRequestManager';
 import { PullRequestModel } from './pullRequestModel';
-import { TimelineEvent, isReviewEvent } from '../common/timelineEvent';
+import { TimelineEvent, ReviewEvent as CommonReviewEvent, isReviewEvent } from '../common/timelineEvent';
 
 interface IRequestMessage<T> {
 	req: string;
@@ -587,8 +587,10 @@ export class PullRequestOverviewPanel {
 	}
 
 	private approvePullRequest(message: IRequestMessage<string>): void {
-		vscode.commands.executeCommand<Github.PullRequestsGetResponse>('pr.approve', this._pullRequest, message.args).then(_ => {
-			this.refreshPanel();
+		vscode.commands.executeCommand<CommonReviewEvent>('pr.approve', this._pullRequest, message.args).then(review => {
+			this._replyMessage(message, {
+				value: review
+			});
 		}, (e) => {
 			vscode.window.showErrorMessage(`Approving pull request failed. ${formatError(e)}`);
 
@@ -597,8 +599,10 @@ export class PullRequestOverviewPanel {
 	}
 
 	private requestChanges(message: IRequestMessage<string>): void {
-		vscode.commands.executeCommand<Github.PullRequestsGetResponse>('pr.requestChanges', this._pullRequest, message.args).then(_ => {
-			this.refreshPanel();
+		vscode.commands.executeCommand<CommonReviewEvent>('pr.requestChanges', this._pullRequest, message.args).then(review => {
+			this._replyMessage(message, {
+				value: review
+			});
 		}, (e) => {
 			vscode.window.showErrorMessage(`Requesting changes failed. ${formatError(e)}`);
 			this._throwError(message, `${formatError(e)}`);
@@ -607,7 +611,9 @@ export class PullRequestOverviewPanel {
 
 	private submitReview(message: IRequestMessage<string>): void {
 		this._pullRequestManager.submitReview(this._pullRequest, ReviewEvent.Comment, message.args).then(review => {
-			this.refreshPanel();
+			this._replyMessage(message, {
+				value: review
+			});
 		}, (e) => {
 			vscode.window.showErrorMessage(`Requesting changes failed. ${formatError(e)}`);
 			this._throwError(message, `${formatError(e)}`);

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -278,6 +278,7 @@ mutation SubmitReview($id: ID!, $event: PullRequestReviewEvent!, $body: String) 
 			comments(first:100) {
 				nodes { ...ReviewComment }
 			}
+			...Review
 		}
 	}
 }

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -84,6 +84,20 @@ export function convertRESTPullRequestToRawPullRequest(pullRequest: Octokit.Pull
 	return item;
 }
 
+export function convertRESTReviewEvent(review: Octokit.PullRequestsCreateReviewResponse): Common.ReviewEvent {
+	return {
+		event: Common.EventType.Reviewed,
+		comments: [],
+		submittedAt: (review as any).submitted_at, // TODO fix typings upstream
+		body: review.body,
+		htmlUrl: review.html_url,
+		user: convertRESTUserToAccount(review.user),
+		authorAssociation: review.user.type,
+		state: review.state as 'COMMENTED' | 'APPROVED' | 'CHANGES_REQUESTED' | 'PENDING',
+		id: review.id
+	};
+}
+
 export function parseCommentDiffHunk(comment: Comment): DiffHunk[] {
 	let diffHunks = [];
 	let diffHunkReader = parseDiffHunk(comment.diffHunk);
@@ -244,6 +258,21 @@ export function parseGraphQLPullRequest(pullRequest: GraphQL.PullRequestResponse
 		mergeable: graphQLPullRequest.mergeable === 'MERGEABLE',
 		nodeId: graphQLPullRequest.id,
 		labels: graphQLPullRequest.labels.nodes
+	};
+}
+
+export function parseGraphQLReviewEvent(review: GraphQL.SubmittedReview): Common.ReviewEvent {
+	return {
+		event: Common.EventType.Reviewed,
+		comments: review.comments.nodes.map(parseGraphQLComment).filter(c => !c.inReplyToId),
+		submittedAt: review.submittedAt,
+		body: review.body,
+		bodyHTML: review.bodyHTML,
+		htmlUrl: review.url,
+		user: review.author,
+		authorAssociation: review.authorAssociation,
+		state: review.state,
+		id: review.databaseId
 	};
 }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/929 and https://github.com/Microsoft/vscode-pull-request-github/issues/912

Instead of triggering a refresh when a review is submitted, send back data about the new review event and re-render events on the webview