### PR TITLE
use workspace root uri scheme instead of file

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -370,8 +370,9 @@ export class ReviewManager implements vscode.DecorationProvider {
 				}
 			}
 
-			const filePath = nodePath.resolve(this._repository.rootUri.fsPath, change.fileName);
-			const uri = vscode.Uri.file(filePath);
+			const filePath = nodePath.resolve(this._repository.rootUri.fsPath, change.fileName).replace(/\\/g, '/');
+			const uri = this._repository.rootUri.with({ path: filePath });
+
 			let changedItem = new GitFileChangeNode(
 				this.prFileChangesProvider.view,
 				pr,


### PR DESCRIPTION
Re #961. Even though it's not perfect, but using the scheme of workspace root uri makes more sense than `file`.