### PR TITLE
Preventing load of avatars on GitHub Enterprise

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -243,9 +243,7 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 							return null;
 						}
 
-						const item = convertRESTPullRequestToRawPullRequest(pullRequest, this);
-
-						return new PullRequestModel(this, this.remote, item);
+						return new PullRequestModel(this, this.remote, convertRESTPullRequestToRawPullRequest(pullRequest, this));
 					}
 				)
 				.filter(item => item !== null) as PullRequestModel[];
@@ -299,8 +297,7 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 					return null;
 				}
 
-				const item = convertRESTPullRequestToRawPullRequest(response.data, this);
-				return new PullRequestModel(this, this.remote, item);
+				return new PullRequestModel(this, this.remote, convertRESTPullRequestToRawPullRequest(response.data, this));
 			}).filter(item => item !== null) as PullRequestModel[];
 
 			Logger.debug(`Fetch pull request catogory ${PRType[prType]} - done`, GitHubRepository.ID);
@@ -336,7 +333,7 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 				});
 				Logger.debug(`Fetch pull request ${id} - done`, GitHubRepository.ID);
 
-				return new PullRequestModel(this, remote, parseGraphQLPullRequest(data));
+				return new PullRequestModel(this, remote, parseGraphQLPullRequest(data, this));
 			} else {
 				let { data } = await octokit.pullRequests.get({
 					owner: remote.owner,
@@ -350,8 +347,7 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 					return;
 				}
 
-				let item = convertRESTPullRequestToRawPullRequest(data, this);
-				return new PullRequestModel(this, remote, item);
+				return new PullRequestModel(this, remote, convertRESTPullRequestToRawPullRequest(data, this));
 			}
 		} catch (e) {
 			Logger.appendLine(`GithubRepository> Unable to fetch PR: ${e}`);

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -30,11 +30,11 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 	static ID = 'GitHubRepository';
 	private _hub: GitHub | undefined;
 	private _initialized: boolean;
-	public readonly isGitHubDotCom: boolean;
 	private _metadata: any;
 	private _toDispose: vscode.Disposable[] = [];
 	public commentsController?: vscode.CommentController;
 	public commentsProvider?: PRDocumentCommentProvider;
+	public readonly isGitHubDotCom: boolean;
 
 	public get hub(): GitHub {
 		if (!this._hub) {

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -29,14 +29,14 @@ export class PullRequestModel {
 	}
 
 	public get userAvatar(): string | undefined {
-		if (this.prItem && this.githubRepository.isGitHubDotCom) {
+		if (this.prItem) {
 			return this.prItem.user.avatarUrl;
 		}
 
 		return undefined;
 	}
 	public get userAvatarUri(): vscode.Uri | undefined {
-		if (this.prItem && this.githubRepository.isGitHubDotCom) {
+		if (this.prItem) {
 			let key = this.userAvatar;
 			if (key) {
 				let uri = vscode.Uri.parse(`${key}&s=${64}`);

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -29,14 +29,14 @@ export class PullRequestModel {
 	}
 
 	public get userAvatar(): string | undefined {
-		if (this.prItem && this._repositoryReturnsAvatar) {
+		if (this.prItem && this.githubRepository.isGitHubDotCom) {
 			return this.prItem.user.avatarUrl;
 		}
 
 		return undefined;
 	}
 	public get userAvatarUri(): vscode.Uri | undefined {
-		if (this.prItem && this._repositoryReturnsAvatar) {
+		if (this.prItem && this.githubRepository.isGitHubDotCom) {
 			let key = this.userAvatar;
 			if (key) {
 				let uri = vscode.Uri.parse(`${key}&s=${64}`);
@@ -82,7 +82,7 @@ export class PullRequestModel {
 	public head: GitHubRef;
 	public base: GitHubRef;
 
-	constructor(public readonly githubRepository: GitHubRepository, public readonly remote: Remote, public prItem: PullRequest, private _repositoryReturnsAvatar: boolean) {
+	constructor(public readonly githubRepository: GitHubRepository, public readonly remote: Remote, public prItem: PullRequest) {
 		this.update(prItem);
 	}
 

--- a/src/test/github/pullRequestModel.test.ts
+++ b/src/test/github/pullRequestModel.test.ts
@@ -171,19 +171,19 @@ const pr: Octokit.PullRequestsGetResponse | Octokit.PullRequestsGetAllResponseIt
 
 describe('PullRequestModel', () => {
 	it('should return `state` properly as `open`', () => {
-		const open = new PullRequestModel(repo, remote, convertRESTPullRequestToRawPullRequest(pr), true);
+		const open = new PullRequestModel(repo, remote, convertRESTPullRequestToRawPullRequest(pr, repo));
 
 		assert.equal(open.state, PullRequestStateEnum.Open);
 	});
 
 	it('should return `state` properly as `closed`', () => {
-		const open = new PullRequestModel(repo, remote, convertRESTPullRequestToRawPullRequest({ ...pr, state: 'closed' }), true);
+		const open = new PullRequestModel(repo, remote, convertRESTPullRequestToRawPullRequest({ ...pr, state: 'closed' }, repo));
 
 		assert.equal(open.state, PullRequestStateEnum.Closed);
 	});
 
 	it('should return `state` properly as `merged`', () => {
-		const open = new PullRequestModel(repo, remote, convertRESTPullRequestToRawPullRequest({ ...pr, merged: true, state: 'closed' }), true);
+		const open = new PullRequestModel(repo, remote, convertRESTPullRequestToRawPullRequest({ ...pr, merged: true, state: 'closed' }, repo));
 
 		assert.equal(open.state, PullRequestStateEnum.Merged);
 	});


### PR DESCRIPTION
Related to #1125 #1145 #1146 #416 

After some research about GitHub Enterprise, I've learned that it will never return an avatar over the avatar url. The authentication needed for this is a cookie created by the GitHub Enterprise instance, we only have an OAuth Token.

I'm removing my previous messy attempts at attempting to check if the GitHub Enterprise instance returns an avatar or not.