### PR TITLE
use path relative to the git repo instead of workspace. Fixes #1374

### DIFF
--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -175,7 +175,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			});
 
 			this._reviewDocumentCommentThreads.maybeDisposeThreads(visibleTextEditors, (editor: vscode.TextEditor, fileName: string, isBase: boolean) => {
-				const editorFileName = vscode.workspace.asRelativePath(editor.document.uri.path);
+				const editorFileName = nodePath.relative(this._repository.rootUri.path, editor.document.uri.path);
 				if (editor.document.uri.scheme !== 'review' && editor.document.uri.scheme === this._repository.rootUri.scheme && editor.document.uri.query) {
 					const params = fromReviewUri(editor.document.uri);
 					if (fileName === editorFileName && params.base === isBase) {
@@ -201,7 +201,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 
 			const workspaceDocuments = visibleTextEditors.filter(editor => editor.document.uri.scheme === this._repository.rootUri.scheme);
 			workspaceDocuments.forEach(editor => {
-				const fileName = vscode.workspace.asRelativePath(editor.document.uri.path);
+				const fileName = nodePath.relative(this._repository.rootUri.path, editor.document.uri.path);
 				const threadsForEditor = this._workspaceFileChangeCommentThreads[fileName] || [];
 				// If the editor has no view column, assume it is part of a diff editor and expand the comments. Otherwise, collapse them.
 				const isEmbedded = !editor.viewColumn;
@@ -275,7 +275,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			return;
 		}
 
-		const fileName = vscode.workspace.asRelativePath(editor.document.uri.path);
+		const fileName = nodePath.relative(this._repository.rootUri.path, editor.document.uri.path);
 		if (editor.document.uri.scheme === this._repository.rootUri.scheme && editor.viewColumn !== undefined) {
 			// local files
 			const matchedFiles = this._localFileChanges.filter(fileChange => fileChange.fileName === fileName);
@@ -384,14 +384,14 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			case 'review':
 				const reviewParams = uri.query && fromReviewUri(uri);
 				if (reviewParams) {
-					const documentFileName = vscode.workspace.asRelativePath(uri.path);
+					const documentFileName = nodePath.relative(this._repository.rootUri.path, uri.path);
 					const existingThreads = this._reviewDocumentCommentThreads.getThreadsForDocument(documentFileName, reviewParams.base) || [];
 					this._reviewDocumentCommentThreads.setDocumentThreads(documentFileName, reviewParams.base, existingThreads.concat(thread));
 					return;
 				}
 
 			case currentWorkspace.uri.scheme:
-				const workspaceFileName = vscode.workspace.asRelativePath(uri.path);
+				const workspaceFileName = nodePath.relative(this._repository.rootUri.path, uri.path);
 				const existingWorkspaceThreads = this._workspaceFileChangeCommentThreads[workspaceFileName];
 				existingWorkspaceThreads.push(thread);
 				return;
@@ -442,7 +442,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 				return;
 			}
 
-			const fileName = vscode.workspace.asRelativePath(document.uri.path);
+			const fileName = nodePath.relative(this._repository.rootUri.path, document.uri.path);
 			const matchedFiles = gitFileChangeNodeFilter(this._localFileChanges).filter(fileChange => fileChange.fileName === fileName);
 			let matchedFile: GitFileChangeNode;
 			const ranges = [];

--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -175,7 +175,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			});
 
 			this._reviewDocumentCommentThreads.maybeDisposeThreads(visibleTextEditors, (editor: vscode.TextEditor, fileName: string, isBase: boolean) => {
-				const editorFileName = this.gitRelativePath(editor.document.uri.path);
+				const editorFileName = this.gitRelativeRootPath(editor.document.uri.path);
 				if (editor.document.uri.scheme !== 'review' && editor.document.uri.scheme === this._repository.rootUri.scheme && editor.document.uri.query) {
 					const params = fromReviewUri(editor.document.uri);
 					if (fileName === editorFileName && params.base === isBase) {
@@ -201,7 +201,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 
 			const workspaceDocuments = visibleTextEditors.filter(editor => editor.document.uri.scheme === this._repository.rootUri.scheme);
 			workspaceDocuments.forEach(editor => {
-				const fileName = this.gitRelativePath(editor.document.uri.path);
+				const fileName = this.gitRelativeRootPath(editor.document.uri.path);
 				const threadsForEditor = this._workspaceFileChangeCommentThreads[fileName] || [];
 				// If the editor has no view column, assume it is part of a diff editor and expand the comments. Otherwise, collapse them.
 				const isEmbedded = !editor.viewColumn;
@@ -275,7 +275,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			return;
 		}
 
-		const fileName = this.gitRelativePath(editor.document.uri.path);
+		const fileName = this.gitRelativeRootPath(editor.document.uri.path);
 		if (editor.document.uri.scheme === this._repository.rootUri.scheme && editor.viewColumn !== undefined) {
 			// local files
 			const matchedFiles = this._localFileChanges.filter(fileChange => fileChange.fileName === fileName);
@@ -384,14 +384,14 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 			case 'review':
 				const reviewParams = uri.query && fromReviewUri(uri);
 				if (reviewParams) {
-					const documentFileName = this.gitRelativePath(uri.path);
+					const documentFileName = this.gitRelativeRootPath(uri.path);
 					const existingThreads = this._reviewDocumentCommentThreads.getThreadsForDocument(documentFileName, reviewParams.base) || [];
 					this._reviewDocumentCommentThreads.setDocumentThreads(documentFileName, reviewParams.base, existingThreads.concat(thread));
 					return;
 				}
 
 			case currentWorkspace.uri.scheme:
-				const workspaceFileName = this.gitRelativePath(uri.path);
+				const workspaceFileName = this.gitRelativeRootPath(uri.path);
 				const existingWorkspaceThreads = this._workspaceFileChangeCommentThreads[workspaceFileName];
 				existingWorkspaceThreads.push(thread);
 				return;
@@ -442,7 +442,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 				return;
 			}
 
-			const fileName = this.gitRelativePath(document.uri.path)
+			const fileName = this.gitRelativeRootPath(document.uri.path)
 			const matchedFiles = gitFileChangeNodeFilter(this._localFileChanges).filter(fileChange => fileChange.fileName === fileName);
 			let matchedFile: GitFileChangeNode;
 			const ranges = [];
@@ -701,7 +701,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 		}
 	}
 
-	private gitRelativePath(path: string) {
+	private gitRelativeRootPath(path: string) {
 		// get path relative to git root directory. Handles windows path by converting it to unix path.
 		return nodePath.relative(this._repository.rootUri.path, path).replace(/\\/g, '/');
 	}

--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -442,7 +442,7 @@ export class ReviewCommentController implements vscode.Disposable, CommentHandle
 				return;
 			}
 
-			const fileName = this.gitRelativeRootPath(document.uri.path)
+			const fileName = this.gitRelativeRootPath(document.uri.path);
 			const matchedFiles = gitFileChangeNodeFilter(this._localFileChanges).filter(fileChange => fileChange.fileName === fileName);
 			let matchedFile: GitFileChangeNode;
 			const ranges = [];


### PR DESCRIPTION
This changes will compare changed file path with path relative to git repo instead of vscode workspace path. Handle windows path as well