### PR TITLE
Disable not available merge methods (fixes #946)

### DIFF
--- a/preview-src/cache.ts
+++ b/preview-src/cache.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { vscode } from './message';
-import { PullRequestStateEnum, IAccount, ReviewState, ILabel } from '../src/github/interface';
+import { PullRequestStateEnum, IAccount, ReviewState, ILabel, MergeMethod, MergeMethodsAvailability } from '../src/github/interface';
 import { TimelineEvent } from '../src/common/timelineEvent';
 import { ReposGetCombinedStatusForRefResponse } from '@octokit/rest';
 
@@ -29,7 +29,8 @@ export interface PullRequest {
 	pendingCommentDrafts?: { [key: string]: string; };
 	status: ReposGetCombinedStatusForRefResponse;
 	mergeable: boolean;
-	defaultMergeMethod: string;
+	defaultMergeMethod: MergeMethod;
+	mergeMethodsAvailability: MergeMethodsAvailability;
 	supportsGraphQl: boolean;
 	reviewers: ReviewState[];
 }

--- a/preview-src/pullRequestOverviewRenderer.ts
+++ b/preview-src/pullRequestOverviewRenderer.ts
@@ -5,7 +5,7 @@
 
 import { dateFromNow } from '../src/common/utils';
 import { TimelineEvent, CommitEvent, ReviewEvent, CommentEvent, isCommentEvent, isReviewEvent, isCommitEvent, isMergedEvent, MergedEvent } from '../src/common/timelineEvent';
-import { PullRequestStateEnum } from '../src/github/interface';
+import { PullRequestStateEnum, MergeMethod, MergeMethodsAvailability } from '../src/github/interface';
 import md from './mdRenderer';
 import { MessageHandler } from './message';
 import { getState, updateState, PullRequest } from './cache';
@@ -206,11 +206,7 @@ function renderMerge(pr: PullRequest, messageHandler: MessageHandler, container:
 	const mergeText = document.createElement('div');
 	mergeText.textContent = 'using method';
 	const mergeSelector = document.createElement('select');
-	mergeSelector.innerHTML = `
-		<option value="merge">Create Merge Commit</option>
-		<option value="squash">Squash and Merge</option>
-		<option value="rebase">Rebase and Merge</option>`;
-
+	mergeSelector.innerHTML = getMergeOptions(pr.mergeMethodsAvailability);
 	mergeSelector.value = pr.defaultMergeMethod;
 
 	mergeSelectorContainer.appendChild(mergeButton);
@@ -283,6 +279,33 @@ function renderMerge(pr: PullRequest, messageHandler: MessageHandler, container:
 	mergeContainer.appendChild(mergeSelectorContainer);
 	mergeContainer.appendChild(mergeInputsContainer);
 	mergeContainer.appendChild(mergeActionsContainer);
+}
+
+function getMergeOptions(methodAvailability: MergeMethodsAvailability): string {
+	const methods: MergeMethod[] = ['merge', 'squash', 'rebase'];
+
+	const options = methods.map(method => {
+		let optionText: string = '';
+		switch (method) {
+			case 'merge':
+				optionText = 'Create Merge Commit';
+				break;
+			case 'squash':
+				optionText = 'Squash and Merge';
+				break;
+			case 'rebase':
+				optionText = 'Rebase and Merge';
+				break;
+		}
+
+		return `
+			<option value=${method}${methodAvailability[method] ? '' : ' disabled'}>
+				${optionText}${methodAvailability[method] ? '' : ' (not enabled)'}
+			</option>
+		`;
+	});
+
+	return options.join('');
 }
 
 function getDefaultTitleText(mergeMethod: string, pr: PullRequest) {

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -102,6 +102,12 @@ export interface IPullRequestEditData {
 	title?: string;
 }
 
+export type MergeMethod = 'merge' | 'squash' | 'rebase';
+
+export type MergeMethodsAvailability = {
+	[method in MergeMethod]: boolean;
+};
+
 export interface ITelemetry {
 	on(action: 'startup'): Promise<void>;
 	on(action: 'authSuccess'): Promise<void>;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -11,7 +11,7 @@ import { Comment } from '../common/comment';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
 import { TimelineEvent, EventType, ReviewEvent as CommonReviewEvent, isReviewEvent, isCommitEvent } from '../common/timelineEvent';
 import { GitHubRepository } from './githubRepository';
-import { IPullRequestsPagingOptions, PRType, ReviewEvent, ITelemetry, IPullRequestEditData, PullRequest, IRawFileChange, IAccount, ILabel } from './interface';
+import { IPullRequestsPagingOptions, PRType, ReviewEvent, ITelemetry, IPullRequestEditData, PullRequest, IRawFileChange, IAccount, ILabel, MergeMethodsAvailability } from './interface';
 import { PullRequestGitHelper } from './pullRequestGitHelper';
 import { PullRequestModel } from './pullRequestModel';
 import { GitHubManager } from '../authentication/githubServer';
@@ -1325,6 +1325,11 @@ export class PullRequestManager {
 	async getPullRequestRepositoryDefaultBranch(pullRequest: PullRequestModel): Promise<string> {
 		const branch = await pullRequest.githubRepository.getDefaultBranch();
 		return branch;
+	}
+
+	async getPullRequestRepositoryMergeMethodsAvailability(pullRequest: PullRequestModel): Promise<MergeMethodsAvailability> {
+		const mergeOptions = await pullRequest.githubRepository.getMergeMethodsAvailability();
+		return mergeOptions;
 	}
 
 	async fullfillPullRequestMissingInfo(pullRequest: PullRequestModel): Promise<void> {

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -7,7 +7,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as Github from '@octokit/rest';
-import { PullRequestStateEnum, ReviewEvent, ReviewState, ILabel, IAccount } from './interface';
+import { PullRequestStateEnum, ReviewEvent, ReviewState, ILabel, IAccount, MergeMethodsAvailability, MergeMethod } from './interface';
 import { onDidUpdatePR } from '../commands';
 import { formatError } from '../common/utils';
 import { GitErrorCodes } from '../git/api';
@@ -196,9 +196,10 @@ export class PullRequestOverviewPanel {
 			this._pullRequestManager.getTimelineEvents(pullRequestModel),
 			this._pullRequestManager.getPullRequestRepositoryDefaultBranch(pullRequestModel),
 			this._pullRequestManager.getStatusChecks(pullRequestModel),
-			this._pullRequestManager.getReviewRequests(pullRequestModel)
+			this._pullRequestManager.getReviewRequests(pullRequestModel),
+			this._pullRequestManager.getPullRequestRepositoryMergeMethodsAvailability(pullRequestModel),
 		]).then(result => {
-			const [pullRequest, timelineEvents, defaultBranch, status, requestedReviewers] = result;
+			const [pullRequest, timelineEvents, defaultBranch, status, requestedReviewers, mergeMethodsAvailability] = result;
 			if (!pullRequest) {
 				throw new Error(`Fail to resolve Pull Request #${pullRequestModel.prNumber} in ${pullRequestModel.remote.owner}/${pullRequestModel.remote.repositoryName}`);
 			}
@@ -208,8 +209,9 @@ export class PullRequestOverviewPanel {
 
 			const isCurrentlyCheckedOut = pullRequestModel.equals(this._pullRequestManager.activePullRequest);
 			const canEdit = this._pullRequestManager.canEditPullRequest(this._pullRequest);
-			const defaultMergeMethod = vscode.workspace.getConfiguration('githubPullRequests').get<string>('defaultMergeMethod');
+			const preferredMergeMethod = vscode.workspace.getConfiguration('githubPullRequests').get<MergeMethod>('defaultMergeMethod');
 			const supportsGraphQl = pullRequestModel.githubRepository.supportsGraphQl;
+			const defaultMergeMethod = getDetaultMergeMethod(mergeMethodsAvailability, preferredMergeMethod);
 
 			this._postMessage({
 				command: 'pr.initialize',
@@ -232,6 +234,7 @@ export class PullRequestOverviewPanel {
 					status: status,
 					mergeable: this._pullRequest.prItem.mergeable,
 					reviewers: this.parseReviewers(requestedReviewers, timelineEvents, this._pullRequest.author),
+					mergeMethodsAvailability,
 					defaultMergeMethod,
 					supportsGraphQl
 				}
@@ -673,4 +676,14 @@ function getNonce() {
 		text += possible.charAt(Math.floor(Math.random() * possible.length));
 	}
 	return text;
+}
+
+function getDetaultMergeMethod(methodsAvailability: MergeMethodsAvailability, userPreferred: MergeMethod | undefined): MergeMethod {
+	// Use default merge method specified by user if it is avaialbe
+	if (userPreferred && methodsAvailability.hasOwnProperty(userPreferred) && methodsAvailability[userPreferred]) {
+		return userPreferred;
+	}
+	const methods: MergeMethod[] = ['merge', 'squash', 'rebase'];
+	// GitHub requires to have at leas one merge method to be enabled; use first available as default
+	return methods.find(method => methodsAvailability[method])!;
 }


### PR DESCRIPTION
This PR adds check for merge methods that are allowed in repository and shows only available methods in dropdown.
If method that user set as their default is disabled for current repo - first available will be selected instead.

Current implementation differs from GitHub which shows in dropdown all options and marks options that are not enabled for repo. Should I change behavior to match GitHub?