### PR TITLE
Both Focus and Select tree item on triggering secondary action

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -155,7 +155,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		const isPartial = fileChangeNode.isPartial;
 		const opts = fileChangeNode.opts;
 
-		fileChangeNode.reveal(fileChangeNode, { select: true });
+		fileChangeNode.reveal(fileChangeNode, { select: true, focus: true });
 
 		if (isPartial) {
 			vscode.window.showInformationMessage('Your local repository is not up to date so only partial content is being displayed');

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -325,7 +325,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 			descriptionNode = rootNodes[0] as DescriptionNode;
 		}
 		const pullRequest = ensurePR(prManager, descriptionNode.pullRequestModel);
-		descriptionNode.reveal(descriptionNode, { select: true });
+		descriptionNode.reveal(descriptionNode, { select: true, focus: true });
 		// Create and show a new webview
 		PullRequestOverviewPanel.createOrShow(context.extensionPath, prManager, pullRequest, descriptionNode);
 
@@ -344,7 +344,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDescriptionToTheSide', async (descriptionNode: DescriptionNode) => {
 		const pr = descriptionNode.pullRequestModel;
 		const pullRequest = ensurePR(prManager, pr);
-		descriptionNode.reveal(descriptionNode, { select: true });
+		descriptionNode.reveal(descriptionNode, { select: true, focus: true });
 		// Create and show a new webview
 		PullRequestOverviewPanel.createOrShow(context.extensionPath, prManager, pullRequest, descriptionNode, true);
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -94,12 +94,12 @@ export class ReviewManager implements vscode.DecorationProvider {
 			const uri = value instanceof GitFileChangeNode ? value.filePath : value;
 
 			if (value instanceof GitFileChangeNode) {
-				value.reveal(value, { select: true });
+				value.reveal(value, { select: true, focus: true });
 			}
 
 			const activeTextEditor = vscode.window.activeTextEditor;
 			const opts: vscode.TextDocumentShowOptions = {
-				preserveFocus: false,
+				preserveFocus: true,
 				viewColumn: vscode.ViewColumn.Active
 			};
 

--- a/src/view/treeNodes/treeNode.ts
+++ b/src/view/treeNodes/treeNode.ts
@@ -24,7 +24,7 @@ export abstract class TreeNode implements vscode.Disposable {
 	}
 
 	async reveal(treeNode: TreeNode, options?: { select?: boolean, focus?: boolean, expand?: boolean | number }): Promise<void> {
-		return this.parent.reveal(treeNode || this);
+		return this.parent.reveal(treeNode || this, options);
 	}
 
 	async revealComment?(comment: IComment) { }


### PR DESCRIPTION
Fixes #1217 

Previously, on triggering a secondary action, the tree view item would gain selected status, but not focused status. Additionally, previously, the 'openFile' command would move focus to the editor, hiding this issue when `git.openDiffOnClick` was true, and reducing keyboard accessibility (#198).

This PR forces the selected item to also gain focus, and prohibits focus from transferring to editor on click.