### PR TITLE
allow the naming of PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
             }
           }
         },
-        "githubPullRequests.pullRequestName": {
+        "githubPullRequests.pullRequestTitle": {
           "type": "string",
           "enum": [
             "commit",
@@ -70,11 +70,11 @@
           "enumDescriptions": [
             "Use the latest commit message",
             "Use the branch name",
-            "Specify a custom message",
+            "Specify a custom title",
             "Ask which of the above methods to use"
           ],
           "default": "ask",
-          "description": "The name used when creating pull requests."
+          "description": "The title used when creating pull requests."
         },
         "githubPullRequests.logLevel": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -68,10 +68,10 @@
             "ask"
           ],
           "enumDescriptions": [
-            "Use the latest commit message.",
-            "Use the branch name.",
-            "Specify a custom message.",
-            "Ask which of the above methods to use."
+            "Use the latest commit message",
+            "Use the branch name",
+            "Specify a custom message",
+            "Ask which of the above methods to use"
           ],
           "default": "ask",
           "description": "The name used when creating pull requests."

--- a/package.json
+++ b/package.json
@@ -59,6 +59,23 @@
             }
           }
         },
+        "githubPullRequests.pullRequestName": {
+          "type": "string",
+          "enum": [
+            "commit",
+            "branch",
+            "custom",
+            "ask"
+          ],
+          "enumDescriptions": [
+            "Use the latest commit message.",
+            "Use the branch name.",
+            "Specify a custom message.",
+            "Ask which of the above methods to use."
+          ],
+          "default": "ask",
+          "description": "The name used when creating pull requests."
+        },
         "githubPullRequests.logLevel": {
           "type": "string",
           "enum": [

--- a/src/view/quickpick.ts
+++ b/src/view/quickpick.ts
@@ -22,3 +22,28 @@ export class RemoteQuickPickItem implements vscode.QuickPickItem {
 		public label = `${owner}:${name}`,
 	) {}
 }
+
+export type PullRequestNameSource = 'commit' | 'branch' | 'custom' | 'ask';
+
+export class PullRequestNameSourceQuickPick implements vscode.QuickPickItem {
+	static allOptions(): PullRequestNameSourceQuickPick[] {
+		const values: PullRequestNameSource[] = ['commit', 'branch', 'custom'];
+		return values.map(x => this.fromPullRequestNameSource(x));
+	}
+	static getDescription(pullRequestNameSource: PullRequestNameSource): string {
+		switch (pullRequestNameSource) {
+			case 'commit':
+				return 'Use the latest commit message';
+			case 'branch':
+				return 'Use the branch name';
+			case 'custom':
+				return 'Specify a custom message';
+		}
+		return '';
+	}
+	static fromPullRequestNameSource(pullRequestNameSource: PullRequestNameSource) {
+		return new this(this.getDescription(pullRequestNameSource), pullRequestNameSource, pullRequestNameSource);
+	}
+	constructor(public description: string, public pullRequestNameSource: PullRequestNameSource, public label: string) { }
+}
+

--- a/src/view/quickpick.ts
+++ b/src/view/quickpick.ts
@@ -23,27 +23,37 @@ export class RemoteQuickPickItem implements vscode.QuickPickItem {
 	) {}
 }
 
-export type PullRequestNameSource = 'commit' | 'branch' | 'custom' | 'ask';
+export type PullRequestTitleSource = 'commit' | 'branch' | 'custom' | 'ask';
 
