### PR TITLE
Fix username suggestions for comments in editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "version": "0.7.0",
   "publisher": "GitHub",
   "engines": {
-    "vscode": "^1.34.0"
+    "vscode": "^1.35.0"
   },
   "categories": [
     "Other"

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -64,6 +64,14 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 
 	}
 
+	public getCommentsProviderId(): string | undefined {
+		if (!this.commentsController) {
+			return undefined;
+		}
+
+		return this.commentsController.id;
+	}
+
 	dispose() {
 		this._toDispose.forEach(d => d.dispose());
 	}

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -64,7 +64,7 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 
 	}
 
-	public getCommentsProviderId(): string | undefined {
+	public getCommentsControllerId(): string | undefined {
 		if (!this.commentsController) {
 			return undefined;
 		}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -18,7 +18,6 @@ import { GitHubManager } from '../authentication/githubServer';
 import { formatError, uniqBy, Predicate } from '../common/utils';
 import { Repository, RefType, UpstreamRef } from '../api/api';
 import Logger from '../common/logger';
-import { EXTENSION_ID } from '../constants';
 import { fromPRUri } from '../common/uri';
 import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount, convertRESTReviewEvent, parseGraphQLReviewEvent } from './utils';
 import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse, EditCommentResponse, DeleteReactionResponse, AddReactionResponse } from './graphql';
@@ -171,8 +170,8 @@ export class PullRequestManager {
 		vscode.languages.registerCompletionItemProvider({ scheme: 'comment' }, {
 			provideCompletionItems: async (document, position, token) => {
 				try {
-					let query = JSON.parse(document.uri.query);
-					if (query.extensionId !== EXTENSION_ID) {
+					const commentControllerId = document.uri.authority;
+					if (!this._githubRepositories.some(repo => repo.getCommentsProviderId() === commentControllerId)) {
 						return;
 					}
 

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -171,7 +171,7 @@ export class PullRequestManager {
 			provideCompletionItems: async (document, position, token) => {
 				try {
 					const commentControllerId = document.uri.authority;
-					if (!this._githubRepositories.some(repo => repo.getCommentsProviderId() === commentControllerId)) {
+					if (!this._githubRepositories.some(repo => repo.getCommentsControllerId() === commentControllerId)) {
 						return;
 					}
 


### PR DESCRIPTION
When typing '@' in a comment inside an editor, autocompletions for GitHub users should show up.

The comment widget within VS Code is itself an editor that has some URL associated with it. Previously, VS Code would encode the extensionId into the query of this URL, which we would parse and check to see if we should provide suggestions. While doing the comments API update, we modified the comment URL to have the comment controller id as the authority of the URL. We want to deprecate having the extensionId in the query, and it's also buggy right now (I just fixed it with https://github.com/microsoft/vscode/commit/83ef31e6a2feb6b55464dfff481c6f1972aab522), so moving to checking the comment controller id instead