### PR TITLE
Add overflow-wrap to fix text overflow in comment-body

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -49,6 +49,10 @@ a:focus, input:focus, select:focus, textarea:focus, .title-text:focus {
 	display: inline;
 }
 
+.comment-body code, .comment-body a, span.lineContent {
+    overflow-wrap: break-word;
+}
+
 #title:empty {
 	border: none;
 }


### PR DESCRIPTION
This happens when you resize Editor too narrow the text in `code`, `a` will overflow

Before
![Screen Shot 2562-10-18 at 15 50 35](https://user-images.githubusercontent.com/2588927/67081052-a5409a00-f1c0-11e9-90c8-17c0ca056050.png)

After
![Screen Shot 2562-10-18 at 15 52 03](https://user-images.githubusercontent.com/2588927/67080968-79bdaf80-f1c0-11e9-91b9-8759f771af78.png)



Before 
![Screen Shot 2562-10-18 at 15 55 20](https://user-images.githubusercontent.com/2588927/67080986-804c2700-f1c0-11e9-9218-5d49c25a93c0.png)
After
![Screen Shot 2562-10-18 at 15 57 28](https://user-images.githubusercontent.com/2588927/67080991-83dfae00-f1c0-11e9-8efe-87d34adbaebc.png)



#806 