### PR TITLE
Fix file name calculation for windows

### DIFF
--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -391,7 +391,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 		}
 
 		if (document.uri.scheme === currentWorkspace.uri.scheme) {
-			const fileName = nodePath.relative(currentWorkspace!.uri.fsPath, document.uri.fsPath);
+			const fileName = vscode.workspace.asRelativePath(document.uri.path);
 			const matchedFiles = gitFileChangeNodeFilter(this._localFileChanges).filter(fileChange => fileChange.fileName === fileName);
 			let matchedFile: GitFileChangeNode;
 			let ranges = [];


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/1273

Using path from node was returning paths with `\` as a file separator. Using vscode.workspace.asRelative returns paths normalized with '/' as file separator