### PR TITLE
Use vscode.env.uriScheme for callback.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "version": "0.5.1",
   "publisher": "GitHub",
   "engines": {
-    "vscode": "^1.32.0"
+    "vscode": "^1.34.0"
   },
   "categories": [
     "Other"

--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -15,9 +15,7 @@ const GHE_OPTIONAL_SCOPES: { [key: string]: boolean } = {'write:discussion': tru
 
 const AUTH_RELAY_SERVER = 'https://vscode-auth.github.com';
 const CALLBACK_PATH = '/did-authenticate';
-const CALLBACK_URI = vscode.version.endsWith('-insider')
-	? `vscode-insiders://${EXTENSION_ID}${CALLBACK_PATH}`
-	: `vscode://${EXTENSION_ID}${CALLBACK_PATH}`;
+const CALLBACK_URI = `${vscode.env.uriScheme}://${EXTENSION_ID}${CALLBACK_PATH}`;
 const MAX_TOKEN_RESPONSE_AGE = 5 * (1000 * 60 /* minutes in ms */);
 
 export class GitHubManager {

--- a/src/typings/vscode.proposed.d.ts
+++ b/src/typings/vscode.proposed.d.ts
@@ -645,6 +645,11 @@ declare module 'vscode' {
 		 * An [event](#Event) that fires when the log level has changed.
 		 */
 		export const onDidChangeLogLevel: Event<LogLevel>;
+
+		/**
+		 * The custom uri scheme the editor registers to in the operating system, like 'vscode', 'vscode-insiders'.
+		 */
+		export const uriScheme: string;
 	}
 
 	//#endregion


### PR DESCRIPTION
Instead of guessing the URI scheme, we now use `vscode.env.uriScheme` to construct the callback url.

We merge this only after we release the next version of VS Code, as this one requires 1.34