### PR TITLE
Add pr updated event, add updatePullRequestBody function

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Uri, Event, Disposable } from 'vscode';
+import { PullRequest } from '../github/interface';
 
 export const enum RefType {
 	Head,
@@ -221,4 +222,16 @@ export interface API {
 	 * @return A git provider or `undefined`
 	 */
 	getGitProvider(uri: Uri): IGit | undefined;
+
+	/**
+	 * Event that is called when a pull request is created.
+	 */
+	onPullRequestCreated: Event<PullRequest>;
+
+	/**
+	 * Update pull request body.
+	 * @param body The body of the pull request.
+	 * @param prNumber The number of the pull request.
+	 */
+	updatePullRequestBody(body: string, prNumber: number): void;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ fetch.Promise = PolyfillPromise;
 
 let telemetry: ITelemetry;
 
-async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: Repository, tree: PullRequestsTreeDataProvider): Promise<void> {
+async function init(context: vscode.ExtensionContext, api: ApiImpl, repository: Repository, tree: PullRequestsTreeDataProvider): Promise<void> {
 	context.subscriptions.push(Logger);
 	Logger.appendLine('Git repository found, initializing review manager and pr tree view.');
 
@@ -52,14 +52,15 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: 
 	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
 	context.subscriptions.push(new FileTypeDecorationProvider());
 
-	const prManager = new PullRequestManager(repository, telemetry);
+	const prManager = new PullRequestManager(api, repository, telemetry);
+	api.pullRequestManager = prManager;
 	context.subscriptions.push(prManager);
 
 	const reviewManager = new ReviewManager(context, repository, prManager, tree, telemetry);
 	tree.initialize(prManager);
 	registerCommands(context, prManager, reviewManager, telemetry);
 
-	git.repositories.forEach(repo => {
+	api.repositories.forEach(repo => {
 		repo.ui.onDidChange(() => {
 			// No multi-select support, always show last selected repo
 			if (repo.ui.selected) {
@@ -70,7 +71,7 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: 
 		});
 	});
 
-	git.onDidOpenRepository(repo => {
+	api.onDidOpenRepository(repo => {
 		repo.ui.onDidChange(() => {
 			if (repo.ui.selected) {
 				prManager.repository = repo;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -22,6 +22,7 @@ import { EXTENSION_ID } from '../constants';
 import { fromPRUri } from '../common/uri';
 import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount, convertRESTReviewEvent, parseGraphQLReviewEvent } from './utils';
 import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse, EditCommentResponse, DeleteReactionResponse, AddReactionResponse, MarkPullRequestReadyForReviewResponse } from './graphql';
+import { ApiImpl } from '../api/api1';
 const queries = require('./queries.gql');
 
 interface PageInformation {
@@ -109,6 +110,7 @@ export class PullRequestManager implements vscode.Disposable {
 	readonly onDidChangeActivePullRequest: vscode.Event<void> = this._onDidChangeActivePullRequest.event;
 
 	constructor(
+		private api: ApiImpl,
 		private _repository: Repository,
 		private readonly _telemetry: ITelemetry,
 		private _credentialStore: CredentialStore = new CredentialStore(_telemetry),
@@ -1084,6 +1086,33 @@ export class PullRequestManager implements vscode.Disposable {
 			const branchNameSeparatorIndex = params.head.indexOf(':');
 			const branchName = params.head.slice(branchNameSeparatorIndex + 1);
 			await PullRequestGitHelper.associateBranchWithPullRequest(this._repository, pullRequestModel, branchName);
+			const pullRequest: PullRequest = {
+				url: data.url,
+				number: data.number,
+				state: data.state,
+				body: data.body,
+				title: data.title,
+				assignee: data.assignee,
+				createdAt: data.created_at,
+				updatedAt: data.updated_at,
+				head: {
+					label: data.head.label,
+					ref: data.head.ref,
+					sha: data.head.sha,
+					repo: { cloneUrl: data.head.repo.clone_url }
+				},
+				base: {
+					label: data.base.label,
+					ref: data.base.ref,
+					sha: data.base.sha,
+					repo: { cloneUrl: data.base.repo.clone_url }
+				},
+				user: data.user,
+				labels: data.labels,
+				merged: false,
+				nodeId: data.node_id
+			};
+			this.api.onPullRequestCreatedEmitter.fire(pullRequest);
 
 			this._telemetry.on(`pr.create${params.draft ? 'Draft' : ''}.success`);
 			return pullRequestModel;

--- a/src/test/view/prsTree.test.ts
+++ b/src/test/view/prsTree.test.ts
@@ -19,6 +19,7 @@ import { Protocol } from '../../common/protocol';
 import { CredentialStore } from '../../github/credentials';
 import { parseGraphQLPullRequest } from '../../github/utils';
 import { Resource } from '../../common/resources';
+import { ApiImpl } from '../../api/api1';
 
 describe('GitHub Pull Requests view', function() {
 	let sinon: SinonSandbox;
@@ -79,7 +80,7 @@ describe('GitHub Pull Requests view', function() {
 		const repository = new MockRepository();
 		repository.addRemote('origin', 'git@github.com:aaa/bbb');
 
-		const manager = new PullRequestManager(repository, telemetry);
+		const manager = new PullRequestManager(new ApiImpl(), repository, telemetry);
 		sinon.stub(manager, 'createGitHubRepository').callsFake((remote, credentialStore) => {
 			return new MockGitHubRepository(remote, credentialStore, sinon);
 		});
@@ -144,7 +145,7 @@ describe('GitHub Pull Requests view', function() {
 
 			await repository.createBranch('non-pr-branch', false);
 
-			const manager = new PullRequestManager(repository, telemetry, credentialStore);
+			const manager = new PullRequestManager(new ApiImpl(), repository, telemetry, credentialStore);
 			sinon.stub(manager, 'createGitHubRepository').callsFake((r, cs) => {
 				assert.deepEqual(r, remote);
 				assert.strictEqual(cs, credentialStore);


### PR DESCRIPTION
Extend the plugins Api with 'pull-request created' event and `updatePullRequestBody()` function. I am going to create a plugin that would be used in [Eclipse-Che](https://github.com/eclipse/che). The plugin would catch the event and add a special link to the PR's description.