### PR TITLE
Guard PR data

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -221,6 +221,13 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 			});
 
 			const hasMorePages = !!result.headers.link && result.headers.link.indexOf('rel="next"') > -1;
+			if (!result.data) {
+				return {
+					pullRequests: [],
+					hasMorePages: false,
+				};
+			}
+
 			const pullRequests = result.data
 				.map(
 					pullRequest => {

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -222,6 +222,9 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 
 			const hasMorePages = !!result.headers.link && result.headers.link.indexOf('rel="next"') > -1;
 			if (!result.data) {
+				// We really don't expect this to happen, but it seems to (see #574).
+				// Log a warning and return an empty set.
+				Logger.appendLine(`Warning: no result data for ${remote.owner}/${remote.repositoryName} Status: ${result.status}`);
 				return {
 					pullRequests: [],
 					hasMorePages: false,


### PR DESCRIPTION
This addresses the error seen by users in #574. I don't know that it'll address the underlying problem, which is that `result` should always return data, but perhaps it'll stop masking it.