### PR TITLE
Make PR comment text area resize handle transparent

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -1108,3 +1108,7 @@ code {
 .title-editing-form > .form-actions {
 	margin-left: 0;
 }
+
+::-webkit-scrollbar-corner {
+	display: none;
+}


### PR DESCRIPTION
Fixes #1361

### Screenshots
#### Dark Theme
![](https://user-images.githubusercontent.com/9157833/66801891-81830880-eecf-11e9-82c3-40d117805699.png)

#### Light Theme
<img width="679" alt="Screen Shot 2019-10-15 at 10 40 27 PM" src="https://user-images.githubusercontent.com/9157833/66891029-de98c000-ef9c-11e9-8bda-e45c311c4317.png">
