### PR TITLE
On checkout, make sure existing remote is found so that existing branch can be checked out

### DIFF
--- a/src/github/pullRequestGitHelper.ts
+++ b/src/github/pullRequestGitHelper.ts
@@ -10,7 +10,6 @@
 import Logger from '../common/logger';
 import { Protocol } from '../common/protocol';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
-import { GitHubRepository } from './githubRepository';
 import { Repository, Branch } from '../api/api';
 import { PullRequestModel } from './pullRequestModel';
 
@@ -44,8 +43,8 @@ export class PullRequestGitHelper {
 		PullRequestGitHelper.associateBranchWithPullRequest(repository, pullRequest, localBranchName);
 	}
 
-	static async fetchAndCheckout(repository: Repository, githubRepositories: GitHubRepository[], pullRequest: PullRequestModel): Promise<void> {
-		const remote = PullRequestGitHelper.getHeadRemoteForPullRequest(repository, githubRepositories, pullRequest);
+	static async fetchAndCheckout(repository: Repository, remotes: Remote[], pullRequest: PullRequestModel): Promise<void> {
+		const remote = PullRequestGitHelper.getHeadRemoteForPullRequest(remotes, pullRequest);
 		if (!remote) {
 			return PullRequestGitHelper.checkoutFromFork(repository, pullRequest);
 		}
@@ -85,7 +84,7 @@ export class PullRequestGitHelper {
 		await PullRequestGitHelper.associateBranchWithPullRequest(repository, pullRequest, branchName);
 	}
 
-	static async checkoutExistingPullRequestBranch(repository: Repository, githubRepositories: GitHubRepository[], pullRequest: PullRequestModel) {
+	static async checkoutExistingPullRequestBranch(repository: Repository, pullRequest: PullRequestModel) {
 		let key = PullRequestGitHelper.buildPullRequestMetadata(pullRequest);
 		let configs = await repository.getConfigs();
 
@@ -223,15 +222,8 @@ export class PullRequestGitHelper {
 		return uniqueName;
 	}
 
-	static getHeadRemoteForPullRequest(repository: Repository, githubRepositories: GitHubRepository[], pullRequest: PullRequestModel): Remote | undefined {
-		for (let i = 0; i < githubRepositories.length; i++) {
-			let remote = githubRepositories[i].remote;
-			if (remote.gitProtocol && remote.gitProtocol.equals(pullRequest.head.repositoryCloneUrl)) {
-				return remote;
-			}
-		}
-
-		return;
+	static getHeadRemoteForPullRequest(remotes: Remote[], pullRequest: PullRequestModel): Remote | undefined {
+		return remotes.find(remote => remote.gitProtocol && remote.gitProtocol.equals(pullRequest.head.repositoryCloneUrl));
 	}
 
 	static async associateBranchWithPullRequest(repository: Repository, pullRequest: PullRequestModel, branchName: string) {

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -97,6 +97,7 @@ export class PullRequestManager {
 	private _activePullRequest?: PullRequestModel;
 	private _credentialStore: CredentialStore;
 	private _githubRepositories: GitHubRepository[];
+	private _allGitHubRemotes: Remote[] = [];
 	private _mentionableUsers?: { [key: string]: IAccount[] };
 	private _fetchMentionableUsersPromise?: Promise<{ [key: string]: IAccount[] }>;
 	private _gitBlameCache: { [key: string]: string } = {};
@@ -350,7 +351,7 @@ export class PullRequestManager {
 		Logger.debug('update repositories', PullRequestManager.ID);
 		const remotes = parseRepositoryRemotes(this.repository);
 		const potentialRemotes = remotes.filter(remote => remote.host);
-		const allGitHubRemotes = await Promise.all(potentialRemotes.map(remote => this._githubManager.isGitHub(remote.gitProtocol.normalizeUri()!)))
+		this._allGitHubRemotes = await Promise.all(potentialRemotes.map(remote => this._githubManager.isGitHub(remote.gitProtocol.normalizeUri()!)))
 			.then(results => potentialRemotes.filter((_, index, __) => results[index]))
 			.catch(e => {
 				Logger.appendLine(`Resolving GitHub remotes failed: ${formatError(e)}`);
@@ -358,7 +359,7 @@ export class PullRequestManager {
 				return [];
 			});
 
-		const activeRemotes = await this.getActiveGitHubRemotes(allGitHubRemotes);
+		const activeRemotes = await this.getActiveGitHubRemotes(this._allGitHubRemotes);
 
 		if (activeRemotes.length) {
 			await vscode.commands.executeCommand('setContext', 'github:hasGitHubRemotes', true);
@@ -442,6 +443,10 @@ export class PullRequestManager {
 		});
 	}
 
+	/**
+	 * Returns the remotes that are currently active, which is those that are important by convention (origin, upstream),
+	 * or the remotes configured by the setting githubPullRequests.remotes
+	 */
 	getGitHubRemotes(): Remote[] {
 		const githubRepositories = this._githubRepositories;
 
@@ -450,6 +455,13 @@ export class PullRequestManager {
 		}
 
 		return githubRepositories.map(repository => repository.remote);
+	}
+
+	/**
+	 * Returns all remotes from the repository.
+	 */
+	getAllGitHubRemotes(): Remote[] {
+		return this._allGitHubRemotes;
 	}
 
 	async authenticate(): Promise<boolean> {
@@ -1407,11 +1419,11 @@ export class PullRequestManager {
 	}
 
 	async checkoutExistingPullRequestBranch(pullRequest: PullRequestModel): Promise<boolean> {
-		return await PullRequestGitHelper.checkoutExistingPullRequestBranch(this.repository, this._githubRepositories, pullRequest);
+		return await PullRequestGitHelper.checkoutExistingPullRequestBranch(this.repository, pullRequest);
 	}
 
 	async fetchAndCheckout(pullRequest: PullRequestModel): Promise<void> {
-		await PullRequestGitHelper.fetchAndCheckout(this.repository, this._githubRepositories, pullRequest);
+		await PullRequestGitHelper.fetchAndCheckout(this.repository, this._allGitHubRemotes, pullRequest);
 	}
 
 	async checkout(branchName: string): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/1135

Our checkout process forks a couple of times - first we check to see if we have already added a key-value pair to the .git/config indicating that a branch is associated with a PR.

If that fails, we then check if there is already a remote for the branch we are trying to switch to. If there's no remote, we create one and create the branch with the pr/user/number pattern. The bug here was with matching the remote - we were looking at remotes that are "active", those we are actually using to display PRs from, and not all of the remotes in the repo. So even if a user already had both a remote from a fork and the local branch, we would fail to match the remote and then create a pr/user/number branch.