### PR TITLE
Fix description not displaying after creating a pull request

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -704,7 +704,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			if (pullRequestModel) {
 				progress.report({ increment: 30, message: `Pull Request #${pullRequestModel.prNumber} Created` });
 				await this.updateState();
-				await vscode.commands.executeCommand('pr.openDescription', pullRequestModel);
+				await vscode.commands.executeCommand('pr.openDescription');
 				progress.report({ increment: 30 });
 			} else {
 				// error: Unhandled Rejection at: Promise [object Promise]. Reason: {"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for rebornix:tree-sitter."}],"documentation_url":"https://developer.github.com/v3/pulls/#create-a-pull-request"}.


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/1040

The `openDescription` command that's being called expects an argument of type description node, which gets passed whenever it's being called from the tree by clicking on that type of node. The description node is used to get information about which PR to show - if no description node is passed, the currently active PR is used instead:

```ts
context.subscriptions.push(vscode.commands.registerCommand('pr.openDescription', async (descriptionNode: DescriptionNode) => {
		if (!descriptionNode) {
			// the command is triggerred from command palette or status bar, which means we are already in checkout mode.
			let rootNodes = await reviewManager.prFileChangesProvider.getChildren();
			descriptionNode = rootNodes[0] as DescriptionNode;
		}
		const pullRequest = ensurePR(prManager, descriptionNode.pullRequestModel);
		// Create and show a new webview
		PullRequestOverviewPanel.createOrShow(context.extensionPath, prManager, pullRequest, descriptionNode);
		telemetry.on('pr.openDescription');
	}));
```

So the fix is to not pass anything when executing the command, since at this point the new PR is now active