### PR TITLE
Make sure author association is set on review events

### DIFF
--- a/src/common/timelineEvent.ts
+++ b/src/common/timelineEvent.ts
@@ -55,7 +55,6 @@ export interface CommitEvent {
 	author: IAccount;
 	event: EventType;
 	sha: string;
-	url: string;
 	htmlUrl: string;
 	message: string;
 	bodyHTML?: string;

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -6,6 +6,7 @@
 export interface MergedEvent {
 	__typename: string;
 	id: string;
+	databaseId: number;
 	actor: {
 		login: string;
 		avatarUrl: string;
@@ -88,6 +89,7 @@ export interface ReviewComment {
 export interface Commit {
 	__typename: string;
 	id: string;
+	databaseId: number;
 	author: {
 		user: {
 			login: string;
@@ -106,6 +108,7 @@ export interface Commit {
 
 export interface AssignedEvent {
 	__typename: string;
+	databaseId: number;
 	actor: {
 		login: string;
 		avatarUrl: string;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/1175

We do authorAssocation.toLowerCase() in the WebView, but were not correctly setting authorAssocation on review events when using the REST API. There's still an "any" that's destroying type safety in the function converting the REST response to normalized form, we need to update our octokit typings. I removed some casts in our GraphQL conversion function that were preventing type checking.