### PR TITLE
Diff: disable selecting line numbers

### DIFF
--- a/preview-src/diff.tsx
+++ b/preview-src/diff.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 
 import { IComment } from '../src/common/comment';
-import { DiffHunk, DiffLine } from '../src/common/diffHunk';
+import { DiffHunk, DiffLine, DiffChangeType } from '../src/common/diffHunk';
 import PullRequestContext from './context';
 
 function Diff({ comment, hunks, path, outdated=false }: { comment: IComment, hunks: DiffHunk[], outdated: boolean, path: string }) {
@@ -23,7 +23,8 @@ const Hunk = ({ hunk, maxLines=4 }: {hunk: DiffHunk, maxLines?: number }) => <>{
 			<div key={keyForDiffLine(line)} className={`diffLine ${getDiffChangeClass(line.type)}`}>
 				<LineNumber num={line.oldLineNumber} />
 				<LineNumber num={line.newLineNumber} />
-				<span className='lineContent'>{(line as any)._raw}</span>
+				<span className='diffTypeSign'>{(line as any)._raw.substr(0,1)}</span>
+				<span className='lineContent'>{(line as any)._raw.substr(1)}</span>
 			</div>)
 }</>;
 
@@ -32,23 +33,6 @@ const keyForDiffLine = (diffLine: DiffLine) =>
 
 const LineNumber = ({ num }: { num: number }) =>
 	<span className='lineNumber'>{num > 0 ? num : ' '}</span>;
-
-export enum DiffChangeType {
-	Context,
-	Add,
-	Delete,
-	Control
-}
-
-export function getDiffChangeType(text: string) {
-	const c = text[0];
-	switch (c) {
-		case ' ': return DiffChangeType.Context;
-		case '+': return DiffChangeType.Add;
-		case '-': return DiffChangeType.Delete;
-		default: return DiffChangeType.Control;
-	}
-}
 
 const getDiffChangeClass = (type: DiffChangeType) =>
 	DiffChangeType[type].toLowerCase();

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -951,6 +951,11 @@ code {
 	background-color: var(--vscode-diffEditor-removedTextBackground);
 }
 
+.diff .diffLine .diffTypeSign {
+	user-select: none;
+	padding-right: 5px;
+}
+
 .diff .diffLine .lineNumber {
 	width: 1%;
 	min-width: 50px;
@@ -963,6 +968,7 @@ code {
 	vertical-align: top;
 	box-sizing: border-box;
 	display: inline-block;
+	user-select: none;
 	font-family: var(--vscode-editor-font-family);
 }
 


### PR DESCRIPTION
Fixes: #354 

This PR:
Splits line content into: `LineNumber`, `diffTypeSign` and `lineContent`
Sets `user-select: none;` for everything that is not a lineContent
Removes some duplicated code from `diff.tsx` file 

I'm not so proud of using private `_raw` field but i was unable to use `DiffLine` methods.