### PR TITLE
Sort label case-sensitively and adding semicolon

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -315,7 +315,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		if (PullRequestOverviewPanel.currentPanel) {
 			PullRequestOverviewPanel.refresh();
 		}
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDescriptionToTheSide', async (descriptionNode: DescriptionNode) => {
 		let pr = descriptionNode.pullRequestModel;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -543,6 +543,8 @@ export class PullRequestManager implements vscode.Disposable {
 				};
 			}));
 
+			results = results.sort((a,b)=> a.name.localeCompare(b.name));
+
 			hasNextPage = !!result.headers.link && result.headers.link.indexOf('rel="next"') > -1;
 			page += 1;
 		} while (hasNextPage);


### PR DESCRIPTION
Fixing issue #1008.

Changes:
1. Sort label case-insensitively
2. Add semicolon to uniform coding style

Sample result:
![labels](https://user-images.githubusercontent.com/1103763/60789083-642ff700-a188-11e9-9284-2ab25494ea6d.png)
