### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -455,7 +455,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "compile": "tsc -p ./",
     "watch": "webpack --watch --env.development",
-    "test": "tsc -p ./ && node ./node_modules/vscode/bin/test"
+    "test": "./test.sh"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",

--- a/src/test/authentication/keychain.test.ts
+++ b/src/test/authentication/keychain.test.ts
@@ -109,7 +109,7 @@ describe('keychain', () => {
 			it('fires an event when a token is removed', async () => {
 				const didChange = promiseFromEvent(onDidChange);
 				deleteToken('github.com', { storage, keychain });
-				assert.deepStrictEqual(await didChange, { host: 'github.com', token: null });
+				assert.deepStrictEqual(await didChange, { host: 'github.com', token: undefined });
 			});
 		});
 
@@ -138,7 +138,7 @@ describe('keychain', () => {
 			it('fires an event when a token is removed', async () => {
 				const didChange = promiseFromEvent(onDidChange);
 				deleteToken('github.com', { storage, keychain });
-				assert.deepStrictEqual(await didChange, { host: 'github.com', token: null });
+				assert.deepStrictEqual(await didChange, { host: 'github.com', token: undefined });
 			});
 		});
 	});

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -53,7 +53,7 @@ describe('Protocol', () => {
 			{ uri: 'ssh://git@github.com/Microsoft/vscode', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'ssh://github.com:Microsoft/vscode.git', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'ssh://git@github.com:433/Microsoft/vscode', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'ssh://user@git.server.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server.org', expectedOwner: null, expectedRepositoryName: 'project' }
+			{ uri: 'ssh://user@git.server.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server.org', expectedOwner: '', expectedRepositoryName: 'project' }
 
 		].forEach(testRemote)
 	);
@@ -63,8 +63,8 @@ describe('Protocol', () => {
 			{ uri: 'git@github.com:Microsoft/vscode', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'git@github.com:Microsoft/vscode.git', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'github.com:Microsoft/vscode.git', expectedType: ProtocolType.SSH, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
-			{ uri: 'user@git.server.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server.org', expectedOwner: null, expectedRepositoryName: 'project' },
-			{ uri: 'git.server2.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server2.org', expectedOwner: null, expectedRepositoryName: 'project' }
+			{ uri: 'user@git.server.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server.org', expectedOwner: '', expectedRepositoryName: 'project' },
+			{ uri: 'git.server2.org:project.git', expectedType: ProtocolType.SSH, expectedHost: 'git.server2.org', expectedOwner: '', expectedRepositoryName: 'project' }
 		].forEach(testRemote)
 	);
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+tsc -p .
+echo -n > out/github/queries.gql
+node ./node_modules/vscode/bin/test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
 		"outDir": "out",
 		"noUnusedLocals": true,
 		"lib": [
+			"dom",
+			"esnext.asynciterable",
 			"es6"
 		],
 		"sourceMap": true,


### PR DESCRIPTION
Some libraries were missing from the `tsconfig.json`, which was causing typescript compilation to fail. The `queries.gql` file also wasn't getting copied to the output folder, so when running the tests couldn't be found. And some tests needed correcting after the strict null work. Now all tests run and pass, yay!