### PR TITLE
Remove usage of rootPath and fix suggested edits

### DIFF
--- a/preview-src/context.tsx
+++ b/preview-src/context.tsx
@@ -122,6 +122,11 @@ export class PRContext {
 		this.updatePR({ labels });
 	}
 
+
+	public applyPatch = async (comment: IComment) => {
+		this.postMessage({ command: 'pr.apply-patch', args: { comment } });
+	}
+
 	private appendReview({ review, reviewers }: any) {
 		const state = this.pr;
 		let events = state.events;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -107,11 +107,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 			// Reset HEAD and then apply reverse diff
 			await vscode.commands.executeCommand('git.unstageAll');
 
-			if (!vscode.workspace.rootPath) {
-				throw new Error('Current workspace root path is undefined.');
-			}
-
-			const tempFilePath = pathLib.resolve(vscode.workspace.rootPath, '.git', `${prManager.activePullRequest.prNumber}.diff`);
+			const tempFilePath = pathLib.join(prManager.repository.rootUri.path, '.git', `${prManager.activePullRequest.prNumber}.diff`);
 			writeFile(tempFilePath, diff, {}, async (writeError) => {
 				if (writeError) {
 					throw writeError;

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -443,10 +443,8 @@ export class PullRequestOverviewPanel {
 			const comment = message.args.comment;
 			const regex = /```diff\n([\s\S]*)\n```/g;
 			const matches = regex.exec(comment.body);
-			if (!vscode.workspace.rootPath) {
-				throw new Error('Current workspace rootpath is undefined.');
-			}
-			const tempFilePath = path.resolve(vscode.workspace.rootPath, '.git', `${comment.id}.diff`);
+
+			const tempFilePath = path.join(this._pullRequestManager.repository.rootUri.path, '.git', `${comment.id}.diff`);
 			writeFile(tempFilePath, matches![1], {}, async (writeError) => {
 				if (writeError) {
 					throw writeError;
@@ -461,6 +459,7 @@ export class PullRequestOverviewPanel {
 							throw err;
 						}
 
+						vscode.window.showInformationMessage('The suggested changes have been applied.');
 						this._replyMessage(message, {});
 					});
 				} catch (e) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/1312

Replace usages of the deprecated `vscode.workspace.rootPath`. While testing, I noticed that the "Suggest edit" workflow wasn't working anymore, seems to have been broken since we refactored the overview page, so I also fixed that