### PR TITLE
Fix review comments

### DIFF
--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -202,30 +202,76 @@ export const CommentBody = ({ bodyHTML, body }: Embodied) =>
 
 export function AddComment({ pendingCommentText }: PullRequest) {
 		const { updatePR, comment } = useContext(PullRequestContext);
-		return <form id='comment-form' className='comment-form main-comment-form' onSubmit={onSubmit}>
+		const [ isBusy, setBusy ] = useState(false);
+		const onSubmit = useCallback(async evt => {
+			evt.preventDefault();
+			try {
+				setBusy(true);
+				await comment((evt.target as any).body.value);
+			} finally {
+				setBusy(false);
+			}
+		}, [comment]);
+
+		const onClose = useCallback(async evt => {
+			evt.preventDefault();
+			try {
+				setBusy(true);
+				await comment((evt.target as any).body.value);
+			} finally {
+				setBusy(false);
+			}
+		}, [comment]);
+
+		const onRequestChanges = useCallback(async evt => {
+			evt.preventDefault();
+			try {
+				setBusy(true);
+				await comment((evt.target as any).body.value);
+			} finally {
+				setBusy(false);
+			}
+		}, [comment]);
+
+		const onApprove = useCallback(async evt => {
+			evt.preventDefault();
+			try {
+				setBusy(true);
+				await comment((evt.target as any).body.value);
+			} finally {
+				setBusy(false);
+			}
+		}, [comment]);
+
+		return <form id='comment-form'
+			className='comment-form main-comment-form'
+			onSubmit={onSubmit}>
 			<textarea id='comment-textarea'
 				name='body'
-				onInput={({ target }) =>
-					updatePR({ pendingCommentText: (target as any).value })}
+				onInput={
+					({ target }) =>
+						updatePR({ pendingCommentText: (target as any).value })
+				}
 				value={pendingCommentText}
 				placeholder='Leave a comment' />
 			<div className='form-actions'>
-				<button id='close' className='secondary'>Close Pull Request</button>
+				<button id='close'
+					className='secondary'
+					disabled={isBusy}
+					onClick={onClose}>Close Pull Request</button>
 				<button id='request-changes'
-					disabled={!pendingCommentText}
-					className='secondary'>Request Changes</button>
+					disabled={isBusy || !pendingCommentText}
+					className='secondary'
+					onClick={onRequestChanges}>Request Changes</button>
 				<button id='approve'
-					className='secondary'>Approve</button>
+					className='secondary'
+					disabled={isBusy}
+					onClick={onApprove}>Approve</button>
 				<input id='reply'
 					value='Comment'
 					type='submit'
 					className='reply-button'
-					disabled={!pendingCommentText} />
+					disabled={isBusy || !pendingCommentText} />
 			</div>
 		</form>;
-
-		function onSubmit(evt) {
-			evt.preventDefault();
-			comment((evt.target as any).body.value);
-		}
 	}

--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -243,10 +243,10 @@ export function AddComment({ pendingCommentText }: PullRequest) {
 			e.preventDefault();
 			const command = e.target.dataset.command as CommentCommand;
 			submit({
-
-			});
+				approve, requestChanges, close
+			}[command]);
 		},
-		[submit]);
+		[submit, approve, requestChanges, close]);
 
 		return <form id='comment-form'
 			ref={form}

--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useContext, useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useContext, useState, useEffect, useRef, useCallback } from 'react';
 
 import Markdown from './markdown';
 import { Spaced, nbsp } from './space';
@@ -7,7 +7,7 @@ import { Avatar, AuthorLink } from './user';
 import Timestamp from './timestamp';
 import { Comment } from '../src/common/comment';
 import { PullRequest } from './cache';
