### PR TITLE
Show PR actions only to users with push access (fixes #967)

### DIFF
--- a/preview-src/cache.ts
+++ b/preview-src/cache.ts
@@ -25,6 +25,11 @@ export interface PullRequest {
 	commitsCount: number;
 	repositoryDefaultBranch: any;
 	canEdit: boolean;
+	/**
+	 * Users with push access to repo have rights to merge/close PRs,
+	 * edit title/description, assign reviewers/labels etc.
+	 */
+	hasWritePermission: boolean;
 	pendingCommentText?: string;
 	pendingCommentDrafts?: { [key: string]: string; };
 	status: ReposGetCombinedStatusForRefResponse;

--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -221,7 +221,7 @@ export const CommentBody = ({ comment, bodyHTML, body }: Embodied) => {
 	</div>;
 };
 
-export function AddComment({ pendingCommentText, state }: PullRequest) {
+export function AddComment({ pendingCommentText, state, hasWritePermission }: PullRequest) {
 	const { updatePR, comment, requestChanges, approve, close } = useContext(PullRequestContext);
 	const [ isBusy, setBusy ] = useState(false);
 	const form = useRef<HTMLFormElement>();
@@ -276,11 +276,14 @@ export function AddComment({ pendingCommentText, state }: PullRequest) {
 				value={pendingCommentText}
 				placeholder='Leave a comment' />
 			<div className='form-actions'>
-				<button id='close'
-					className='secondary'
-					disabled={isBusy || state !== PullRequestStateEnum.Open}
-					onClick={onClick}
-					data-command='close'>Close Pull Request</button>
+				{ hasWritePermission
+					? <button id='close'
+						className='secondary'
+						disabled={isBusy || state !== PullRequestStateEnum.Open}
+						onClick={onClick}
+						data-command='close'>Close Pull Request</button>
+					: null
+				}
 				<button id='request-changes'
 					disabled={isBusy || !pendingCommentText}
 					className='secondary'

--- a/preview-src/test/builder/pullRequest.ts
+++ b/preview-src/test/builder/pullRequest.ts
@@ -22,6 +22,7 @@ export const PullRequestBuilder = createBuilderClass<PullRequest>()({
 	commitsCount: {default: 10},
 	repositoryDefaultBranch: {default: 'master'},
 	canEdit: {default: true},
+	hasWritePermission: {default: true},
 	pendingCommentText: {default: null},
 	pendingCommentDrafts: {default: null},
 	status: {linked: CombinedStatusBuilder},

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -102,3 +102,8 @@ export type MergeMethod = 'merge' | 'squash' | 'rebase';
 export type MergeMethodsAvailability = {
 	[method in MergeMethod]: boolean;
 };
+
+export type RepoAccessAndMergeMethods = {
+	hasWritePermission: boolean;
+	mergeMethodsAvailability: MergeMethodsAvailability
+};

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -11,7 +11,7 @@ import { IComment } from '../common/comment';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
 import { TimelineEvent, EventType, ReviewEvent as CommonReviewEvent, isReviewEvent, isCommitEvent } from '../common/timelineEvent';
 import { GitHubRepository } from './githubRepository';
-import { IPullRequestsPagingOptions, PRType, ReviewEvent, IPullRequestEditData, PullRequest, IRawFileChange, IAccount, ILabel, MergeMethodsAvailability } from './interface';
+import { IPullRequestsPagingOptions, PRType, ReviewEvent, IPullRequestEditData, PullRequest, IRawFileChange, IAccount, ILabel, RepoAccessAndMergeMethods } from './interface';
 import { PullRequestGitHelper, PullRequestMetadata } from './pullRequestGitHelper';
 import { PullRequestModel, IResolvedPullRequestModel } from './pullRequestModel';
 import { GitHubManager } from '../authentication/githubServer';
@@ -1783,8 +1783,8 @@ export class PullRequestManager implements vscode.Disposable {
 		return branch;
 	}
 
-	async getPullRequestRepositoryMergeMethodsAvailability(pullRequest: PullRequestModel): Promise<MergeMethodsAvailability> {
-		const mergeOptions = await pullRequest.githubRepository.getMergeMethodsAvailability();
+	async getPullRequestRepositoryAccessAndMergeMethods(pullRequest: PullRequestModel): Promise<RepoAccessAndMergeMethods> {
+		const mergeOptions = await pullRequest.githubRepository.getRepoAccessAndMergeMethods();
 		return mergeOptions;
 	}
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -206,9 +206,9 @@ export class PullRequestOverviewPanel {
 			this._pullRequestManager.getPullRequestRepositoryDefaultBranch(pullRequestModel),
 			this._pullRequestManager.getStatusChecks(pullRequestModel),
 			this._pullRequestManager.getReviewRequests(pullRequestModel),
-			this._pullRequestManager.getPullRequestRepositoryMergeMethodsAvailability(pullRequestModel),
+			this._pullRequestManager.getPullRequestRepositoryAccessAndMergeMethods(pullRequestModel),
 		]).then(result => {
-			const [pullRequest, timelineEvents, defaultBranch, status, requestedReviewers, mergeMethodsAvailability] = result;
+			const [pullRequest, timelineEvents, defaultBranch, status, requestedReviewers, {hasWritePermission, mergeMethodsAvailability }] = result;
 			if (!pullRequest) {
 				throw new Error(`Fail to resolve Pull Request #${pullRequestModel.prNumber} in ${pullRequestModel.remote.owner}/${pullRequestModel.remote.repositoryName}`);
 			}
@@ -247,6 +247,7 @@ export class PullRequestOverviewPanel {
 					head: this._pullRequest.head && this._pullRequest.head.label || 'UNKNOWN',
 					repositoryDefaultBranch: defaultBranch,
 					canEdit: canEdit,
+					hasWritePermission,
 					status: status ? status : { statuses: [] },
 					mergeable: this._pullRequest.prItem.mergeable,
 					reviewers: this.parseReviewers(requestedReviewers, timelineEvents, this._pullRequest.author),


### PR DESCRIPTION
This PR changes visibility rules for PR actions (Merge, Mark as ready for review) which were previously available to all users.

- "Merge Pull Request" button, merge method dropdown, and "Close Pull Request" button only available to users with push permission

- "Ready for review" button only available for PR author and users with push permission

With `canMerge` in place it is now possible to change visibility of more controls - edit title/description #1065 and add/remove reviewers and labels (not sure if there is tracking issue).
Should I change visibility rules for these places too or in separate PR?