### PR TITLE
Context menu entries for opening all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,11 +304,6 @@
         "category": "GitHub Pull Requests"
       },
       {
-        "command": "pr.openAllFiles",
-        "title": "Open All Files",
-        "category": "GitHub Pull Requests"
-      },
-      {
         "command": "pr.copyCommitHash",
         "title": "Copy Commit Hash",
         "category": "GitHub Pull Requests"
@@ -331,6 +326,21 @@
           "light": "resources/icons/light/open-change.svg",
           "dark": "resources/icons/dark/open-change.svg"
         }
+      },
+      {
+        "command": "pr.openAllDiffViews",
+        "title": "Open All Diff Views",
+        "category": "GitHub Pull Requests"
+      },
+      {
+        "command": "pr.openAllModifiedFiles",
+        "title": "Open All Modified Files",
+        "category": "GitHub Pull Requests"
+      },
+      {
+        "command": "pr.openAllOriginalFiles",
+        "title": "Open All Original Files",
+        "category": "GitHub Pull Requests"
       },
       {
         "command": "pr.openChangedFile",
@@ -536,7 +546,11 @@
           "when": "false"
         },
         {
-          "command": "pr.openAllFiles",
+          "command": "pr.openDiffView",
+          "when": "false"
+        },
+        {
+          "command": "pr.openModifiedFile",
           "when": "false"
         },
         {
@@ -544,7 +558,15 @@
           "when": "false"
         },
         {
-          "command": "pr.openModifiedFile",
+          "command": "pr.openAllDiffViews",
+          "when": "false"
+        },
+        {
+          "command": "pr.openAllModifiedFiles",
+          "when": "false"
+        },
+        {
+          "command": "pr.openAllOriginalFiles",
           "when": "false"
         },
         {
@@ -553,10 +575,6 @@
         },
         {
           "command": "pr.deleteLocalBranch",
-          "when": "false"
-        },
-        {
-          "command": "pr.openDiffView",
           "when": "false"
         },
         {
@@ -668,10 +686,6 @@
           "when": "view =~ /(pr|prStatus)/ && viewItem =~ /filechange/"
         },
         {
-          "command": "pr.openAllFiles",
-          "when": "view =~ /prStatus/ && viewItem =~ /directory|files/"
-        },
-        {
           "command": "pr.copyCommitHash",
           "when": "view =~ /prStatus/ && viewItem =~ /commit/"
         },
@@ -697,6 +711,18 @@
         {
           "command": "pr.openModifiedFile",
           "when": "view =~ /(pr|prStatus)/ && viewItem =~ /filechange:MODIFY/"
+        },
+        {
+          "command": "pr.openAllDiffViews",
+          "when": "view =~ /prStatus/ && viewItem =~ /directory|files/"
+        },
+        {
+          "command": "pr.openAllModifiedFiles",
+          "when": "view =~ /prStatus/ && viewItem =~ /directory|files/"
+        },
+        {
+          "command": "pr.openAllOriginalFiles",
+          "when": "view =~ /prStatus/ && viewItem =~ /directory|files/"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -304,6 +304,11 @@
         "category": "GitHub Pull Requests"
       },
       {
+        "command": "pr.openAllFiles",
+        "title": "Open All Files",
+        "category": "GitHub Pull Requests"
+      },
+      {
         "command": "pr.copyCommitHash",
         "title": "Copy Commit Hash",
         "category": "GitHub Pull Requests"
@@ -531,6 +536,10 @@
           "when": "false"
         },
         {
+          "command": "pr.openAllFiles",
+          "when": "false"
+        },
+        {
           "command": "pr.openOriginalFile",
           "when": "false"
         },
