### PR TITLE
When file change has an empty patch, try to directly fetch the file contents

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -163,16 +163,6 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		vscode.commands.executeCommand('vscode.diff', parentFilePath, filePath, fileName, opts);
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffGitHub', (uri: string) => {
-		vscode.window
-			.showWarningMessage('This file is either too large, of an unsupported type, or has only been renamed. Would you like to view it on GitHub?', 'Open in GitHub')
-			.then(result => {
-				if (result === 'Open in GitHub') {
-					vscode.commands.executeCommand('vscode.open', uri);
-				}
-			});
-	}));
-
 	context.subscriptions.push(vscode.commands.registerCommand('pr.deleteLocalBranch', async (e: PRNode) => {
 		const pullRequestModel = ensurePR(prManager, e);
 		const DELETE_BRANCH_FORCE = 'delete branch (even if not merged)';

--- a/src/common/diffHunk.ts
+++ b/src/common/diffHunk.ts
@@ -260,18 +260,8 @@ export async function parseDiff(reviews: IRawFileChange[], repository: Repositor
 		const gitChangeType = getGitChangeType(review.status);
 
 		if (!review.patch) {
-			// Patch is not returned if
-			// 1. File has only been renamed
-			// 2. The diff is "too large"
-			// 3. The file is empty
-			// 4. Unknown other reasons
-			// Treat case 3 as something that should be opened locally, offer to open everything else on GitHub
-			if (review.status === 'renamed' || review.additions || review.changes || review.deletions) {
-				fileChanges.push(new SlimFileChange(review.blob_url, gitChangeType, review.filename, review.previous_filename));
-				continue;
-			} else {
-				review.patch = '';
-			}
+			fileChanges.push(new SlimFileChange(parentCommit, review.blob_url, gitChangeType, review.filename, review.previous_filename));
+			continue;
 		}
 
 		let originalFileExist = false;

--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -33,6 +33,7 @@ export class InMemFileChange {
 
 export class SlimFileChange {
 	constructor(
+		public readonly baseCommit: string,
 		public readonly blobUrl: string,
 		public readonly status: GitChangeType,
 		public readonly fileName: string,

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -807,6 +807,20 @@ export class PullRequestManager implements vscode.Disposable {
 		}
 	}
 
+	async getFile(pullRequest: PullRequestModel, filePath: string, commit: string) {
+		const { octokit, remote } = await pullRequest.githubRepository.ensure();
+		const fileContent = await octokit.repos.getContents({
+			owner: remote.owner,
+			repo: remote.repositoryName,
+			path: filePath,
+			ref: commit
+		});
+
+		const contents = fileContent.data.content;
+		const buff = new Buffer(contents, fileContent.data.encoding);
+		return buff.toString();
+	}
+
 	async getTimelineEvents(pullRequest: PullRequestModel): Promise<TimelineEvent[]> {
 		Logger.debug(`Fetch timeline events of PR #${pullRequest.prNumber} - enter`, PullRequestManager.ID);
 		const githubRepository = pullRequest.githubRepository;

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -365,7 +365,7 @@ export class ReviewManager implements vscode.DecorationProvider {
 			if (change instanceof InMemFileChange) {
 				isPartial = change.isPartial;
 				diffHunks = change.diffHunks;
-			} else {
+			} else if (change.status !== GitChangeType.RENAME) {
 				try {
 					const patch = await this._repository.diffBetween(pr.base.sha, pr.head.sha, change.fileName);
 					diffHunks = parsePatch(patch);

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -22,15 +22,20 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 	public iconPath?: string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } | vscode.ThemeIcon;
 	public command: vscode.Command;
 	public resourceUri: vscode.Uri;
+	public contextValue: string;
 
 	constructor(
 		public readonly parent: TreeNode | vscode.TreeView<TreeNode>,
 		public readonly pullRequest: PullRequestModel,
 		public readonly status: GitChangeType,
 		public readonly fileName: string,
-		public readonly blobUrl: string
+		public readonly previousFileName: string | undefined,
+		public readonly blobUrl: string,
+		public readonly filePath: vscode.Uri,
+		public readonly parentFilePath: vscode.Uri
 	) {
 		super();
+		this.contextValue = `filechange:${GitChangeType[status]}`;
 		this.label = path.basename(fileName);
 		this.description = path.relative('.', path.dirname(fileName));
 		this.iconPath = vscode.ThemeIcon.File;
@@ -38,9 +43,9 @@ export class RemoteFileChangeNode extends TreeNode implements vscode.TreeItem {
 
 		this.command = {
 			title: 'show remote file',
-			command: 'pr.openDiffGitHub',
+			command: 'pr.openDiffView',
 			arguments: [
-				vscode.Uri.parse(this.blobUrl)
+				this
 			]
 		};
 	}

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -356,8 +356,9 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 				let oldCommentThreads: GHPRCommentThread[] = [];
 
 				if (incremental) {
-					const oldLeftSideCommentThreads = commentThreadCache[editor.fileName].filter(thread => thread.uri.toString() === parentFilePath.toString());
-					const oldRightSideCommentThreads = commentThreadCache[editor.fileName].filter(thread => thread.uri.toString() === filePath.toString());
+					const cachedThreads = commentThreadCache[editor.fileName] || [];
+					const oldLeftSideCommentThreads = cachedThreads.filter(thread => thread.uri.toString() === parentFilePath.toString());
+					const oldRightSideCommentThreads = cachedThreads.filter(thread => thread.uri.toString() === filePath.toString());
 
 					oldCommentThreads = [...oldLeftSideCommentThreads, ...oldRightSideCommentThreads];
 				}


### PR DESCRIPTION
Completely removes the "Would you like to open this in GitHub?" notification when the file change does not have a patch. Instead, when loading the diff, make another request to fetch the file content for that commit.

https://github.com/microsoft/vscode-pull-request-github/issues/305
https://github.com/microsoft/vscode-pull-request-github/issues/1160