### PR TITLE
Support images in 'review' and `pr` diff viewers

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -144,28 +144,58 @@ export interface Repository {
 	 * The counterpart of `getConfig`
 	 */
 	setConfig(key: string, value: string): Promise<string>;
+	getGlobalConfig(key: string): Promise<string>;
 
 	getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }>;
+	detectObjectType(object: string): Promise<{ mimetype: string, encoding?: string }>;
+	buffer(ref: string, path: string): Promise<Buffer>;
 	show(ref: string, path: string): Promise<string>;
 	getCommit(ref: string): Promise<Commit>;
+
+	clean(paths: string[]): Promise<void>;
+
 	apply(patch: string, reverse?: boolean): Promise<void>;
 	diff(cached?: boolean): Promise<string>;
+	diffWithHEAD(): Promise<Change[]>;
+	diffWithHEAD(path: string): Promise<string>;
+	diffWith(ref: string): Promise<Change[]>;
 	diffWith(ref: string, path: string): Promise<string>;
+	diffIndexWithHEAD(): Promise<Change[]>;
+	diffIndexWithHEAD(path: string): Promise<string>;
+	diffIndexWith(ref: string): Promise<Change[]>;
+	diffIndexWith(ref: string, path: string): Promise<string>;
 	diffBlobs(object1: string, object2: string): Promise<string>;
+	diffBetween(ref1: string, ref2: string): Promise<Change[]>;
 	diffBetween(ref1: string, ref2: string, path: string): Promise<string>;
+
 	hashObject(data: string): Promise<string>;
+
 	createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
 	deleteBranch(name: string, force?: boolean): Promise<void>;
 	getBranch(name: string): Promise<Branch>;
 	setBranchUpstream(name: string, upstream: string): Promise<void>;
+	getMergeBase(ref1: string, ref2: string): Promise<string>;
+
 	status(): Promise<void>;
 	checkout(treeish: string): Promise<void>;
+
 	addRemote(name: string, url: string): Promise<void>;
 	removeRemote(name: string): Promise<void>;
+
 	fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
 	pull(unshallow?: boolean): Promise<void>;
 	push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
+
 	blame(path: string): Promise<string>;
