### PR TITLE
Show "Successfully signed in" in status bar after login instead of notification

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -149,7 +149,6 @@ export class CredentialStore implements vscode.Disposable {
 				if (login && login.token) {
 					octokit = await this.createHub(login);
 					await setToken(login.host, login.token);
-					vscode.window.showInformationMessage(`You are now signed in to ${authority}`);
 				}
 			} catch (e) {
 				Logger.appendLine(`Error signing in to ${authority}: ${e}`);
@@ -257,15 +256,18 @@ export class CredentialStore implements vscode.Disposable {
 			} catch (e) {
 				text = '$(mark-github) Signed in';
 			}
-
 			command = undefined;
+			// Temporarily show successful sign-in status
+			statusBarItem.text = '$(mark-github) Successfully signed in';
+			setTimeout(async () => {
+				statusBarItem.text = text;
+			}, 2000);
 		} else {
 			const authority = remote.gitProtocol.normalizeUri()!.authority;
 			text = `$(mark-github) Sign in to ${authority}`;
 			command = 'pr.signin';
+			statusBarItem.text = text;
 		}
-
-		statusBarItem.text = text;
 		statusBarItem.command = command;
 	}
 


### PR DESCRIPTION
Closes #1347

Shows for 2 seconds before showing the GitHub username.

<img width="550" alt="Screen Shot 2019-10-06 at 10 34 15 PM" src="https://user-images.githubusercontent.com/9157833/66287222-b2d55600-e889-11e9-9735-4b136a37b0e3.png">
