### PR TITLE
Fix for displaying invalid pull request messages

### DIFF
--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -154,7 +154,7 @@ export class PullRequestModel implements IPullRequestModel {
 			message = reason;
 		}
 
-		vscode.window.showWarningMessage(reason, 'Open in GitHub').then(action => {
+		vscode.window.showWarningMessage(message, 'Open in GitHub').then(action => {
 			if (action && action === 'Open in GitHub') {
 				vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(this.html_url));
 			}


### PR DESCRIPTION
No matter what was passed as `message`, warning message was always the
same. Probably someone confused those two variables.

### Previous behavior:
`validatePullRequestModel()`
displays: 
`There is no upstream branch for Pull Request #${this.prNumber}. View it on GitHub for more details`

`validatePullRequestModel('Checkout pull request failed')`
displays: 
`There is no upstream branch for Pull Request #${this.prNumber}. View it on GitHub for more details`

### After merging this PR:
`validatePullRequestModel()`
displays: 
`There is no upstream branch for Pull Request #${this.prNumber}. View it on GitHub for more details`

`validatePullRequestModel('Checkout pull request failed')`
displays: 
`Checkout pull request failed: There is no upstream branch for Pull Request #${this.prNumber}. View it on GitHub for more details`

