### PR TITLE
Limit gh pr commands to itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -667,22 +667,24 @@
         {
           "command": "pr.editComment",
           "group": "inline@1",
-          "when": "comment =~ /canEdit/"
+          "when": "commentController =~ /^(browse|review)/ && comment =~ /canEdit/"
         },
         {
           "command": "pr.deleteComment",
           "group": "inline@2",
-          "when": "comment =~ /canDelete/"
+          "when": "commentController =~ /^(browse|review)/ && comment =~ /canDelete/"
         }
       ],
       "comments/comment/context": [
         {
           "command": "pr.cancelEditComment",
-          "group": "inline@1"
+          "group": "inline@1",
+          "when": "commentController =~ /^(browse|review)/"
         },
         {
           "command": "pr.saveComment",
-          "group": "inline@2"
+          "group": "inline@2",
+          "when": "commentController =~ /^(browse|review)/"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -629,7 +629,8 @@
       "comments/commentThread/context": [
         {
           "command": "pr.createComment",
-          "group": "inline"
+          "group": "inline",
+          "when": "commentController =~ /^(browse|review)/"
         },
         {
           "command": "pr.startReview",


### PR DESCRIPTION
To avoid it bleed into comment widgets created by other extensions.