### PR TITLE
Show login in quick pick when adding reviewers

### DIFF
--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -325,10 +325,11 @@ export class PullRequestOverviewPanel {
 			const reviewersToAdd = await vscode.window.showQuickPick(newReviewers.map(reviewer => {
 				return {
 					label: reviewer.login,
-					details: reviewer.name
+					description: reviewer.name
 				};
 			}), {
-				canPickMany: true
+				canPickMany: true,
+				matchOnDescription: true
 			});
 
 			if (reviewersToAdd) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/985, use the correct property to display names next to logins. Looking at the quickpick API, there doesn't seem to be a way to display an icon for each, so this doesn't add support for that.