### PR TITLE
Correct text alignment in merged timeline events

### DIFF
--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -149,13 +149,12 @@ const MergedEventView = (event: MergedEvent) =>
 			</div>
 			<AuthorLink for={event.user} />
 			<div className='message'>
-				merged commit
-				<a className='sha' href={event.commitUrl}>{event.sha.substr(0, 7)}</a>
-				into
-				{event.mergeRef}
+				merged commit{nbsp}
+				<a className='sha' href={event.commitUrl}>{event.sha.substr(0, 7)}</a>{nbsp}
+				into {event.mergeRef}{nbsp}
 			</div>
+			<Timestamp href={event.url} date={event.createdAt} />
 		</div>
-		<Timestamp href={event.url} date={event.createdAt} />
 	</div>;
 
 // TODO: We should show these, but the pre-React overview page didn't. Add


### PR DESCRIPTION
Add `&nbsp;` characters and shuffle markup to align inline text elements within the "merged" event views.

| Before | After |
| -- | -- |
| <img width="549" alt="before" src="https://user-images.githubusercontent.com/17565/58908379-69f47180-86de-11e9-8eb5-aded6d3e023d.png"> | <img width="677" alt="after" src="https://user-images.githubusercontent.com/17565/58908391-72e54300-86de-11e9-87b2-3b2f32695c62.png"> |

Fixes #1199.