### PR TITLE
Comments collpased for workspace files.

### DIFF
--- a/src/view/reviewDocumentCommentProvider.ts
+++ b/src/view/reviewDocumentCommentProvider.ts
@@ -126,7 +126,7 @@ export class ReviewDocumentCommentProvider implements vscode.Disposable, Comment
 			matchingComments = mapCommentsToHead(matchedFile.diffHunks, contentDiff, matchingComments);
 
 			let threads = workspaceLocalCommentsToCommentThreads(
-				this._repository, matchedFile, matchingComments, vscode.CommentThreadCollapsibleState.Expanded).map(thread => createVSCodeCommentThread(thread, this._commentController!, this._prManager.activePullRequest!, inDraftMode, this));
+				this._repository, matchedFile, matchingComments, vscode.CommentThreadCollapsibleState.Collapsed).map(thread => createVSCodeCommentThread(thread, this._commentController!, this._prManager.activePullRequest!, inDraftMode, this));
 			this._workspaceFileChangeCommentThreads[matchedFile.fileName] = threads;
 		});
 


### PR DESCRIPTION
As discussed during sitdown, we now follow the behavior of old API and workspace comments are collapsed by default.

Switching between documents didn't restore comment widget collapisable state, we can do that in upstream.