+	log(options?: LogOptions): Promise<Commit[]>;
+}
+
+/**
+ * Log options.
+ */
+export interface LogOptions {
+	/** Max number of log entries to retrieve. If not specified, the default is 32. */
+	readonly maxEntries?: number;
 }
 
 export const enum GitErrorCodes {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as pathLib from 'path';
 import { ReviewManager } from './view/reviewManager';
 import { PullRequestOverviewPanel } from './github/pullRequestOverview';
-import { fromReviewUri, ReviewUriParams, asImageDataURI } from './common/uri';
+import { fromReviewUri, ReviewUriParams, asImageDataURI, EMPTY_IMAGE_URI } from './common/uri';
 import { GitFileChangeNode, InMemFileChangeNode } from './view/treeNodes/fileChangeNode';
 import { CommitNode } from './view/treeNodes/commitNode';
 import { PRNode } from './view/treeNodes/pullRequestNode';
@@ -168,9 +168,9 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		const originalURI = imageDataURI || parentFilePath;
 
 		if (fileChangeNode.status === GitChangeType.ADD) {
-			vscode.commands.executeCommand('vscode.open', filePath);
+			vscode.commands.executeCommand('vscode.diff', EMPTY_IMAGE_URI, filePath, fileName, opts);
 		} else if (fileChangeNode.status === GitChangeType.DELETE) {
-			vscode.commands.executeCommand('vscode.open', originalURI);
+			vscode.commands.executeCommand('vscode.diff', originalURI, EMPTY_IMAGE_URI, fileName, opts);
 		} else {
 			vscode.commands.executeCommand('vscode.diff', originalURI, filePath, fileName, opts);
 		}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -162,10 +162,18 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		if (isPartial) {
 			vscode.window.showInformationMessage('Your local repository is not up to date so only partial content is being displayed');
 		}
+
 		// if this is an image, encode it as a base64 data URI
 		const imageDataURI = await asImageDataURI(parentFilePath, prManager.repository);
+		const originalURI = imageDataURI || parentFilePath;
 
-		vscode.commands.executeCommand('vscode.diff', imageDataURI || parentFilePath, filePath, fileName, opts);
+		if (fileChangeNode.status === GitChangeType.ADD) {
+			vscode.commands.executeCommand('vscode.open', filePath);
+		} else if (fileChangeNode.status === GitChangeType.DELETE) {
+			vscode.commands.executeCommand('vscode.open', originalURI);
+		} else {
+			vscode.commands.executeCommand('vscode.diff', originalURI, filePath, fileName, opts);
+		}
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffGitHub', (uri: string) => {

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -59,8 +59,10 @@ export const EMPTY_IMAGE_URI = Uri.parse(`data:image/gif;base64,R0lGODlhAQABAIAA
 
 export async function asImageDataURI(uri: Uri, repository: Repository): Promise<Uri | undefined> {
 	try {
-		const { commit } = JSON.parse(uri.query);
-		const { size, object } = await repository.getObjectDetails(commit, uri.fsPath);
+		const { commit, baseCommit, headCommit, isBase } = JSON.parse(uri.query);
+		const ref = uri.scheme === 'review' ? commit :
+			isBase ? baseCommit : headCommit;
+		const { size, object } = await repository.getObjectDetails(ref, uri.fsPath);
 		const { mimetype } = await repository.detectObjectType(object);
 
 		if (mimetype === 'text/plain') {
@@ -68,8 +70,8 @@ export async function asImageDataURI(uri: Uri, repository: Repository): Promise<
 		}
 
 		if (ImageMimetypes.indexOf(mimetype) > -1) {
-			const contents = await repository.buffer(commit, uri.fsPath);
-			return Uri.parse(`data:${mimetype};label:${pathUtils.basename(uri.fsPath)};description:${commit};size:${size};base64,${contents.toString('base64')}`);
+			const contents = await repository.buffer(ref, uri.fsPath);
+			return Uri.parse(`data:${mimetype};label:${pathUtils.basename(uri.fsPath)};description:${ref};size:${size};base64,${contents.toString('base64')}`);
 		}
 	} catch (err) {
 		return;

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -54,6 +54,9 @@ const ImageMimetypes = [
 	'image/bmp'
 ];
 
+// a 1x1 pixel transparent gif, from http://png-pixel.com/
+export const EMPTY_IMAGE_URI = Uri.parse(`data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==`);
+
 export async function asImageDataURI(uri: Uri, repository: Repository): Promise<Uri | undefined> {
 	try {
 		const { commit } = JSON.parse(uri.query);

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -9,7 +9,7 @@ import { Uri, UriHandler, EventEmitter } from 'vscode';
 import { GitChangeType } from './file';
 import { PullRequestModel } from '../github/pullRequestModel';
 import { Repository } from '../api/api';
-import * as path from 'path';
+import * as pathUtils from 'path';
 
 export interface ReviewUriParams {
 	path: string;
@@ -66,7 +66,7 @@ export async function asImageDataURI(uri: Uri, repository: Repository): Promise<
 
 		if (ImageMimetypes.indexOf(mimetype) > -1) {
 			const contents = await repository.buffer(commit, uri.fsPath);
-			return Uri.parse(`data:${mimetype};label:${path.basename(uri.fsPath)};description:${commit};size:${size};base64,${contents.toString('base64')}`);
+			return Uri.parse(`data:${mimetype};label:${pathUtils.basename(uri.fsPath)};description:${commit};size:${size};base64,${contents.toString('base64')}`);
 		}
 	} catch (err) {
 		return;

--- a/src/test/mocks/mockRepository.ts
+++ b/src/test/mocks/mockRepository.ts
@@ -44,13 +44,13 @@ export class MockRepository implements Repository {
 		mergeChanges: [],
 		indexChanges: [],
 		workingTreeChanges: [],
-		onDidChange: () => ({ dispose() { } }),
+		onDidChange: () => ({ dispose() {} }),
 	};
 	private _config: Map<string, string> = new Map();
 	private _branches: Branch[] = [];
-	private _expectedFetches: { remoteName?: string, ref?: string, depth?: number }[] = [];
-	private _expectedPulls: { unshallow?: boolean }[] = [];
-	private _expectedPushes: { remoteName?: string, branchName?: string, setUpstream?: boolean }[] = [];
+	private _expectedFetches: {remoteName?: string, ref?: string, depth?: number}[] = [];
+	private _expectedPulls: {unshallow?: boolean}[] = [];
+	private _expectedPushes: {remoteName?: string, branchName?: string, setUpstream?: boolean}[] = [];
 
 	rootUri = Uri.file('/root');
 
@@ -58,11 +58,11 @@ export class MockRepository implements Repository {
 
 	ui: RepositoryUIState = {
 		selected: true,
-		onDidChange: () => ({ dispose() { } }),
+		onDidChange: () => ({ dispose() {} }),
 	};
 
-	async getConfigs(): Promise<{ key: string, value: string }[]> {
-		return Array.from(this._config, ([k, v]) => ({ key: k, value: v }));
+	async getConfigs(): Promise<{key: string, value: string}[]> {
+		return Array.from(this._config, ([k, v]) => ({key: k, value: v}));
 	}
 
 	async getConfig(key: string): Promise<string> {
@@ -252,14 +252,14 @@ export class MockRepository implements Repository {
 	}
 
 	expectFetch(remoteName?: string, ref?: string, depth?: number) {
-		this._expectedFetches.push({ remoteName, ref, depth });
+		this._expectedFetches.push({remoteName, ref, depth});
 	}
 
 	expectPull(unshallow?: boolean) {
-		this._expectedPulls.push({ unshallow });
+		this._expectedPulls.push({unshallow});
 	}
 
 	expectPush(remoteName?: string, branchName?: string, setUpstream?: boolean) {
-		this._expectedPushes.push({ remoteName, branchName, setUpstream });
+		this._expectedPushes.push({remoteName, branchName, setUpstream});
 	}
 }

--- a/src/test/mocks/mockRepository.ts
+++ b/src/test/mocks/mockRepository.ts
@@ -1,12 +1,40 @@
 import { Uri } from 'vscode';
 
-import { Repository, RepositoryState, RepositoryUIState, Commit, Branch, RefType } from '../../api/api';
+import { Repository, RepositoryState, RepositoryUIState, Commit, Change, Branch, RefType } from '../../api/api';
 
 type Mutable<T> = {
-	-readonly[P in keyof T]: T[P];
+	-readonly [P in keyof T]: T[P];
 };
 
 export class MockRepository implements Repository {
+	getGlobalConfig(key: string): Promise<string> {
+		return Promise.reject(new Error(`Unexpected getGlobalConfig(${key})`));
+	}
+	detectObjectType(object: string): Promise<{ mimetype: string; encoding?: string | undefined; }> {
+		return Promise.reject(new Error(`Unexpected detectObjectType(${object})`));
+	}
+	buffer(ref: string, path: string): Promise<Buffer> {
+		return Promise.reject(new Error(`Unexpected buffer(${ref}, ${path})`));
+	}
+	clean(paths: string[]): Promise<void> {
+		return Promise.reject(new Error(`Unexpected clean(${paths})`));
+	}
+	diffWithHEAD(path?: any): any {
+		return Promise.reject(new Error(`Unexpected diffWithHEAD(${path})`));
+	}
+	diffIndexWithHEAD(path?: any): any {
+		return Promise.reject(new Error(`Unexpected diffIndexWithHEAD(${path})`));
+	}
+	diffIndexWith(ref: any, path?: any): any {
+		return Promise.reject(new Error(`Unexpected diffIndexWith(${ref}, ${path})`));
+	}
+	getMergeBase(ref1: string, ref2: string): Promise<string> {
+		return Promise.reject(new Error(`Unexpected getMergeBase(${ref1}, ${ref2})`));
+	}
+	log(options?: any): Promise<Commit[]> {
+		return Promise.reject(new Error(`Unexpected log(${options})`));
+	}
+
 	private _state: Mutable<RepositoryState> = {
 		HEAD: undefined,
 		refs: [],
@@ -16,13 +44,13 @@ export class MockRepository implements Repository {
 		mergeChanges: [],
 		indexChanges: [],
 		workingTreeChanges: [],
-		onDidChange: () => ({ dispose() {} }),
+		onDidChange: () => ({ dispose() { } }),
 	};
 	private _config: Map<string, string> = new Map();
 	private _branches: Branch[] = [];
-	private _expectedFetches: {remoteName?: string, ref?: string, depth?: number}[] = [];
-	private _expectedPulls: {unshallow?: boolean}[] = [];
-	private _expectedPushes: {remoteName?: string, branchName?: string, setUpstream?: boolean}[] = [];
+	private _expectedFetches: { remoteName?: string, ref?: string, depth?: number }[] = [];
+	private _expectedPulls: { unshallow?: boolean }[] = [];
+	private _expectedPushes: { remoteName?: string, branchName?: string, setUpstream?: boolean }[] = [];
 
 	rootUri = Uri.file('/root');
 
@@ -30,11 +58,11 @@ export class MockRepository implements Repository {
 
 	ui: RepositoryUIState = {
 		selected: true,
-		onDidChange: () => ({ dispose() {} }),
+		onDidChange: () => ({ dispose() { } }),
 	};
 
-	async getConfigs(): Promise<{key: string, value: string}[]> {
-		return Array.from(this._config, ([k, v]) => ({key: k, value: v}));
+	async getConfigs(): Promise<{ key: string, value: string }[]> {
+		return Array.from(this._config, ([k, v]) => ({ key: k, value: v }));
 	}
 
 	async getConfig(key: string): Promise<string> {
@@ -67,7 +95,9 @@ export class MockRepository implements Repository {
 		return Promise.reject(new Error(`Unexpected diff(${cached})`));
 	}
 
-	diffWith(ref: string, treePath: string): Promise<string> {
+	diffWith(ref: string): Promise<Change[]>;
+	diffWith(ref: string, treePath: string): Promise<string>;
+	diffWith(ref: string, treePath?: string) {
 		return Promise.reject(new Error(`Unexpected diffWith(${ref}, ${treePath})`));
 	}
 
@@ -75,7 +105,9 @@ export class MockRepository implements Repository {
 		return Promise.reject(new Error(`Unexpected diffBlobs(${object1}, ${object2})`));
 	}
 
-	diffBetween(ref1: string, ref2: string, treePath: string): Promise<string> {
+	diffBetween(ref1: string, ref2: string): Promise<Change[]>;
+	diffBetween(ref1: string, ref2: string, treePath: string): Promise<string>;
+	diffBetween(ref1: string, ref2: string, treePath?: string) {
 		return Promise.reject(new Error(`Unexpected diffBlobs(${ref1}, ${ref2}, ${treePath})`));
 	}
 
@@ -220,14 +252,14 @@ export class MockRepository implements Repository {
 	}
 
 	expectFetch(remoteName?: string, ref?: string, depth?: number) {
-		this._expectedFetches.push({remoteName, ref, depth});
+		this._expectedFetches.push({ remoteName, ref, depth });
 	}
 
 	expectPull(unshallow?: boolean) {
-		this._expectedPulls.push({unshallow});
+		this._expectedPulls.push({ unshallow });
 	}
 
 	expectPush(remoteName?: string, branchName?: string, setUpstream?: boolean) {
-		this._expectedPushes.push({remoteName, branchName, setUpstream});
+		this._expectedPushes.push({ remoteName, branchName, setUpstream });
 	}
 }


### PR DESCRIPTION
Fixes #1356.

Uses a trick from the builtin git extension to represent images as data URL's, as the `provideTextDocument` API does not handle images. There is a `fileSystemProvider` API that we could use instead, but it ends up being more complicated.