### PR TITLE
Add more telemetry

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -367,6 +367,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.deleteThread', async (thread: vscode.CommentThread) => {
+		telemetry.on('pr.deleteThread');
 		thread.dispose!();
 	}));
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -177,8 +177,10 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		}
 
 		if (error) {
+			telemetry.on('pr.deleteLocalPullRequest.failure');
 			await vscode.window.showErrorMessage(`Deleting local pull request branch failed: ${error}`);
 		} else {
+			telemetry.on('pr.deleteLocalPullRequest.success');
 			// fire and forget
 			vscode.commands.executeCommand('pr.refreshList');
 		}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -217,9 +217,11 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 				try {
 					newPR = await prManager.mergePullRequest(pullRequest);
 					vscode.commands.executeCommand('pr.refreshList');
+					telemetry.on('pr.merge.success');
 					return newPR;
 				} catch (e) {
 					vscode.window.showErrorMessage(`Unable to merge pull request. ${formatError(e)}`);
+					telemetry.on('pr.merge.failure');
 					return newPR;
 				}
 			}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -337,26 +337,32 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.replyComment', async (handler: CommentHandler, thread: vscode.CommentThread) => {
+		telemetry.on('pr.replyComment');
 		handler.createOrReplyComment(thread);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.startReview', async (handler: CommentHandler, thread: vscode.CommentThread) => {
+		telemetry.on('pr.startReview');
 		handler.startReview(thread);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.finishReview', async (handler: CommentHandler, thread: vscode.CommentThread) => {
+		telemetry.on('pr.finishReview');
 		await handler.finishReview(thread);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.deleteReview', async (handler: CommentHandler) => {
+		telemetry.on('pr.deleteReview');
 		await handler.deleteReview();
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.editComment', async (handler: CommentHandler, thread: vscode.CommentThread, comment: vscode.Comment) => {
+		telemetry.on('pr.editComment');
 		await handler.editComment(thread, comment);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.deleteComment', async (handler: CommentHandler, thread: vscode.CommentThread, comment: vscode.Comment) => {
+		telemetry.on('pr.deleteComment');
 		await handler.deleteComment(thread, comment);
 	}));
 

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -201,9 +201,11 @@ export class CredentialStore {
 		await graphql.query({ query: gql `query { viewer { login } }` })
 			.then(result => {
 				Logger.appendLine(`${baseUrl}: GraphQL support detected`);
+				this._telemetry.on('auth.graphql.supported');
 			})
 			.catch(err => {
 				Logger.appendLine(`${baseUrl}: GraphQL not supported (${err.message})`);
+				this._telemetry.on('auth.graphql.unsupported');
 				supportsGraphQL = false;
 			});
 


### PR DESCRIPTION
addresses https://github.com/Microsoft/vscode-pull-request-github/issues/1029

### Metrics added

- [x] How many users are GitHub users compared to GitHub Enterprise users?  Is it possible to know what version of Enterprise customers are on?

I did not see an easy way to see which users are enterprise users from the extension (although perhaps it might be easier from the auth server).  Super open to suggestions about how to approach this, though!

Do we really care about enterprise versions?  Or do we care about graphQL support?  I figured it was the latter, and added some metrics at the time we check for graphQL support.  One concern that I have is that it looks like this code is called every time we make a request.  It seems like some caching would be useful here.  Anyhow, on the dashboard side we should make sure we are de duping this query by UUID or something, so we get the number of users with supported graphQL versions and not just the number of requests.

- [x] How many times are pull requests are merged? closed?
Closed pull requests are already being logged and on the dashboard, but I added metrics for merging success and failure.

- [x] How many times is the local pull request branch deleted?
Added success and failure metrics.

- [x] How many times an inline/review comment is added?
Added metrics for replying to a comment, starting a review, finishing a review, deleting a review, editing a comment, deleting a comment, and deleting a thread.  

- [ ] how many times users click the GitHub icon on the activity bar.
It looks like this icon is defined by configuration in `package.json` but it looks like the click handling is handled outside of the code for the extension.  Is that correct?  Or am I missing something? 

### Verification plan
- [x]  used `Logger.appendLine` and ran through each of these activities.  