### PR TITLE
Ensure tree refreshes after sign in

### DIFF
--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
         },
         {
           "command": "auth.signout",
-          "when": "gitOpenRepositoryCount != 0"
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated"
         },
         {
           "command": "pr.configureRemotes",
@@ -450,11 +450,11 @@
         },
         {
           "command": "pr.create",
-          "when": "gitOpenRepositoryCount != 0 && !github:inReviewMode"
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated && !github:inReviewMode"
         },
         {
           "command": "pr.createDraft",
-          "when": "gitOpenRepositoryCount != 0 && !github:inReviewMode"
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated && !github:inReviewMode"
         },
         {
           "command": "pr.merge",
@@ -466,6 +466,10 @@
         },
         {
           "command": "pr.openPullRequestInGitHub",
+          "when": "gitOpenRepositoryCount != 0 && github:inReviewMode"
+        },
+        {
+          "command": "pr.refreshDescription",
           "when": "gitOpenRepositoryCount != 0 && github:inReviewMode"
         },
         {
@@ -494,7 +498,7 @@
         },
         {
           "command": "pr.refreshList",
-          "when": "gitOpenRepositoryCount != 0 && github:hasGitHubRemotes"
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated && github:hasGitHubRemotes"
         },
         {
           "command": "pr.refreshChanges",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,8 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: 
 		if (prManager) {
 			try {
 				await prManager.clearCredentialCache();
-				if (repository) {
-					repository.status();
+				if (reviewManager) {
+					reviewManager.updateState();
 				}
 				await tree.refresh();
 			} catch (e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,6 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: 
 				if (reviewManager) {
 					reviewManager.updateState();
 				}
-				await tree.refresh();
 			} catch (e) {
 				vscode.window.showErrorMessage(formatError(e));
 			}

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -148,7 +148,7 @@ export class CredentialStore implements vscode.Disposable {
 				const login = await server.login();
 				if (login && login.token) {
 					octokit = await this.createHub(login);
-					await setToken(login.host, login.token, { emit: false });
+					await setToken(login.host, login.token);
 					vscode.window.showInformationMessage(`You are now signed in to ${authority}`);
 				}
 			} catch (e) {

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import Octokit = require('@octokit/rest');
 import Logger from '../common/logger';
 import { Remote, parseRemote } from '../common/remote';
-import { IGitHubRepository, IAccount, MergeMethodsAvailability } from './interface';
+import { IAccount, MergeMethodsAvailability } from './interface';
 import { PullRequestModel } from './pullRequestModel';
 import { CredentialStore, GitHub } from './credentials';
 import { AuthenticationError } from '../common/authentication';
@@ -30,7 +30,7 @@ export interface IMetadata extends Octokit.ReposGetResponse {
 	currentUser: any;
 }
 
-export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
+export class GitHubRepository implements vscode.Disposable {
 	static ID = 'GitHubRepository';
 	protected _initialized: boolean;
 	protected _hub: GitHub | undefined;
@@ -155,16 +155,6 @@ export class GitHubRepository implements IGitHubRepository, vscode.Disposable {
 		}
 
 		return this;
-	}
-
-	async authenticate(): Promise<boolean> {
-		this._initialized = true;
-		if (!await this._credentialStore.hasOctokit(this.remote)) {
-			this._hub = await this._credentialStore.login(this.remote);
-		} else {
-			this._hub = this._credentialStore.getHub(this.remote);
-		}
-		return this.octokit !== undefined;
 	}
 
 	async getDefaultBranch(): Promise<string> {

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -92,10 +92,6 @@ export interface IPullRequestsPagingOptions {
 	fetchNextPage: boolean;
 }
 
-export interface IGitHubRepository {
-	authenticate(): Promise<boolean>;
-}
-
 export interface IPullRequestEditData {
 	body?: string;
 	title?: string;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -520,7 +520,6 @@ export class PullRequestManager implements vscode.Disposable {
 		});
 
 		return Promise.all(promises).then(_ => {
-			this.hasAuthenticated = wasSuccessful;
 			return wasSuccessful;
 		});
 	}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -531,8 +531,7 @@ export class PullRequestManager implements vscode.Disposable {
 
 	async authenticate(): Promise<boolean> {
 		let wasSuccessful = false;
-		const allGitHubRemotes = await this.getAllGitHubRemotes();
-		const activeRemotes = await this.getActiveGitHubRemotes(allGitHubRemotes);
+		const activeRemotes = await this.getActiveGitHubRemotes(this._allGitHubRemotes);
 
 		const promises = uniqBy(activeRemotes, x => x.normalizedHost).map(async remote => {
 			wasSuccessful = !!(await this._credentialStore.login(remote)) || wasSuccessful;

--- a/src/test/mocks/mockGitHubRepository.ts
+++ b/src/test/mocks/mockGitHubRepository.ts
@@ -45,10 +45,6 @@ export class MockGitHubRepository extends GitHubRepository {
 		return this;
 	}
 
-	async authenticate() {
-		return !this._options.failAuthentication;
-	}
-
 	get supportsGraphQl() {
 		return !this._options.noGraphQL;
 	}

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -9,7 +9,7 @@ import { PRCategoryActionNode, CategoryTreeNode, PRCategoryActionType } from './
 import { PRType } from '../github/interface';
 import { fromFileChangeNodeUri } from '../common/uri';
 import { getInMemPRContentProvider } from './inMemPRContentProvider';
-import { PullRequestManager, SETTINGS_NAMESPACE, REMOTES_SETTING, UpdateRepositoryState } from '../github/pullRequestManager';
+import { PullRequestManager, SETTINGS_NAMESPACE, REMOTES_SETTING } from '../github/pullRequestManager';
 import { ITelemetry } from '../common/telemetry';
 
 interface IQueryInfo {
@@ -119,8 +119,12 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 			}
 		}
 
+		if (!this._prManager.hasInitializedRepositories) {
+			return Promise.resolve([new PRCategoryActionNode(this._view, PRCategoryActionType.Initializing)]);
+		}
+
 		if (!this._prManager.getGitHubRemotes().length) {
-			if (this._prManager.state !== UpdateRepositoryState.Authenticated) {
+			if (!this._prManager.hasAuthenticated) {
 				return Promise.resolve([new PRCategoryActionNode(this._view, PRCategoryActionType.Login)]);
 			}
 

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -9,7 +9,7 @@ import { PRCategoryActionNode, CategoryTreeNode, PRCategoryActionType } from './
 import { PRType } from '../github/interface';
 import { fromFileChangeNodeUri } from '../common/uri';
 import { getInMemPRContentProvider } from './inMemPRContentProvider';
-import { PullRequestManager, SETTINGS_NAMESPACE, REMOTES_SETTING } from '../github/pullRequestManager';
+import { PullRequestManager, SETTINGS_NAMESPACE, REMOTES_SETTING, PRManagerState } from '../github/pullRequestManager';
 import { ITelemetry } from '../common/telemetry';
 
 interface IQueryInfo {
@@ -83,6 +83,9 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 
 		this._initialized = true;
 		this._prManager = prManager;
+		this._disposables.push(this._prManager.onDidChangeState(() => {
+			this._onDidChangeTreeData.fire();
+		}));
 		this.initializeCategories();
 		this.refresh();
 	}
@@ -119,12 +122,12 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 			}
 		}
 
-		if (!this._prManager.hasInitializedRepositories) {
+		if (this._prManager.state === PRManagerState.Initializing) {
 			return Promise.resolve([new PRCategoryActionNode(this._view, PRCategoryActionType.Initializing)]);
 		}
 
 		if (!this._prManager.getGitHubRemotes().length) {
-			if (!this._prManager.hasAuthenticated) {
+			if (this._prManager.state === PRManagerState.NeedsAuthentication) {
 				return Promise.resolve([new PRCategoryActionNode(this._view, PRCategoryActionType.Login)]);
 			}
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -232,7 +232,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		}, 1000 * 30);
 	}
 
-	private async updateState() {
+	public async updateState() {
 		if (this.switchingToReviewMode) {
 			return;
 		}

--- a/src/view/treeNodes/categoryNode.ts
+++ b/src/view/treeNodes/categoryNode.ts
@@ -22,7 +22,8 @@ export enum PRCategoryActionType {
 	NoGitRepositories,
 	NoOpenFolder,
 	NoMatchingRemotes,
-	ConfigureRemotes
+	ConfigureRemotes,
+	Initializing
 }
 
 export class PRCategoryActionNode extends TreeNode implements vscode.TreeItem {
@@ -89,6 +90,8 @@ export class PRCategoryActionNode extends TreeNode implements vscode.TreeItem {
 					arguments: []
 				};
 				break;
+			case PRCategoryActionType.Initializing:
+				this.label = 'Loading...';
 			default:
 				break;
 		}


### PR DESCRIPTION
Follow up on https://github.com/microsoft/vscode-pull-request-github/issues/1269

With both the new 'sign in' option in the tree, and the sign in command, the tree was not properly updating after finishing auth. The problem was that within `updateRepositories`, we await for user response to a notification. I removed this call from that code path. Now, when the PR manager is initialized, it will show the notification if not logged in, but not block on it.

I also introduced an "Initialized" flag for the PR manager to indicate that a complete cycle of `updateRepositories` has been finished. This way, the tree will show "Loading..." until the repository data is completely there.