### PR TITLE
Update outdated label and commit lines

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -430,7 +430,7 @@ body .overview-title .button-group button {
 
 .comment-container.commit,
 .comment-container.merged {
-	padding-left: 16px;
+	padding: 16px 0 0 12px;
 	box-sizing: border-box
 }
 

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -834,11 +834,10 @@ code {
 }
 
 .diff .diffHeader .outdatedLabel {
-	border: 1px solid rgba(27,31,35,.15);
+	border: 1px solid var(--vscode-editorOverviewRuler-findMatchForeground);
 	box-shadow: none;
-	color: #586069;
+	color: var(--vscode-editorOverviewRuler-findMatchForeground);
 	padding: 2px 4px;
-	background-color: #fff5b1;
 	margin-left: 5px;
 	border-radius: 2px;
 	line-height: 1;

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -834,10 +834,11 @@ code {
 }
 
 .diff .diffHeader .outdatedLabel {
-	border: 1px solid var(--vscode-editorOverviewRuler-findMatchForeground);
+	border-radius: 3px;
 	box-shadow: none;
-	color: var(--vscode-editorOverviewRuler-findMatchForeground);
-	padding: 2px 4px;
+	color: var(--vscode-badge-foreground);
+	background: var(--vscode-badge-background);
+	padding: 2px 6px;
 	margin-left: 5px;
 	border-radius: 2px;
 	line-height: 1;


### PR DESCRIPTION
This makes the outdated label themeable (and passes the color contrast ratio) and makes the commit logs more compact.

## Commit logs
<img width="964" alt="image" src="https://user-images.githubusercontent.com/35271042/53270839-a6f1a680-36a1-11e9-87fd-bfa838434731.png">

## Outdated label
<img width="702" alt="image" src="https://user-images.githubusercontent.com/35271042/53271121-4fa00600-36a2-11e9-9c36-cc2b6e42eaf7.png">
