### PR TITLE
Description view of PR : whole commit line clickable

### DIFF
--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -37,7 +37,7 @@ export const Timeline = ({ events }: { events: TimelineEvent[] }) =>
 export default Timeline;
 
 const CommitEventView = (event: CommitEvent) =>
-	<div className='comment-container commit'>
+	<a className='comment-container commit' href={event.htmlUrl}>
 		<div className='commit-message'>
 			{commitIcon}{nbsp}
 			<div className='avatar-container'>
@@ -46,8 +46,8 @@ const CommitEventView = (event: CommitEvent) =>
 			<AuthorLink for={event.author} />
 			<div className='message'>{event.message}</div>
 		</div>
-		<a className='sha' href={event.htmlUrl}>{event.sha.slice(0, 7)}</a>
-	</div>;
+		<div className='sha'>{event.sha.slice(0, 7)}</div>
+	</a>;
 
 const association = (
 	{ authorAssociation }: ReviewEvent,

--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -37,17 +37,17 @@ export const Timeline = ({ events }: { events: TimelineEvent[] }) =>
 export default Timeline;
 
 const CommitEventView = (event: CommitEvent) =>
-	<a className='comment-container commit' href={event.htmlUrl}>
+	<div className='comment-container commit'>
 		<div className='commit-message'>
 			{commitIcon}{nbsp}
 			<div className='avatar-container'>
 				<Avatar for={event.author} />
 			</div>
 			<AuthorLink for={event.author} />
-			<div className='message'>{event.message}</div>
+			<a className='message' href={event.htmlUrl}>{event.message}</a>
 		</div>
-		<div className='sha'>{event.sha.slice(0, 7)}</div>
-	</a>;
+		<a className='sha' href={event.htmlUrl}>{event.sha.slice(0, 7)}</a>
+	</div>;
 
 const association = (
 	{ authorAssociation }: ReviewEvent,


### PR DESCRIPTION
This PR comes from: [Whole commit line should be clickable not only commit hash #221](https://github.com/microsoft/vscode-pull-request-github/issues/221).

**Initially**
Only the hash were clickable on commit lines in the description view of a pull request.

**Now**
All the line is clickable and leads to the current commit.

**_Little note_**
This is my first contribution to a project. I'm willing to hear advices and best practices if needed.