### PR TITLE
Preserve expansaion state of tree view items on checkout

### DIFF
--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -428,6 +428,7 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 			prNumber,
 			author,
 			isDraft,
+			html_url
 		} = this.pullRequestModel;
 
 		const {
@@ -443,6 +444,7 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 
 		return {
 			label,
+			id: html_url, // unique id stable across checkout status
 			tooltip,
 			description,
 			collapsibleState: 1,


### PR DESCRIPTION
Fixes #238 by adding an `id` parameter (the PR's URL) to the `TreeItem`'s, whereas previously they defaulted to using the `label` as the `id`, which was not stable across checking out (the `✓` would come and go). 


