### PR TITLE
Show suggested reviewers and limit list to assignable users

### DIFF
--- a/src/github/enterprise.gql
+++ b/src/github/enterprise.gql
@@ -248,6 +248,16 @@ query PullRequest($owner: String!, $name: String!, $number: Int!) {
 			mergeable
 			id
 			databaseId
+			suggestedReviewers {
+				isAuthor
+				isCommenter
+				reviewer {
+					login
+					avatarUrl
+					name
+					url
+				}
+			}
 		}
 	}
 	rateLimit {
@@ -364,6 +374,29 @@ mutation DeleteReaction($input: RemoveReactionInput!){
 query GetMentionableUsers($owner: String!, $name: String!, $first: Int!, $after: String) {
 	repository(owner: $owner, name: $name) {
 		mentionableUsers(first: $first, after: $after) {
+			nodes {
+				login
+				avatarUrl
+				name
+				url
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
+	}
+}
+
+query GetAssignableUsers($owner: String!, $name: String!, $first: Int!, $after: String) {
+	repository(owner: $owner, name: $name) {
+		assignableUsers(first: $first, after: $after) {
 			nodes {
 				login
 				avatarUrl

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -205,14 +205,30 @@ export interface PullRequestCommentsResponse {
 export interface MentionableUsersResponse {
 	repository: {
 		mentionableUsers: {
-			nodes: [
-				{
-					login: string;
-					avatarUrl: string;
-					name: string;
-					url: string;
-				}
-			];
+			nodes: {
+				login: string;
+				avatarUrl: string;
+				name: string;
+				url: string;
+			}[];
+			pageInfo: {
+				hasNextPage: boolean;
+				endCursor: string;
+			};
+		}
+	};
+	rateLimit: RateLimit;
+}
+
+export interface AssignableUsersResponse {
+	repository: {
+		assignableUsers: {
+			nodes: {
+				login: string;
+				avatarUrl: string;
+				name: string;
+				url: string;
+			}[];
 			pageInfo: {
 				hasNextPage: boolean;
 				endCursor: string;
@@ -300,6 +316,17 @@ export interface Ref {
 	};
 }
 
+export interface SuggestedReviewerResponse {
+	isAuthor: boolean;
+	isCommenter: boolean;
+	reviewer: {
+		login: string;
+		avatarUrl: string;
+		name: string;
+		url: string;
+	};
+}
+
 export interface PullRequestResponse {
 	repository: {
 		pullRequest: {
@@ -323,11 +350,12 @@ export interface PullRequestResponse {
 			labels: {
 				nodes: {
 					name: string;
-				}[],
+				}[];
 			}
 			merged: boolean;
 			mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
 			isDraft?: boolean;
+			suggestedReviewers?: SuggestedReviewerResponse[];
 		}
 	};
 	rateLimit: RateLimit;

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -355,7 +355,7 @@ export interface PullRequestResponse {
 			merged: boolean;
 			mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
 			isDraft?: boolean;
-			suggestedReviewers?: SuggestedReviewerResponse[];
+			suggestedReviewers: SuggestedReviewerResponse[];
 		}
 	};
 	rateLimit: RateLimit;

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -39,6 +39,11 @@ export interface IAccount {
 	url: string;
 }
 
+export interface ISuggestedReviewer extends IAccount {
+	isAuthor: boolean;
+	isCommenter: boolean;
+}
+
 export interface MergePullRequest {
 	sha: string;
 	merged: boolean;
@@ -80,6 +85,7 @@ export interface PullRequest {
 	merged: boolean;
 	mergeable: PullRequestMergeability;
 	isDraft?: boolean;
+	suggestedReviewers: ISuggestedReviewer[];
 }
 
 export interface IRawFileChange {

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { GitHubRef } from '../common/githubRef';
 import { Remote } from '../common/remote';
 import { GitHubRepository } from './githubRepository';
-import { IAccount, PullRequest, PullRequestStateEnum } from './interface';
+import { IAccount, PullRequest, PullRequestStateEnum, ISuggestedReviewer } from './interface';
 
 interface IPullRequestModel {
 	head: GitHubRef | null;
@@ -31,6 +31,7 @@ export class PullRequestModel implements IPullRequestModel {
 	public localBranchName?: string;
 	public mergeBase?: string;
 	public isDraft?: boolean;
+	public suggestedReviewers: ISuggestedReviewer[];
 
 	public get isOpen(): boolean {
 		return this.state === PullRequestStateEnum.Open;
@@ -106,6 +107,7 @@ export class PullRequestModel implements IPullRequestModel {
 		this.html_url = prItem.url;
 		this.author = prItem.user;
 		this.isDraft = prItem.isDraft;
+		this.suggestedReviewers = prItem.suggestedReviewers;
 
 		if (prItem.state.toLowerCase() === 'open') {
 			this.state = PullRequestStateEnum.Open;

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -249,6 +249,16 @@ query PullRequest($owner: String!, $name: String!, $number: Int!) {
 			id
 			databaseId
 			isDraft
+			suggestedReviewers {
+				isAuthor
+				isCommenter
+				reviewer {
+					login
+					avatarUrl
+					name
+					url
+				}
+			}
 		}
 	}
 	rateLimit {
@@ -365,6 +375,29 @@ mutation DeleteReaction($input: RemoveReactionInput!){
 query GetMentionableUsers($owner: String!, $name: String!, $first: Int!, $after: String) {
 	repository(owner: $owner, name: $name) {
 		mentionableUsers(first: $first, after: $after) {
+			nodes {
+				login
+				avatarUrl
+				name
+				url
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}
+	rateLimit {
+		limit
+		cost
+		remaining
+		resetAt
+	}
+}
+
+query GetAssignableUsers($owner: String!, $name: String!, $first: Int!, $after: String) {
+	repository(owner: $owner, name: $name) {
+		assignableUsers(first: $first, after: $after) {
 			nodes {
 				login
 				avatarUrl

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -338,11 +338,7 @@ export function parseGraphQLPullRequest(pullRequest: GraphQL.PullRequestResponse
 	};
 }
 
-function parseSuggestedReviewers(suggestedReviewers: GraphQL.SuggestedReviewerResponse[] | undefined): ISuggestedReviewer[] {
-	if (!suggestedReviewers) {
-		return [];
-	}
-
+function parseSuggestedReviewers(suggestedReviewers: GraphQL.SuggestedReviewerResponse[]): ISuggestedReviewer[] {
 	const ret: ISuggestedReviewer[] = suggestedReviewers.map(suggestedReviewer => {
 		return {
 			login: suggestedReviewer.reviewer.login,

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -6,7 +6,7 @@
 
 import * as Octokit from '@octokit/rest';
 import * as vscode from 'vscode';
-import { IAccount, PullRequest, IGitHubRef, PullRequestMergeability } from './interface';
+import { IAccount, PullRequest, IGitHubRef, PullRequestMergeability, ISuggestedReviewer } from './interface';
 import { IComment, Reaction } from '../common/comment';
 import { parseDiffHunk, DiffHunk } from '../common/diffHunk';
 import * as Common from '../common/timelineEvent';
@@ -133,7 +133,8 @@ export function convertRESTPullRequestToRawPullRequest(pullRequest: Octokit.Pull
 			base: convertRESTHeadToIGitHubRef(base),
 			mergeable: (pullRequest as Octokit.PullsGetResponse).mergeable ? PullRequestMergeability.Mergeable : PullRequestMergeability.NotMergeable,
 			labels,
-			isDraft: draft
+			isDraft: draft,
+			suggestedReviewers: [] // suggested reviewers only available through GraphQL API
 	};
 
 	return item;
@@ -332,8 +333,36 @@ export function parseGraphQLPullRequest(pullRequest: GraphQL.PullRequestResponse
 		merged: graphQLPullRequest.merged,
 		mergeable: parseMergeability(graphQLPullRequest.mergeable),
 		labels: graphQLPullRequest.labels.nodes,
-		isDraft: graphQLPullRequest.isDraft
+		isDraft: graphQLPullRequest.isDraft,
+		suggestedReviewers: parseSuggestedReviewers(graphQLPullRequest.suggestedReviewers)
 	};
+}
+
+function parseSuggestedReviewers(suggestedReviewers: GraphQL.SuggestedReviewerResponse[] | undefined): ISuggestedReviewer[] {
+	if (!suggestedReviewers) {
+		return [];
+	}
+
+	const ret: ISuggestedReviewer[] = suggestedReviewers.map(suggestedReviewer => {
+		return {
+			login: suggestedReviewer.reviewer.login,
+			avatarUrl: suggestedReviewer.reviewer.avatarUrl,
+			name: suggestedReviewer.reviewer.name,
+			url: suggestedReviewer.reviewer.url,
+			isAuthor: suggestedReviewer.isAuthor,
+			isCommenter: suggestedReviewer.isCommenter
+		};
+	});
+
+	return ret.sort(loginComparator);
+}
+
+/**
+ * Used for case insensitive sort by login
+ */
+export function loginComparator(a: IAccount, b: IAccount) {
+	// sensitivity: 'accent' allows case insensitive comparison
+	return a.login.localeCompare(b.login, 'en', {sensitivity: 'accent'});
 }
 
 export function parseGraphQLReviewEvent(review: GraphQL.SubmittedReview, githubRepository: GitHubRepository): Common.ReviewEvent {

--- a/src/test/builders/graphql/pullRequestBuilder.ts
+++ b/src/test/builders/graphql/pullRequestBuilder.ts
@@ -47,6 +47,7 @@ export const PullRequestBuilder = createBuilderClass<PullRequestResponse>()({
 			merged: {default: false},
 			mergeable: {default: 'MERGEABLE'},
 			isDraft: {default: false},
+			suggestedReviewers: {default: []}
 		}),
 	}),
 	rateLimit: {linked: RateLimitBuilder},


### PR DESCRIPTION
Fixes #1424 

This PR provides next improvements to add reviewers (quick)pick list:
1. Suggested reviewers are displayed at the top of the pick list with suggestion reason below login and name. 
It is possible to add ⭐ before their logins to make suggested reviewers look more distinctive, but skipped this until review.

1. Only assignable users are displayed in pick list instead of all mentionable users. Big improvement for list in some repos.

1. List is now sorted by `login` (sort is case insensitive, same as quick pick built-in filter)

![image](https://user-images.githubusercontent.com/1312662/67827160-b69a7800-fad7-11e9-8dcc-20b905495c1a.png)


The only difference from GitHub that I've noticed is that I'm in list of suggested reviewers even if I already posted review - [example from same PR](https://user-images.githubusercontent.com/1312662/67826407-0f1c4600-fad5-11e9-9d8b-82d5fabc35b0.png).

It may be related to fact that GitHub has "Re-request review" for existing reviewers, but AFAIK this extension doesn't support this action so I left filtering out existing reviewers from suggested at this point.