### PR TITLE
Fix LGTM.com alerts

### DIFF
--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -743,8 +743,6 @@ function getDiffChangeClass(type: DiffChangeType) {
 			return 'delete';
 		case DiffChangeType.Context:
 			return 'context';
-		case DiffChangeType.Context:
-			return 'context';
 		default:
 			return 'control';
 	}

--- a/src/common/protocol.ts
+++ b/src/common/protocol.ts
@@ -90,7 +90,7 @@ export class Protocol {
 	}
 
 	getRepositoryName(path: string) {
-		let normalized = path.replace('\\', '/');
+		let normalized = path.replace(/\\/g, '/');
 		if (normalized.endsWith('/')) {
 			normalized = normalized.substr(0, normalized.length - 1);
 		}
@@ -104,7 +104,7 @@ export class Protocol {
 	}
 
 	getOwnerName(path: string) {
-		let normalized = path.replace('\\', '/');
+		let normalized = path.replace(/\\/g, '/');
 		if (normalized.endsWith('/')) {
 			normalized = normalized.substr(0, normalized.length - 1);
 		}

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -152,7 +152,7 @@ export class CredentialStore {
 
 			if (octokit) {
 				retry = false;
-			} else if (retry) {
+			} else {
 				retry = (await vscode.window.showErrorMessage(`Error signing in to ${authority}`, TRY_AGAIN)) === TRY_AGAIN;
 			}
 		}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -616,7 +616,7 @@ export class PullRequestManager {
 
 			const comments = data.repository.pullRequest.reviews.nodes
 				.map((node: any) => node.comments.nodes.map((comment: any) => parseGraphQLComment(comment), remote))
-				.reduce((prev: any, curr: any) => curr = prev.concat(curr), []);
+				.reduce((prev: any, curr: any) => prev.concat(curr), []);
 			return comments;
 		} catch (e) {
 			Logger.appendLine(`Failed to get pull request review comments: ${formatError(e)}`);

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -83,7 +83,7 @@ export class InMemFileChangeNode extends TreeNode implements vscode.TreeItem {
 		this.contextValue = 'filechange';
 		this.label = path.basename(fileName);
 		this.description = path.relative('.', path.dirname(fileName));
-		this.iconPath = this.iconPath = vscode.ThemeIcon.File;
+		this.iconPath = vscode.ThemeIcon.File;
 		this.resourceUri = toFileChangeNodeUri(this.filePath, comments.length > 0, status);
 
 		this.opts = {

--- a/src/view/treeNodes/treeNode.ts
+++ b/src/view/treeNodes/treeNode.ts
@@ -34,7 +34,7 @@ export abstract class TreeNode implements vscode.Disposable {
 	}
 
 	dispose(): void {
-		if (this.childrenDisposables && this.childrenDisposables) {
+		if (this.childrenDisposables) {
 			this.childrenDisposables.forEach(dispose => dispose.dispose());
 		}
 	}


### PR DESCRIPTION
This PR fixes all of the [alerts for this project](https://lgtm.com/projects/g/Microsoft/vscode-pull-request-github/alerts) found by LGTM.com.

The only change that could potentially change behaviour are the fixes to the string replacing in `protocol.ts`, everything else is just cleaning up redundant code.

The only alerts that would remain after this PR gets merged are false positives for 'Useless assignment to property', which is fixed in https://github.com/Semmle/ql/pull/920 (and should be deployed to LGTM shortly).

*(Full disclosure: I'm part of the team behind LGTM.com)*