### PR TITLE
Fix rendering of checkboxes on description page

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -558,7 +558,7 @@ body .comment-form {
 	margin-right: 0;
 }
 
-textarea, input {
+textarea, input[type='text'] {
 	display: block;
 	box-sizing: border-box;
 	padding: 10px;
@@ -581,6 +581,10 @@ select {
 	background-color: var(--vscode-dropdown-background);
 	color: var(--vscode-dropdown-foreground);
 	border: 1px solid transparent;
+}
+
+.task-list-item {
+	list-style-type: none;
 }
 
 #status-checks textarea {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/1038

The css rule for input was too general and was getting applied to them. Also, hides the extraneous bullet points in front of the checkboxes. The HTML returned from the server wraps all of them in `<li>` with class `task-list-item`, so fixed by not displaying these as list items