### PR TITLE
Fix a test failure on master.

### DIFF
--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -70,7 +70,7 @@ describe('Protocol', () => {
 
 	it('should handle local remotes', () =>
 		[
-			{ uri: '/opt/git/project.git', expectedType: ProtocolType.OTHER, expectedHost: '', expectedOwner: '', expectedRepositoryName: '' },
+			{ uri: '/opt/git/project.git', expectedType: ProtocolType.Local, expectedHost: '', expectedOwner: '', expectedRepositoryName: '' },
 			{ uri: 'file:///opt/git/project.git', expectedType: ProtocolType.Local, expectedHost: '', expectedOwner: '', expectedRepositoryName: '' }
 		].forEach(testRemote)
 	);


### PR DESCRIPTION

It looks like the behavior of vscode.Uri has changed at some point to recognize file paths like '/opt/git/project.git' as `file:` scheme URLs.

Our tests were very surprised by this.

Co-Authored-By: kuychaco@github.com