-export class PullRequestNameSourceQuickPick implements vscode.QuickPickItem {
-	static allOptions(): PullRequestNameSourceQuickPick[] {
-		const values: PullRequestNameSource[] = ['commit', 'branch', 'custom'];
-		return values.map(x => this.fromPullRequestNameSource(x));
+export enum PullRequestTitleSourceEnum {
+	Commit = 'commit',
+	Branch = 'branch',
+	Custom = 'custom',
+	Ask = 'ask'
+}
+
+export class PullRequestTitleSourceQuickPick implements vscode.QuickPickItem {
+	static allOptions(): PullRequestTitleSourceQuickPick[] {
+		const values: PullRequestTitleSource[] = [
+			PullRequestTitleSourceEnum.Commit,
+			PullRequestTitleSourceEnum.Branch,
+			PullRequestTitleSourceEnum.Custom
+		];
+		return values.map(x => this.fromPullRequestTitleSource(x));
 	}
-	static getDescription(pullRequestNameSource: PullRequestNameSource): string {
-		switch (pullRequestNameSource) {
-			case 'commit':
+	static getDescription(pullRequestTitleSource: PullRequestTitleSource): string {
+		switch (pullRequestTitleSource) {
+			case PullRequestTitleSourceEnum.Commit:
 				return 'Use the latest commit message';
-			case 'branch':
+			case PullRequestTitleSourceEnum.Branch:
 				return 'Use the branch name';
-			case 'custom':
-				return 'Specify a custom message';
+			case PullRequestTitleSourceEnum.Custom:
+				return 'Specify a custom title';
 		}
 		return '';
 	}
-	static fromPullRequestNameSource(pullRequestNameSource: PullRequestNameSource) {
-		return new this(this.getDescription(pullRequestNameSource), pullRequestNameSource, pullRequestNameSource);
+	static fromPullRequestTitleSource(pullRequestTitleSource: PullRequestTitleSource) {
+		return new this(this.getDescription(pullRequestTitleSource), pullRequestTitleSource, pullRequestTitleSource);
 	}
-	constructor(public description: string, public pullRequestNameSource: PullRequestNameSource, public label: string) { }
+	constructor(public description: string, public pullRequestTitleSource: PullRequestTitleSource, public label: string) { }
 }
-

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -20,7 +20,7 @@ import { PullRequestsTreeDataProvider } from './prsTreeDataProvider';
 import { PRNode } from './treeNodes/pullRequestNode';
 import { PullRequestOverviewPanel } from '../github/pullRequestOverview';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
-import { RemoteQuickPickItem } from './quickpick';
+import { RemoteQuickPickItem, PullRequestNameSourceQuickPick, PullRequestNameSource } from './quickpick';
 import { PullRequestManager, titleAndBodyFrom } from '../github/pullRequestManager';
 import { PullRequestModel, IResolvedPullRequestModel } from '../github/pullRequestModel';
 import { ReviewCommentController } from './reviewCommentController';
@@ -704,6 +704,25 @@ export class ReviewManager implements vscode.DecorationProvider {
 		};
 	}
 
+	private async getPullRequestNameSetting(): Promise<PullRequestNameSource | undefined> {
+		const method = vscode.workspace.getConfiguration('githubPullRequests').get<PullRequestNameSource>('pullRequestName', 'ask');
+
+		if(method == "ask") {
+			const titleSource = await vscode.window.showQuickPick<PullRequestNameSourceQuickPick>(PullRequestNameSourceQuickPick.allOptions(), {
+				ignoreFocusOut: true,
+				placeHolder: "Pull Request Name Source"
+			});
+
+			if (!titleSource) {
+				return;
+			}
+
+			return titleSource.pullRequestNameSource;
+		}
+
+		return method;
+	}
+
 	public async createPullRequest(draft=false): Promise<void> {
 		const pullRequestDefaults = await this._prManager.getPullRequestDefaults();
 		const githubRemotes = this._prManager.getGitHubRemotes();
@@ -764,8 +783,37 @@ export class ReviewManager implements vscode.DecorationProvider {
 				return;
 			}
 
+			let { title } = titleAndDescriptionDefaults;
+
+			const pullRequestNameMethod = await this.getPullRequestNameSetting();
+
+			// User cancelled the name selection process, cancel the create process
+			if (!pullRequestNameMethod) {
+				return;
+			}
+
+			switch(pullRequestNameMethod) {
+				case "branch":
+					if(branchName) {
+						title = branchName;
+					}
+					break;
+				case "custom":
+					const nameResult = await vscode.window.showInputBox({
+						value: title,
+						ignoreFocusOut: true,
+						prompt: `What would you like to name your PR?`,
+					});
+
+					if(!nameResult) {
+						return;
+					}
+
+					title = nameResult;
+			}
+
 			const createParams = {
-				title: titleAndDescriptionDefaults.title,
+				title,
 				body: titleAndDescriptionDefaults.description,
 				base: target,
 				// For cross-repository pull requests, the owner must be listed. Always list to be safe. See https://developer.github.com/v3/pulls/#create-a-pull-request.


### PR DESCRIPTION
addresses: https://github.com/microsoft/vscode-pull-request-github/issues/906

I couldn't find any tests covering this logic, but I did extensive manual testing.

Settings view:
![image](https://user-images.githubusercontent.com/7690508/66446219-a67f0380-ea17-11e9-8f8e-0f3cbae99cad.png)

Prompt for name source when `ask` is set:
![image](https://user-images.githubusercontent.com/7690508/66446282-e514be00-ea17-11e9-89e4-a466eba31335.png)

Naming prompt when `custom` selected:
![image](https://user-images.githubusercontent.com/7690508/66446303-fb227e80-ea17-11e9-83e0-7caaafaf6095.png)
