### PR TITLE
Change "wants to merge" text when viewing merged PR

### DIFF
--- a/preview-src/header.tsx
+++ b/preview-src/header.tsx
@@ -18,7 +18,8 @@ export function Header({ canEdit, state, head, base, title, number, url, created
 			<Avatar for={author} />
 			<span className='author'>
 				<Spaced>
-					<AuthorLink for={author} /> wants to merge changes
+					<AuthorLink for={author} />
+					{getActionText(state)}
 					into <code>{base}</code>
 					from <code>{head}</code>
 				</Spaced>.
@@ -104,5 +105,13 @@ export function getStatus(state: PullRequestStateEnum) {
 		return 'Open';
 	} else {
 		return 'Closed';
+	}
+}
+
+export function getActionText(state: PullRequestStateEnum) {
+	if (state === PullRequestStateEnum.Merged) {
+		return 'merged changes';
+	} else {
+		return 'wants to merge changes';
 	}
 }

--- a/preview-src/header.tsx
+++ b/preview-src/header.tsx
@@ -108,7 +108,7 @@ export function getStatus(state: PullRequestStateEnum) {
 	}
 }
 
-export function getActionText(state: PullRequestStateEnum) {
+function getActionText(state: PullRequestStateEnum) {
 	if (state === PullRequestStateEnum.Merged) {
 		return 'merged changes';
 	} else {


### PR DESCRIPTION
When viewing an unmerged pull request, the header looks like so:

<img width="700" alt="before-merge" src="https://user-images.githubusercontent.com/17565/58909596-7f1ecf80-86e1-11e9-9ad2-57412d18b8f3.png">

When viewing a merged pull request, it now reads as:

<img width="700" alt="after-merged" src="https://user-images.githubusercontent.com/17565/58909610-87770a80-86e1-11e9-83b1-2dc55db20961.png">

Fixes #1027.