### PR TITLE
Normalize www.github.com => github.com. Fixes #903

### DIFF
--- a/src/common/protocol.ts
+++ b/src/common/protocol.ts
@@ -83,7 +83,10 @@ export class Protocol {
 		const matches = /^(?:.*:?@)?([^:]*)(?::.*)?$/.exec(authority);
 
 		if (matches && matches.length >= 2) {
-			return matches[1];
+
+			// normalize to fix #903.
+			// www.github.com will redirect anyways, so this is safe in this specific case, but potentially not in others.
+			return matches[1].toLocaleLowerCase() === 'www.github.com' ? 'github.com' : matches[1];
 		}
 
 		return '';

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -34,8 +34,10 @@ describe('Protocol', () => {
 		[
 			{ uri: 'http://rmacfarlane@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'http://rmacfarlane:password@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://rmacfarlane:password@www.github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'http://github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'http://github.com/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'http://www.github.com/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'http://github.com:/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'http://github.com:433/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'https://rmacfarlane@github.com/Microsoft/vscode', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
@@ -44,6 +46,7 @@ describe('Protocol', () => {
 			{ uri: 'https://github.com/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'https://github.com:/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'https://github.com:433/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
+			{ uri: 'https://www.github.com:433/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.com', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' },
 			{ uri: 'https://github.enterprise.corp/Microsoft/vscode.git', expectedType: ProtocolType.HTTP, expectedHost: 'github.enterprise.corp', expectedOwner: 'Microsoft', expectedRepositoryName: 'vscode' }
 		].forEach(testRemote)
 	);


### PR DESCRIPTION
Applying the normalization in `src/common/protocol.ts` as opposed to `src/authentication/configuration.ts`, as applying right at initial URI normalization fixes issues with needing to authenticate to `www.github.com` separately from `github.com`, and fixes some strange issues with profile pictures not appearing.