### PR TITLE
Remove unneeded validateDraftMode calls

### DIFF
--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -114,12 +114,12 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 	// #region initialize
 	async initialize(): Promise<void> {
 		this._visibleNormalTextEditors = vscode.window.visibleTextEditors.filter(ed => ed.document.uri.scheme !== 'comment');
+		await this._prManager.validateDraftMode(this._prManager.activePullRequest!);
 		await this.initializeWorkspaceCommentThreads();
 		await this.initializeDocumentCommentThreadsAndListeners();
 	}
 
 	async initializeWorkspaceCommentThreads(): Promise<void[]> {
-		await this._prManager.validateDraftMode(this._prManager.activePullRequest!);
 		const localFileChangePromises = this._localFileChanges.map(async matchedFile => {
 			const threadData = await this.getWorkspaceFileThreadDatas(matchedFile);
 			this._workspaceFileChangeCommentThreads[matchedFile.fileName] = threadData.map(thread => createVSCodeCommentThread(thread, this._commentController!));
@@ -259,8 +259,6 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 				let matchedFileChanges = this._localFileChanges.filter(localFileChange => localFileChange.fileName === params.fileName);
 
 				if (matchedFileChanges.length) {
-					await this._prManager.validateDraftMode(this._prManager.activePullRequest!);
-
 					const documentComments = getDocumentThreadDatas(editor.document.uri, params.isBase, matchedFileChanges[0], matchedFileChanges[0].comments);
 					const newThreads: GHPRCommentThread[] = documentComments.map(thread => createVSCodeCommentThread(thread, this._commentController!));
 
@@ -305,8 +303,6 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			}
 
 			this._reviewDocumentCommentThreads.setDocumentThreads(fileName, query.base, []);
-
-			await this._prManager.validateDraftMode(this._prManager.activePullRequest!);
 
 			const threadData = this.provideCommentsForReviewUri(editor.document, query);
 			const newThreads = threadData.map(thread => createVSCodeCommentThread(thread, this._commentController!));
@@ -951,7 +947,6 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 
 	// #region Incremental update comments
 	public async update(localFileChanges: GitFileChangeNode[], obsoleteFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[]): Promise<void> {
-		await this._prManager.validateDraftMode(this._prManager.activePullRequest!);
 		// _workspaceFileChangeCommentThreads
 		for (let fileName in this._workspaceFileChangeCommentThreads) {
 			this.updateFileChangeCommentThreads(localFileChanges, fileName, false);

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -229,7 +229,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 				await this.updateComments();
 			}
 			this.pollForStatusChange();
-		}, 1000 * 30);
+		}, 1000 * 60 * 5);
 	}
 
 	public async updateState() {
@@ -347,6 +347,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 		}
 
 		await this.getPullRequestData(pr);
+		await this._prManager.validateDraftMode(this._prManager.activePullRequest!);
 		await this._reviewCommentController.update(this._localFileChanges, this._obsoleteFileChanges);
 
 		return Promise.resolve(void 0);

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -274,7 +274,6 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 				}
 			});
 
-			const inDraftMode = await this._prManager.validateDraftMode(this.pullRequestModel);
 			currentPRDocuments.forEach(editor => {
 				let fileChange = this._fileChanges.find(fc => fc.fileName === editor.fileName);
 
@@ -297,7 +296,7 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 					oldCommentThreads = [...oldLeftSideCommentThreads, ...oldRightSideCommentThreads];
 				}
 
-				this.updateFileChangeCommentThreads(oldCommentThreads, [...newLeftCommentThreads, ...newRightSideCommentThreads], fileChange, inDraftMode);
+				this.updateFileChangeCommentThreads(oldCommentThreads, [...newLeftCommentThreads, ...newRightSideCommentThreads], fileChange);
 			});
 
 		}
@@ -480,7 +479,7 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 	// #endregion
 
 	// #region Incremental updates
-	private updateFileChangeCommentThreads(oldCommentThreads: GHPRCommentThread[], newCommentThreads: ThreadData[], newFileChange: InMemFileChangeNode, inDraftMode: boolean) {
+	private updateFileChangeCommentThreads(oldCommentThreads: GHPRCommentThread[], newCommentThreads: ThreadData[], newFileChange: InMemFileChangeNode) {
 		// remove
 		oldCommentThreads.forEach(thread => {
 			// No current threads match old thread, it has been removed
@@ -746,7 +745,8 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 			thread.comments = thread.comments.filter(c => c instanceof TemporaryComment && c.id === comment.id);
 		}
 
-		await this._prManager.validateDraftMode(this.pullRequestModel);
+		const inDraftMode = await this._prManager.validateDraftMode(this.pullRequestModel);
+		this.setContextKey(inDraftMode);
 	}
 	// #endregion
 


### PR DESCRIPTION
Only make a network call to validate draft mode on initialization and during update, as the methods for starting and deleting reviews should already correctly set the state.

Also made the interval for polling for updates longer, since I think it's very aggressive now. Let me know if you think we should keep it shorter.