### PR TITLE
Look for pull request templates during PR creation

### DIFF
--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -98,6 +98,12 @@ export enum UpdateRepositoryState {
 	Authenticated
 }
 
+export interface PullRequestDefaults {
+	owner: string;
+	repo: string;
+	base: string;
+}
+
 export class PullRequestManager implements vscode.Disposable {
 	static ID = 'PullRequestManager';
 
@@ -1019,7 +1025,22 @@ export class PullRequestManager implements vscode.Disposable {
 		}
 	}
 
-	async getPullRequestDefaults(): Promise<Octokit.PullsCreateParams> {
+	async getPullRequestTemplates(): Promise<vscode.Uri[]> {
+		/**
+		 * Places a PR template can be:
+		 * - At the root, the docs folder, or the.github folder, named pull_request_template.md or PULL_REQUEST_TEMPLATE.md
+		 * - At the same folder locations under a PULL_REQUEST_TEMPLATE folder with any name
+		 */
+		const templatesPattern1 = await vscode.workspace.findFiles(new vscode.RelativePattern(this._repository.rootUri.path, '{pull_request_template,PULL_REQUEST_TEMPLATE}.md'));
+		const templatesPattern2 = await vscode.workspace.findFiles(new vscode.RelativePattern(this._repository.rootUri.path, '{docs,.github}/{pull_request_template,PULL_REQUEST_TEMPLATE}.md'));
+
+		const templatesPattern3 = await vscode.workspace.findFiles(new vscode.RelativePattern(this._repository.rootUri.path, 'PULL_REQUEST_TEMPLATE/*.md'));
+		const templatesPattern4 = await vscode.workspace.findFiles(new vscode.RelativePattern(this._repository.rootUri.path, '{docs,.github}/PULL_REQUEST_TEMPLATE/*.md'));
+
+		return [...templatesPattern1, ...templatesPattern2, ...templatesPattern3, ...templatesPattern4];
+	}
+
+	async getPullRequestDefaults(): Promise<PullRequestDefaults> {
 		if (!this.repository.state.HEAD) {
 			throw new DetachedHeadError(this.repository);
 		}
@@ -1028,15 +1049,11 @@ export class PullRequestManager implements vscode.Disposable {
 		const parent = meta.fork
 			? meta.parent
 			: await (this.findRepo(byRemoteName('upstream')) || origin).getMetadata();
-		const branchName = this.repository.state.HEAD.name;
-		const { title, body } = titleAndBodyFrom(await this.getHeadCommitMessage());
+
 		return {
-			title, body,
 			owner: parent.owner.login,
 			repo: parent.name,
-			head: `${meta.owner.login}:${branchName}`,
-			base: parent.default_branch,
-			draft: false,
+			base: parent.default_branch
 		};
 	}
 
@@ -1708,7 +1725,7 @@ const ownedByMe: Predicate<GitHubRepository> = repo => {
 const byRemoteName = (name: string): Predicate<GitHubRepository> =>
 	({ remote: { remoteName } }) => remoteName === name;
 
-const titleAndBodyFrom = (message: string): { title: string, body: string } => {
+export const titleAndBodyFrom = (message: string): { title: string, body: string } => {
 	const idxLineBreak = message.indexOf('\n');
 	return {
 		title: idxLineBreak === -1

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -650,13 +650,8 @@ export class ReviewManager implements vscode.DecorationProvider {
 	}
 
 	private async getPullRequestTitleAndDescriptionDefaults(progress: vscode.Progress<{message?: string, increment?: number}>): Promise<{ title: string, description: string } | undefined> {
-		progress.report({ increment: 5, message: 'Looking for pull request template...' });
 		const pullRequestTemplates = await this._prManager.getPullRequestTemplates();
 		let template: vscode.Uri | undefined;
-
-		if (pullRequestTemplates.length === 0) {
-			progress.report({ increment: 5, message: 'No pull request template found. Creating pull request...' });
-		}
 
 		if (pullRequestTemplates.length === 1) {
 			template = pullRequestTemplates[0];

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -21,7 +21,7 @@ import { PRNode } from './treeNodes/pullRequestNode';
 import { PullRequestOverviewPanel } from '../github/pullRequestOverview';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
 import { RemoteQuickPickItem } from './quickpick';
-import { PullRequestManager } from '../github/pullRequestManager';
+import { PullRequestManager, titleAndBodyFrom } from '../github/pullRequestManager';
 import { PullRequestModel } from '../github/pullRequestModel';
 import { ReviewCommentController } from './reviewCommentController';
 import { ITelemetry } from '../common/telemetry';
@@ -649,6 +649,57 @@ export class ReviewManager implements vscode.DecorationProvider {
 		return selected;
 	}
 
+	private async getPullRequestTitleAndDescriptionDefaults(progress: vscode.Progress<{message?: string, increment?: number}>): Promise<{ title: string, description: string } | undefined> {
+		progress.report({ increment: 5, message: 'Looking for pull request template...' });
+		const pullRequestTemplates = await this._prManager.getPullRequestTemplates();
+		let template: vscode.Uri | undefined;
+
+		if (pullRequestTemplates.length === 0) {
+			progress.report({ increment: 5, message: 'No pull request template found. Creating pull request...' });
+		}
+
+		if (pullRequestTemplates.length === 1) {
+			template = pullRequestTemplates[0];
+			progress.report({ increment: 5, message: 'Found pull request template. Creating pull request...' });
+		}
+
+		if (pullRequestTemplates.length > 1) {
+			const targetTemplate = await vscode.window.showQuickPick(pullRequestTemplates.map(uri => {
+				return {
+					label: vscode.workspace.asRelativePath(uri.path),
+					uri: uri
+				};
+			}), {
+				ignoreFocusOut: true,
+				placeHolder: 'Select the pull request template to use'
+			});
+
+			// Treat user pressing escape as cancel
+			if (!targetTemplate) {
+				return;
+			}
+
+			template = targetTemplate.uri;
+			progress.report({ increment: 5, message: 'Creating pull request...' });
+		}
+
+		const { title, body } = titleAndBodyFrom(await this._prManager.getHeadCommitMessage());
+		let description = body;
+		if (template) {
+			try {
+				const templateContent = await vscode.workspace.fs.readFile(template);
+				description = templateContent.toString();
+			} catch (e) {
+				Logger.appendLine(`Reading pull request template failed: ${e}`);
+			}
+		}
+
+		return {
+			title,
+			description
+		};
+	}
+
 	public async createPullRequest(draft=false): Promise<void> {
 		const pullRequestDefaults = await this._prManager.getPullRequestDefaults();
 		const githubRemotes = this._prManager.getGitHubRemotes();
@@ -703,13 +754,24 @@ export class ReviewManager implements vscode.DecorationProvider {
 				return;
 			}
 
-			pullRequestDefaults.base = target;
-			// For cross-repository pull requests, the owner must be listed. Always list to be safe. See https://developer.github.com/v3/pulls/#create-a-pull-request.
-			pullRequestDefaults.head = `${headRemote.owner}:${branchName}`;
-			pullRequestDefaults.owner = targetRemote!.owner;
-			pullRequestDefaults.repo = targetRemote!.name;
-			pullRequestDefaults.draft = draft;
-			const pullRequestModel = await this._prManager.createPullRequest(pullRequestDefaults);
+			const titleAndDescriptionDefaults = await this.getPullRequestTitleAndDescriptionDefaults(progress);
+			// User cancelled a quick input, cancel the create process
+			if (!titleAndDescriptionDefaults) {
+				return;
+			}
+
+			const createParams = {
+				title: titleAndDescriptionDefaults.title,
+				body: titleAndDescriptionDefaults.description,
+				base: target,
+				// For cross-repository pull requests, the owner must be listed. Always list to be safe. See https://developer.github.com/v3/pulls/#create-a-pull-request.
+				head: `${headRemote.owner}:${branchName}`,
+				owner: targetRemote!.owner,
+				repo: targetRemote!.name,
+				draft: draft
+			};
+
+			const pullRequestModel = await this._prManager.createPullRequest(createParams);
 
 			if (pullRequestModel) {
 				progress.report({ increment: 30, message: `Pull Request #${pullRequestModel.prNumber} Created` });
@@ -718,7 +780,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 				progress.report({ increment: 30 });
 			} else {
 				// error: Unhandled Rejection at: Promise [object Promise]. Reason: {"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for rebornix:tree-sitter."}],"documentation_url":"https://developer.github.com/v3/pulls/#create-a-pull-request"}.
-				progress.report({ increment: 90, message: `Failed to create pull request for ${pullRequestDefaults.head}` });
+				progress.report({ increment: 90, message: `Failed to create pull request for ${branchName}` });
 			}
 		});
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/798

During PR creation, look to see if there is a pull request template file. If there's only one, use it for the description. If there are multiple, show a quick pick with the file paths for them. If there are none, then just use the commit information as before.

There's no GitHub API that I can see for fetching the template, so instead I'm doing a file search against the repo. To be completely correct, this should actually be a find against the files as they are in the default branch of the repo, but that would require a large number of network calls since the templates can be located in a variety of places, and with arbitrary names in some cases. Or checking out the default branch, doing the search, and returning to the previous branch. The current approach should be much faster than that and correct a vast majority of the time.