@@ -657,6 +666,10 @@
         {
           "command": "pr.openFileInGitHub",
           "when": "view =~ /(pr|prStatus)/ && viewItem =~ /filechange/"
+        },
+        {
+          "command": "pr.openAllFiles",
+          "when": "view =~ /prStatus/ && viewItem =~ /directory|files/"
         },
         {
           "command": "pr.copyCommitHash",

--- a/src/view/treeNodes/directoryTreeNode.ts
+++ b/src/view/treeNodes/directoryTreeNode.ts
@@ -11,12 +11,14 @@ export class DirectoryTreeNode extends TreeNode implements vscode.TreeItem {
 	public collapsibleState: vscode.TreeItemCollapsibleState;
 	public children: (RemoteFileChangeNode | InMemFileChangeNode | GitFileChangeNode | DirectoryTreeNode)[] =  new Array();
 	private pathToChild: Map<string, DirectoryTreeNode> = new Map();
+	public contextValue?: string;
 
 	constructor(
 		public parent: TreeNode | vscode.TreeView<TreeNode>,
 		public label: string,
 	) {
 		super();
+		this.contextValue = 'directory';
 		this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
 	}
 

--- a/src/view/treeNodes/filesCategoryNode.ts
+++ b/src/view/treeNodes/filesCategoryNode.ts
@@ -12,7 +12,7 @@ export class FilesCategoryNode extends TreeNode implements vscode.TreeItem {
 	public label: string = 'Files';
 	public collapsibleState: vscode.TreeItemCollapsibleState;
 	public contextValue?: string;
-	private directories: TreeNode[] = [];
+	public directories: TreeNode[] = [];
 
 	constructor(public parent: TreeNode | vscode.TreeView<TreeNode>, private _fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[]) {
 		super();
@@ -44,9 +44,5 @@ export class FilesCategoryNode extends TreeNode implements vscode.TreeItem {
 			nodes = this._fileChanges;
 		}
 		return Promise.resolve(nodes);
-	}
-
-	async getFileChanges(): Promise<(GitFileChangeNode | RemoteFileChangeNode)[]> {
-		return this._fileChanges;
 	}
 }

--- a/src/view/treeNodes/filesCategoryNode.ts
+++ b/src/view/treeNodes/filesCategoryNode.ts
@@ -45,4 +45,8 @@ export class FilesCategoryNode extends TreeNode implements vscode.TreeItem {
 		}
 		return Promise.resolve(nodes);
 	}
+
+	async getFileChanges(): Promise<(GitFileChangeNode | RemoteFileChangeNode)[]> {
+		return this._fileChanges;
+	}
 }

--- a/src/view/treeNodes/filesCategoryNode.ts
+++ b/src/view/treeNodes/filesCategoryNode.ts
@@ -11,10 +11,12 @@ import { DirectoryTreeNode } from './directoryTreeNode';
 export class FilesCategoryNode extends TreeNode implements vscode.TreeItem {
 	public label: string = 'Files';
 	public collapsibleState: vscode.TreeItemCollapsibleState;
+	public contextValue?: string;
 	private directories: TreeNode[] = [];
 
 	constructor(public parent: TreeNode | vscode.TreeView<TreeNode>, private _fileChanges: (GitFileChangeNode | RemoteFileChangeNode)[]) {
 		super();
+		this.contextValue = 'files';
 		this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
 
 		// tree view


### PR DESCRIPTION
Closes #1248.

I added context menu entries mirroring the single-selection context menu entries:

- Open All Diff Views
- Open All Modified Files
- Open All Original Files

### Demo
![output2](https://user-images.githubusercontent.com/9157833/68540412-a50e6700-0346-11ea-8f9e-c5bcc6823769.gif)


### Notes
- Because of some of the asynchronous nature of the code, I had to add `await` to several calls like `vscode.commands.executeCommand();`, otherwise files would open in new tabs in an arbitrary order every time "Open all Files" is activated. However, the main downside is that opening a large number of files may take noticeable amount of time because it waits until each "open file" command is finished executing, as seen in the video. Not sure if this is the best approach.

- `FilesCategoryNode` has a private field `_fileChanges` which stores a list of all changed files, but the ordering is different than just traversing straight down the file tree, which is why I did not opt for that method.

- A confirmation dialog is displayed when the user tries to open 10 or more files all at once.

- Currently only supports opening files under the current Pull Request (Changes in Pull Request viewlet).

Open to feedback and suggestions on improving how this all should work.