### PR TITLE
Add lgtm integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ See our [wiki](https://github.com/Microsoft/vscode-pull-request-github/wiki) for
 
 ## Contributing
 
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/Microsoft/vscode-pull-request-github.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Microsoft/vscode-pull-request-github/alerts/)
+
 If you're interested in contributing, or want to explore the source code of this extension yourself, see our [contributing guide](https://github.com/Microsoft/vscode-pull-request-github/wiki/Contributing), which includes:
  - [How to Build and Run](https://github.com/Microsoft/vscode-pull-request-github/wiki/Contributing#build-and-run)
  - [Architecture](https://github.com/Microsoft/vscode-pull-request-github/wiki/Contributing#architecture)


### PR DESCRIPTION
Following #948 getting merged, and https://github.com/Semmle/ql/pull/920 being deployed to LGTM, there are now 0 alerts for this project on LGTM :).

It's probably a good idea to try and keep these alerts 0 or low. And there are a couple of ways that you could go about doing this:
* Adding a badge to the `README` that tracks how many LGTM alerts there are. This PR introduces that badge, though there aren't currently any other badges on the `README`, so I wasn't sure where the best place for it would be (this currently adds it under the Contributing header). *(there's also a [code quality badge](https://lgtm.com/projects/g/Microsoft/vscode-pull-request-github/ci/) if you care about that)*
* Enabling the [automated code review](https://lgtm.com/projects/g/Microsoft/vscode-pull-request-github/ci/) for pull requests, which will check all incoming pull requests to see if they would introduce any alerts.

Not sure which of these you'd prefer, but let me know if you have any questions. :)