### PR TITLE
Don't prompt for sign in after user has ignored once. 

### DIFF
--- a/src/common/persistentState.ts
+++ b/src/common/persistentState.ts
@@ -8,11 +8,11 @@ export const MISSING = {} as const;
 
 export function init(ctx: GlobalStateContext) {
 	defaultStorage = ctx.globalState;
-};
+}
 
 export const fetch = (scope: string, key: string): unknown => {
 	if (!defaultStorage) {
-		throw new Error('Persistent store not initialized.')
+		throw new Error('Persistent store not initialized.');
 	}
 	return defaultStorage.get(scope + ':' + key, MISSING);
 };

--- a/src/common/persistentState.ts
+++ b/src/common/persistentState.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import * as vscode from 'vscode';
 
 export type GlobalStateContext = { globalState: vscode.Memento };

--- a/src/common/persistentState.ts
+++ b/src/common/persistentState.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+
+export type GlobalStateContext = { globalState: vscode.Memento };
+
+let defaultStorage: vscode.Memento | undefined = undefined;
+
+export const MISSING = {} as const;
+
+export function init(ctx: GlobalStateContext) {
+	defaultStorage = ctx.globalState;
+};
+
+export const fetch = (scope: string, key: string): unknown => {
+	if (!defaultStorage) {
+		throw new Error('Persistent store not initialized.')
+	}
+	return defaultStorage.get(scope + ':' + key, MISSING);
+};
+
+export const store = (scope: string, key: string, value: any) => {
+	if (!defaultStorage) {
+		throw new Error('Persistent store not initialized.');
+	}
+	return defaultStorage.update(scope + ':' + key, value);
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import Logger from './common/logger';
 import { Resource } from './common/resources';
 import { handler as uriHandler } from './common/uri';
 import { formatError, onceEvent } from './common/utils';
+import * as PersistentState from './common/persistentState';
 import { EXTENSION_ID } from './constants';
 import { PullRequestManager } from './github/pullRequestManager';
 import { registerBuiltinGitProvider, registerLiveShareGitProvider } from './gitProviders/api';
@@ -36,6 +37,8 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, repository: 
 	Logger.appendLine('Git repository found, initializing review manager and pr tree view.');
 
 	Keychain.init(context);
+	PersistentState.init(context);
+
 	await migrateConfiguration();
 	context.subscriptions.push(Keychain.onDidChange(async _ => {
 		if (prManager) {

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -21,7 +21,7 @@ import { ITelemetry } from '../common/telemetry';
 
 const TRY_AGAIN = 'Try again?';
 const SIGNIN_COMMAND = 'Sign in';
-const IGNORE_COMMAND = 'Close';
+const IGNORE_COMMAND = 'Don\'t show again';
 
 const PROMPT_FOR_SIGN_IN_SCOPE = 'prompt for sign in';
 const AUTH_INPUT_TOKEN_CMD = 'auth.inputTokenCallback';
@@ -115,7 +115,7 @@ export class CredentialStore implements vscode.Disposable {
 		const storageKey = `${normalizedUri.scheme}://${normalizedUri.authority}`;
 
 		if (PersistentState.fetch(PROMPT_FOR_SIGN_IN_SCOPE, storageKey) === false) {
-			return;
+			// return;
 		}
 
 		const result = await vscode.window.showInformationMessage(


### PR DESCRIPTION
Fixes #1389.

Added a new persistent global state store, as it seems like the existing solution (authentication/keychain.ts) was pretty heavily tied to passwords/keytar.