-import PullRequestContext, { CommentCommand } from './context';
+import PullRequestContext from './context';
 import { editIcon, deleteIcon } from './icon';
 
 export type Props = Partial<Comment & PullRequest> & {
@@ -110,16 +110,16 @@ function CommentBox({
 	</div>;
 }
 
-type FormInputSet ={
+type FormInputSet = {
 	[name: string]: HTMLInputElement | HTMLTextAreaElement
-}
+};
 
 type EditCommentProps = {
 	id: number
 	body: string
 	onCancel: () => void
 	onSave: (body: string) => Promise<any>
-}
+};
 
 function EditComment({ id, body, onCancel, onSave }: EditCommentProps) {
 	const { updateDraft } = useContext(PullRequestContext);
@@ -241,10 +241,8 @@ export function AddComment({ pendingCommentText }: PullRequest) {
 	const onClick = useCallback(
 		e => {
 			e.preventDefault();
-			const command = e.target.dataset.command as CommentCommand;
-			submit({
-				approve, requestChanges, close
-			}[command]);
+			const { command } = e.target.dataset;
+			submit({ approve, requestChanges, close }[command]);
 		},
 		[submit, approve, requestChanges, close]);
 

--- a/preview-src/context.tsx
+++ b/preview-src/context.tsx
@@ -128,7 +128,11 @@ export class PRContext {
 			});
 		}
 		state.reviewers = reviewers;
-		state.events = [...state.events, review];
+		state.events = [
+			...state.events
+				.filter(e => isReviewEvent(e) ? e.state !== 'PENDING' : e),
+			review
+		];
 		this.updatePR(state);
 	}
 

--- a/preview-src/context.tsx
+++ b/preview-src/context.tsx
@@ -3,13 +3,7 @@ import { getMessageHandler, MessageHandler } from './message';
 import { PullRequest, getState, setState, updateState } from './cache';
 import { MergeMethod } from '../src/github/interface';
 import { Comment } from '../src/common/comment';
-import { EventType, ReviewEvent, isReviewEvent, TimelineEvent } from '../src/common/timelineEvent';
-
-export type CommentCommand =
-	'pr.comment' |
-	'pr.close' |
-	'pr.approve' |
-	'pr.request-changes';
+import { EventType, ReviewEvent, isReviewEvent } from '../src/common/timelineEvent';
 
 export class PRContext {
 	constructor(
@@ -106,6 +100,9 @@ export class PRContext {
 
 	public submit = async (body: string) =>
 		this.appendReview(await this.postMessage({ command: 'pr.submit', args: body }))
+
+	public close = async (body?: string) =>
+		this.appendReview(await this.postMessage({ command: 'pr.close', args: body }))
 
 	public removeReviewer = async (login: string) => {
 		await this.postMessage({ command: 'pr.remove-reviewer', args: login });

--- a/preview-src/context.tsx
+++ b/preview-src/context.tsx
@@ -3,7 +3,13 @@ import { getMessageHandler, MessageHandler } from './message';
 import { PullRequest, getState, setState, updateState } from './cache';
 import { MergeMethod } from '../src/github/interface';
 import { Comment } from '../src/common/comment';
-import { EventType, ReviewEvent, isReviewEvent } from '../src/common/timelineEvent';
+import { EventType, ReviewEvent, isReviewEvent, TimelineEvent } from '../src/common/timelineEvent';
+
+export type CommentCommand =
+	'pr.comment' |
+	'pr.close' |
+	'pr.approve' |
+	'pr.request-changes';
 
 export class PRContext {
 	constructor(

--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -11,7 +11,6 @@ import Timestamp from './timestamp';
 import { CommentView, CommentBody } from './comment';
 import Diff from './diff';
 import PullRequestContext from './context';
-import { ReviewState } from '../src/github/interface';
 
 export const Timeline = ({ events }: { events: TimelineEvent[] }) =>
 	<>{
@@ -80,7 +79,6 @@ const reviewDescriptor = (state: string) =>
 	DESCRIPTORS[state] || 'reviewed';
 
 const ReviewEventView = (event: ReviewEvent) => {
-	console.log(event)
 	const comments = groupCommentsByPath(event.comments);
 	return <div className='comment-container comment'>
 		<div className='review-comment-container'>

--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -95,7 +95,7 @@ const ReviewEventView = (event: ReviewEvent) => {
 				</Spaced>
 			</div>
 			{
-				event.state !== 'PENDING'
+				event.state !== 'PENDING' && event.body
 					? <CommentBody body={event.body} />
 					: null
 			}


### PR DESCRIPTION
@kuychaco and I discovered and fixed some issues with review comments on the overview page.

In particular, we now:
  * send the correct events in response to the end-of-overview-page buttons (we weren't)
  * show review the body of reviews (we weren't)
  * customize the "reviewed" string based on the review type (we weren't; I think we weren't even before the React PR, but anyway, we are now)

We unearthed all this while making an ergonomic tweak. Namely, we now accept ⌘Enter and C-Enter to submit a comment.