### PR TITLE
Ensure review manager state gets properly updated when git extension state changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,10 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: 
 	tree.initialize(prManager);
 	registerCommands(context, prManager, reviewManager, telemetry);
 
+	git.onDidChangeState(() => {
+		reviewManager.updateState();
+	});
+
 	git.repositories.forEach(repo => {
 		repo.ui.onDidChange(() => {
 			// No multi-select support, always show last selected repo

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -145,9 +145,6 @@ export class PullRequestManager implements vscode.Disposable {
 			}
 		}));
 
-		this._subs.push(this._git.onDidChangeState(async _ => {
-			await this.updateRepositories();
-		}));
 
 		this.setUpCompletionItemProvider();
 		this.showLoginPrompt();

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -145,7 +145,6 @@ export class PullRequestManager implements vscode.Disposable {
 			}
 		}));
 
-
 		this.setUpCompletionItemProvider();
 		this.showLoginPrompt();
 	}


### PR DESCRIPTION
Currently, the pull request manager waits to initialize the array of github repositories until the git extension's state has changed to initialized. The pull request manager is directly listening for changes to git extension state.

However, the review manager also has state that depends on the array of github repositories. So the git extension changing state should instead trigger an update for the review manager, which will update the pull request manager and then be able to successfully resolve the pull request.