### PR TITLE
Issue 1369: Add pending label to comments of pending reviews on timeline

### DIFF
--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -15,6 +15,7 @@ import { useStateProp } from './hooks';
 export type Props = Partial<IComment & PullRequest> & {
 	headerInEditMode?: boolean
 	isPRDescription?: boolean
+	parentPending?: boolean
 };
 
 export function CommentView(comment: Props) {
@@ -72,7 +73,7 @@ export function CommentView(comment: Props) {
 }
 
 type CommentBoxProps = {
-	for: Partial<IComment & PullRequest>
+	for: Partial<IComment & PullRequest> & { parentPending?: boolean }
 	header?: React.ReactChild
 	onMouseEnter?: any
 	onMouseLeave?: any
@@ -82,7 +83,7 @@ type CommentBoxProps = {
 function CommentBox({
 	for: comment,
 	onMouseEnter, onMouseLeave, children }: CommentBoxProps) {
-	const	{ user, author, createdAt, htmlUrl } = comment;
+	const	{ user, author, createdAt, htmlUrl, parentPending } = comment;
 	return <div className='comment-container comment review-comment'
 		{...{onMouseEnter, onMouseLeave}}
 	>
@@ -98,6 +99,13 @@ function CommentBox({
 									<Timestamp href={htmlUrl} date={createdAt} />
 								</>
 							: <em>pending</em>
+					}
+					{
+						parentPending
+							? <>
+									<span className='pending-label'>Pending</span>
+								</>
+							: null
 					}
 				</Spaced>
 			</div>

--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -15,7 +15,6 @@ import { useStateProp } from './hooks';
 export type Props = Partial<IComment & PullRequest> & {
 	headerInEditMode?: boolean
 	isPRDescription?: boolean
-	parentPending?: boolean
 };
 
 export function CommentView(comment: Props) {
@@ -73,7 +72,7 @@ export function CommentView(comment: Props) {
 }
 
 type CommentBoxProps = {
-	for: Partial<IComment & PullRequest> & { parentPending?: boolean }
+	for: Partial<IComment & PullRequest>
 	header?: React.ReactChild
 	onMouseEnter?: any
 	onMouseLeave?: any
@@ -83,7 +82,7 @@ type CommentBoxProps = {
 function CommentBox({
 	for: comment,
 	onMouseEnter, onMouseLeave, children }: CommentBoxProps) {
-	const	{ user, author, createdAt, htmlUrl, parentPending } = comment;
+	const	{ user, author, createdAt, htmlUrl, isDraft } = comment;
 	return <div className='comment-container comment review-comment'
 		{...{onMouseEnter, onMouseLeave}}
 	>
@@ -101,7 +100,7 @@ function CommentBox({
 							: <em>pending</em>
 					}
 					{
-						parentPending
+						isDraft
 							? <>
 									<span className='pending-label'>Pending</span>
 								</>

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -255,6 +255,13 @@ body .merged .merged-message > a {
 	white-space: nowrap;
 }
 
+body .comment-container .review-comment-container .pending-label {
+	border: 1px solid;
+    border-radius: 2px 2px 2px 2px;
+    padding: 0.1rem 0.3rem;
+    font-style: italic;
+}
+
 body .comment-container .comment-body, .review-body {
 	padding: 10px;
 	border: 1px solid var(--vscode-list-inactiveSelectionBackground);

--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -83,7 +83,7 @@ const reviewDescriptor = (state: string) =>
 
 const ReviewEventView = (event: ReviewEvent) => {
 	const comments = groupCommentsByPath(event.comments);
-	const reviewIsPending = event.state === 'PENDING';
+	const reviewIsPending = event.state.toLocaleUpperCase() === 'PENDING';
 	return <div className='comment-container comment'>
 		<div className='review-comment-container'>
 			<div className='review-comment-header'>
@@ -91,7 +91,7 @@ const ReviewEventView = (event: ReviewEvent) => {
 					<Avatar for={event.user} />
 					<AuthorLink for={event.user} />{association(event)}
 					{ reviewIsPending
-						? <span>review pending</span>
+						? <em>review pending</em>
 						: <>
 								{reviewDescriptor(event.state)}{nbsp}
 								<Timestamp href={event.htmlUrl} date={event.submittedAt} />
@@ -113,7 +113,7 @@ const ReviewEventView = (event: ReviewEvent) => {
 									hunks={thread[0].diffHunks}
 									outdated={thread[0].position === null}
 									path={thread[0].path} />
-								{thread.map(c => <CommentView {...c} pullRequestReviewId={event.id} parentPending={reviewIsPending} />)}
+								{thread.map(c => <CommentView {...c} pullRequestReviewId={event.id} />)}
 							</div>
 					)
 			}</div>

--- a/preview-src/timeline.tsx
+++ b/preview-src/timeline.tsx
@@ -83,14 +83,15 @@ const reviewDescriptor = (state: string) =>
 
 const ReviewEventView = (event: ReviewEvent) => {
 	const comments = groupCommentsByPath(event.comments);
+	const reviewIsPending = event.state === 'PENDING';
 	return <div className='comment-container comment'>
 		<div className='review-comment-container'>
 			<div className='review-comment-header'>
 				<Spaced>
 					<Avatar for={event.user} />
 					<AuthorLink for={event.user} />{association(event)}
-					{ event.state === 'PENDING'
-						? <em>review pending</em>
+					{ reviewIsPending
+						? <span>review pending</span>
 						: <>
 								{reviewDescriptor(event.state)}{nbsp}
 								<Timestamp href={event.htmlUrl} date={event.submittedAt} />
@@ -112,12 +113,12 @@ const ReviewEventView = (event: ReviewEvent) => {
 									hunks={thread[0].diffHunks}
 									outdated={thread[0].position === null}
 									path={thread[0].path} />
-								{thread.map(c => <CommentView {...c} pullRequestReviewId={event.id} />)}
+								{thread.map(c => <CommentView {...c} pullRequestReviewId={event.id} parentPending={reviewIsPending} />)}
 							</div>
 					)
 			}</div>
 			{
-				event.state === 'PENDING' ?
+				reviewIsPending ?
 					<AddReviewSummaryComment />
 				: null
 			}


### PR DESCRIPTION
Resolves issue #1369 

<img width="824" alt="Screen Shot 2019-10-14 at 10 26 14 AM" src="https://user-images.githubusercontent.com/9094098/66759401-2f5dcb00-ee6e-11e9-8244-6ffa5f2ee8f2.png">

Added label and manually tested to confirm that it shows up only on comments for pending reviews. Added some minor styling to make the label more obvious like on GH, but am happy to leave as just an `em` tag, to match with the pending label already being used in the Diff view.