### PR TITLE
Align commit hash in PR description and avoid breaking username on hyphen

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -543,6 +543,7 @@ body .overview-title .button-group button {
 }
 
 .commit .sha {
+	align-self: center;
 	margin-left: auto;
 }
 

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -252,6 +252,7 @@ body .comment-container .review-comment-header > a,
 body .commit .commit-message > a,
 body .merged .merged-message > a {
 	margin-right: 4px;
+	white-space: nowrap;
 }
 
 body .comment-container .comment-body, .review-body {


### PR DESCRIPTION
Closes #1353

This change makes sure the commit hash is always vertically centred. Previously it was aligned towards the top when the username overflows to two lines.

Before:
<img width="684" alt="Screen Shot 2019-10-02 at 10 56 02 PM" src="https://user-images.githubusercontent.com/9157833/66249218-80d6bf00-e6e4-11e9-90ae-e487db098990.png">

After:
<img width="676" alt="Screen Shot 2019-10-03 at 11 06 02 PM" src="https://user-images.githubusercontent.com/9157833/66184905-7360fc80-e632-11e9-86e3-de5c0843f92d.png">
<img width="679" alt="Screen Shot 2019-10-03 at 11 05 51 PM" src="https://user-images.githubusercontent.com/9157833/66184908-7360fc80-e632-11e9-9eba-bad488744426.png">

**Update**:
Second commit prevents username from line-wrapping when there's a dash:
<img width="674" alt="Screen Shot 2019-10-04 at 8 17 51 PM" src="https://user-images.githubusercontent.com/9157833/66249141-2b9aad80-e6e4-11e9-8c32-184f73c066fe.png">
