### PR TITLE
Fix "Cannot read property 'commentThreadCache' of undefined" error

### DIFF
--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -249,6 +249,13 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 
 				this._fileChanges = fileChanges;
 				await this.refreshExistingPREditors(vscode.window.visibleTextEditors, true);
+
+				this._disposables.push(vscode.window.onDidChangeVisibleTextEditors(async e => {
+					// Create Comment Threads when the editor is visible
+					// Dispose when the editor is invisible and remove them from the cache map
+					// Comment Threads in cache map is updated only when users trigger refresh
+					await this.refreshExistingPREditors(e, false);
+				}));
 			} else {
 				await this.pullRequestModel.githubRepository.ensureCommentsProvider();
 				this.pullRequestModel.githubRepository.commentsProvider!.clearCommentThreadCache(this.pullRequestModel.prNumber);
@@ -261,13 +268,6 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 			}, this.pullRequestModel), ...this._fileChanges];
 
 			this.childrenDisposables = result;
-
-			this._disposables.push(vscode.window.onDidChangeVisibleTextEditors(async e => {
-				// Create Comment Threads when the editor is visible
-				// Dispose when the editor is invisible and remove them from the cache map
-				// Comment Threads in cache map is updated only when users trigger refresh
-				await this.refreshExistingPREditors(e, false);
-			}));
 			return result;
 		} catch (e) {
 			Logger.appendLine(e);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/1076

The listener for editor changes should only be added when the comment controller is created for the PR node, i.e. when it does not match the currently checked out PR