### PR TITLE
URI encode base and head parameters

### DIFF
--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -1297,8 +1297,8 @@ export class PullRequestManager {
 		const { data } = await octokit.repos.compareCommits({
 			repo: remote.repositoryName,
 			owner: remote.owner,
-			base: `${pullRequest.base.repositoryCloneUrl.owner}:${pullRequest.base.ref}`,
-			head: `${pullRequest.head.repositoryCloneUrl.owner}:${pullRequest.head.ref}`
+			base: `${pullRequest.base.repositoryCloneUrl.owner}:${encodeURIComponent(pullRequest.base.ref)}`,
+			head: `${pullRequest.head.repositoryCloneUrl.owner}:${encodeURIComponent(pullRequest.head.ref)}`
 		});
 
 		pullRequest.mergeBase = data.merge_base_commit.sha;
@@ -1381,8 +1381,8 @@ export class PullRequestManager {
 				const { data } = await octokit.repos.compareCommits({
 					repo: remote.repositoryName,
 					owner: remote.owner,
-					base: `${pullRequest.base.repositoryCloneUrl.owner}:${pullRequest.base.ref}`,
-					head: `${pullRequest.head.repositoryCloneUrl.owner}:${pullRequest.head.ref}`
+					base: `${pullRequest.base.repositoryCloneUrl.owner}:${encodeURIComponent(pullRequest.base.ref)}`,
+					head: `${pullRequest.head.repositoryCloneUrl.owner}:${encodeURIComponent(pullRequest.head.ref)}`
 				});
 
 				pullRequest.mergeBase = data.merge_base_commit.sha;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/1059

octokit/rest is not URI encoding parameters passed to it https://github.com/octokit/rest.js/issues/1355