### PR TITLE
Avoid constructing Protocols with empty strings

### DIFF
--- a/src/test/github/pullRequestModel.test.ts
+++ b/src/test/github/pullRequestModel.test.ts
@@ -13,7 +13,7 @@ const telemetry = {
 	shutdown: () => Promise.resolve()
 };
 const credentials = new CredentialStore(telemetry);
-const protocol = new Protocol('');
+const protocol = new Protocol('https://github.com/github/test.git');
 const remote = new Remote('test', 'github/test', protocol);
 const repo = new GitHubRepository(remote, credentials);
 const user: Octokit.PullRequestsGetAllResponseItemUser = {
@@ -84,7 +84,7 @@ const githubRepo: Octokit.PullRequestsGetResponseHeadRepo = {
 	tags_url: '',
 	teams_url: '',
 	trees_url: '',
-	clone_url: '',
+	clone_url: 'https://github.com/owner/name.git',
 	mirror_url: '',
 	hooks_url: '',
 	svn_url: '',
@@ -132,12 +132,12 @@ const pr: Octokit.PullRequestsGetResponse | Octokit.PullRequestsGetAllResponseIt
 	milestone: null,
 	locked: false,
 	active_lock_reason: '',
-	closed_at: null,
-	merged_at: null,
-	_links: null,
-	merge_commit_sha: null,
+	closed_at: undefined,
+	merged_at: undefined,
+	_links: undefined,
+	merge_commit_sha: undefined,
 	mergeable: true,
-	merged_by: null,
+	merged_by: undefined,
 	additions:1,
 	deletions: 1,
 	changed_files: 1,


### PR DESCRIPTION
Without this in place, running the `PullRequestModel` tests produces a number of stack traces within the test output:

```
[object Object]
    at /Users/smashwilson/src/microsoft/vscode-pull-request-github/.vscode-test/vscode-1.34.0/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:120:484
    at new f (/Users/smashwilson/src/microsoft/vscode-pull-request-github/.vscode-test/vscode-1.34.0/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:120:557)
    at new p (/Users/smashwilson/src/microsoft/vscode-pull-request-github/.vscode-test/vscode-1.34.0/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:122:808)
    at Function.parse (/Users/smashwilson/src/microsoft/vscode-pull-request-github/.vscode-test/vscode-1.34.0/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:122:157)
    at new Protocol (/Users/smashwilson/src/microsoft/vscode-pull-request-github/src/common/protocol.ts:40:26)
    at new GitHubRef (/Users/smashwilson/src/microsoft/vscode-pull-request-github/src/common/githubRef.ts:16:29)
    at PullRequestModel.update (/Users/smashwilson/src/microsoft/vscode-pull-request-github/src/github/pullRequestModel.ts:109:15)
    at new PullRequestModel (/Users/smashwilson/src/microsoft/vscode-pull-request-github/src/github/pullRequestModel.ts:86:8)
    at Context.it (/Users/smashwilson/src/microsoft/vscode-pull-request-github/src/test/github/pullRequestModel.test.ts:174:16)
    at callFn (/Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runnable.js:354:21)
    at Test.Runnable.run (/Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runnable.js:346:7)
    at Runner.runTest (/Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runner.js:442:10)
    at /Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runner.js:560:12
    at next (/Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runner.js:356:14)
    at /Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runner.js:366:7
    at next (/Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runner.js:290:14)
    at Immediate._onImmediate (/Users/smashwilson/src/microsoft/vscode-pull-request-github/node_modules/vscode/node_modules/mocha/lib/runner.js:334:5)
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
```

Non-fatal, but noisy. Let's use more parseable URIs and clean that up a bit.