### PR TITLE
Use proper API to get webview script URI

### DIFF
--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -778,7 +778,7 @@ export class PullRequestOverviewPanel {
 
 	private getHtmlForWebview(number: string) {
 		const scriptPathOnDisk = vscode.Uri.file(path.join(this._extensionPath, 'media', 'index.js'));
-		const scriptUri = scriptPathOnDisk.with({ scheme: 'vscode-resource' });
+		const scriptUri = this._panel.webview.asWebviewUri(scriptPathOnDisk);
 		const nonce = getNonce();
 
 		return `<!DOCTYPE html>


### PR DESCRIPTION
Minor change to remove [warning introduced in VSCode 1.39](https://code.visualstudio.com/updates/v1_39#_warning-if-webviews-dont-use-webviewaswebviewuri-for-local-resources). Noticed only during extension debug at this point.

![image](https://user-images.githubusercontent.com/1312662/67606854-50d28700-f78b-11e9-8981-394139ed3cb4.png)

As I can see 1.39 is now minimum required VSCode version and `asWebviewUri` was introduced in 1.38, so it shouldn't break anything.