### PR TITLE
Fix issue with file path on windows for custom file system providers

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -374,7 +374,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 				}
 			}
 
-			const filePath = nodePath.resolve(this._repository.rootUri.fsPath, change.fileName).replace(/\\/g, '/');
+			const filePath = nodePath.join(this._repository.rootUri.path, change.fileName).replace(/\\/g, '/');
 			const uri = this._repository.rootUri.with({ path: filePath });
 
 			let changedItem = new GitFileChangeNode(


### PR DESCRIPTION
Currently, the result of `filePath` for the Uri that we create on windows is something like `"e:/dev/pullrequest-demo/data/products.json"`. This should have a leading `/` - for extensions that are registering their own git API and using a custom file system provider, the file system provider API in vscode will throw when trying to open the URI if it doesn't have this.