### PR TITLE
Update the "Request Changes" and "Approve" buttons alignment

### DIFF
--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -286,7 +286,7 @@ export function AddComment({ pendingCommentText, state }: PullRequest) {
 				<input id='reply'
 					value='Comment'
 					type='submit'
-					className='reply-button'
+					className='secondary'
 					disabled={isBusy || !pendingCommentText} />
 			</div>
 		</form>;

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -618,14 +618,6 @@ body .comment-form {
 	padding: 10px 0;
 }
 
-.review-comment-container #request-changes {
-	margin-left: auto;
-}
-
-.review-comment-container #submit {
-	margin-right: 0;
-}
-
 textarea, input[type='text'] {
 	display: block;
 	box-sizing: border-box;
@@ -679,9 +671,19 @@ textarea:focus {
 	padding: 5px 0;
 }
 
-.reply-button {
+.comment-form .form-actions > button,
+.comment-form .form-actions > input[type=submit] {
+	margin-right: 0;
+	margin-left: 0;
+}
+
+.comment-form .form-actions > #request-changes {
 	margin-left: auto;
-	margin-right: 0 !important;
+}
+
+.comment-form .form-actions > #close {
+	margin-left: 0;
+	margin-right: auto;
 }
 
 .form-actions {


### PR DESCRIPTION
This Pull Request updates the style of the PR Description page to move the `Request Changes` and `Approve` buttons to the right side, near the `Comment` button. This way, those related functionalities are grouped together and far from the `Close Pull Request` button.

**Related Issues**: #297 

Preview:
![image](https://user-images.githubusercontent.com/10552039/66248706-79251380-e700-11e9-8ad9-aa102c211a9e.png)

![image](https://user-images.githubusercontent.com/10552039/66248703-6f9bab80-e700-11e9-88db-473b44c8e1ea.png)
