### PR TITLE
Create comment threads for files with review query.

### DIFF
--- a/src/view/reviewDocumentCommentProvider.ts
+++ b/src/view/reviewDocumentCommentProvider.ts
@@ -179,6 +179,12 @@ export class ReviewDocumentCommentProvider implements vscode.Disposable, Comment
 			for (let fileName in this._reviewDocumentCommentThreads) {
 				let threads = this._reviewDocumentCommentThreads[fileName];
 				let visible = vscode.window.visibleTextEditors.find(editor => {
+					if (editor.document.uri.scheme !== 'review' && editor.document.uri.scheme === this._repository.rootUri.scheme && editor.document.uri.query) {
+						if (fileName === editor.document.uri.toString()) {
+							return true;
+						}
+					}
+
 					if (editor.document.uri.scheme !== 'review') {
 						return false;
 					}
@@ -272,7 +278,7 @@ export class ReviewDocumentCommentProvider implements vscode.Disposable, Comment
 			return;
 		}
 
-		if (editor.document.uri.scheme !== 'review' && editor.document.uri.scheme === this._repository.rootUri.scheme) {
+		if (editor.document.uri.scheme !== 'review' && editor.document.uri.scheme === this._repository.rootUri.scheme && !editor.document.uri.query) {
 			let fileName = vscode.workspace.asRelativePath(editor.document.uri.path);
 			// local files
 			let matchedFiles = this._localFileChanges.filter(fileChange => fileChange.fileName === fileName);


### PR DESCRIPTION
Fix #1089.

This bug was caused by a feature we added to the "Changes In Pull Request" view. When users browse this viewlet, they expect the right side editor to be editable. However, we can't simply use local file for the right side editor, because

* Workspace files display comments on both original content and modified content. Say there is a comment on the left diff editor and another comment on the right diff editor on github.com, we will display both of them in workspace file.
* For "Changes In Pull Request" file diff view, if the right side editor shows the normal workspace file, users will see duplicated comments

To solve this problem, we add `ReviewParams`  query to right side `file` scheme document. https://github.com/Microsoft/vscode-pull-request-github/blob/2ceb7f61089d06a2ae117175efeef493cb8c9d1d/src/view/reviewManager.ts#L388

Now with the new API, we create comment threads for workspace files (`file://Users/abc/vscode/packaeg.json`) when we detect the repository is in review mode. However no one takes care of `file` scheme documents with `ReviewParams` query.