### PR TITLE
Remove branching logic for graphql

### DIFF
--- a/preview-src/cache.ts
+++ b/preview-src/cache.ts
@@ -39,7 +39,6 @@ export interface PullRequest {
 	mergeable: PullRequestMergeability;
 	defaultMergeMethod: MergeMethod;
 	mergeMethodsAvailability: MergeMethodsAvailability;
-	supportsGraphQl: boolean;
 	reviewers: ReviewState[];
 	isDraft?: boolean;
 }

--- a/preview-src/context.tsx
+++ b/preview-src/context.tsx
@@ -131,15 +131,12 @@ export class PRContext {
 
 	private appendReview({ review, reviewers }: any) {
 		const state = this.pr;
-		let events = state.events;
-		if (state.supportsGraphQl) {
-			events = events.filter(e => !isReviewEvent(e) || e.state.toLowerCase() !== 'pending');
+		const events = state.events.filter(e => !isReviewEvent(e) || e.state.toLowerCase() !== 'pending');
 			events.forEach(event => {
 				if (isReviewEvent(event)) {
 					event.comments.forEach(c => c.isDraft = false);
 				}
 			});
-		}
 		state.reviewers = reviewers;
 		state.events = [
 			...state.events

--- a/preview-src/test/builder/pullRequest.ts
+++ b/preview-src/test/builder/pullRequest.ts
@@ -29,7 +29,6 @@ export const PullRequestBuilder = createBuilderClass<PullRequest>()({
 	mergeable: {default: PullRequestMergeability.Mergeable},
 	defaultMergeMethod: {default: 'merge'},
 	mergeMethodsAvailability: {default: {merge: true, squash: true, rebase: true}},
-	supportsGraphQl: {default: true},
 	reviewers: {default: []},
 	isDraft: {default: false},
 });

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import Octokit = require('@octokit/rest');
-import { ApolloClient, InMemoryCache, NormalizedCacheObject, gql } from 'apollo-boost';
+import { ApolloClient, InMemoryCache, NormalizedCacheObject } from 'apollo-boost';
 import { setContext } from 'apollo-link-context';
 import * as vscode from 'vscode';
 import { agent } from '../common/net';
@@ -251,28 +251,9 @@ export class CredentialStore implements vscode.Disposable {
 			}
 		});
 
-		let supportsGraphQL = true;
-		await graphql.query({ query: gql`query { viewer { login } }` })
-			.then(result => {
-				Logger.appendLine(`${graphQLBaseURL}: GraphQL support detected`);
-
-				/* __GDPR__
-					"auth.graphql.supported" : {}
-				*/
-				this._telemetry.sendTelemetryEvent('auth.graphql.supported');
-			})
-			.catch(err => {
-				Logger.appendLine(`${graphQLBaseURL}: GraphQL not supported (${err.message})`);
-				/* __GDPR__
-					"auth.graphql.unsupported" : {}
-				*/
-				this._telemetry.sendTelemetryEvent('auth.graphql.unsupported');
-				supportsGraphQL = false;
-			});
-
 		return {
 			octokit,
-			graphql: supportsGraphQL ? graphql : null,
+			graphql,
 			schema: schema,
 		};
 	}

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -9,7 +9,7 @@ import Octokit = require('@octokit/rest');
 import { CredentialStore } from './credentials';
 import { IComment } from '../common/comment';
 import { Remote, parseRepositoryRemotes } from '../common/remote';
-import { TimelineEvent, EventType, ReviewEvent as CommonReviewEvent, isReviewEvent, isCommitEvent } from '../common/timelineEvent';
+import { TimelineEvent, EventType, ReviewEvent as CommonReviewEvent, isReviewEvent } from '../common/timelineEvent';
 import { GitHubRepository, PullRequestData } from './githubRepository';
 import { IPullRequestsPagingOptions, PRType, ReviewEvent, IPullRequestEditData, PullRequest, IRawFileChange, IAccount, ILabel, RepoAccessAndMergeMethods, PullRequestMergeability } from './interface';
 import { PullRequestGitHelper, PullRequestMetadata } from './pullRequestGitHelper';
@@ -20,7 +20,7 @@ import { Repository, RefType, UpstreamRef } from '../api/api';
 import Logger from '../common/logger';
 import { EXTENSION_ID } from '../constants';
 import { fromPRUri } from '../common/uri';
-import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount, convertRESTReviewEvent, parseGraphQLReviewEvent, loginComparator } from './utils';
+import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount, convertRESTReviewEvent, parseGraphQLReviewEvent, loginComparator } from './utils';
 import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse, EditCommentResponse, DeleteReactionResponse, AddReactionResponse, MarkPullRequestReadyForReviewResponse, PullRequestState } from './graphql';
 import { ITelemetry } from '../common/telemetry';
 import { ApiImpl } from '../api/api1';
@@ -800,13 +800,6 @@ export class PullRequestManager implements vscode.Disposable {
 	}
 
 	async getPullRequestComments(pullRequest: PullRequestModel): Promise<IComment[]> {
-		const { supportsGraphQl } = pullRequest.githubRepository;
-		return supportsGraphQl
-			? this.getAllPullRequestReviewComments(pullRequest)
-			: this.getPullRequestReviewComments(pullRequest);
-	}
-
-	private async getAllPullRequestReviewComments(pullRequest: PullRequestModel): Promise<IComment[]> {
 		const { remote, query, schema } = await pullRequest.githubRepository.ensure();
 		try {
 			const { data } = await query<PullRequestCommentsResponse>({
@@ -828,24 +821,6 @@ export class PullRequestManager implements vscode.Disposable {
 			Logger.appendLine(`Failed to get pull request review comments: ${formatError(e)}`);
 			return [];
 		}
-	}
-
-	/**
-	 * Returns review comments from the pull request using the REST API, comments on pending reviews are not included.
-	 */
-	private async getPullRequestReviewComments(pullRequest: PullRequestModel): Promise<IComment[]> {
-		Logger.debug(`Fetch comments of PR #${pullRequest.prNumber} - enter`, PullRequestManager.ID);
-		const githubRepository = (pullRequest as PullRequestModel).githubRepository;
-		const { remote, octokit } = await githubRepository.ensure();
-		const reviewData = await octokit.pulls.listComments({
-			owner: remote.owner,
-			repo: remote.repositoryName,
-			pull_number: pullRequest.prNumber,
-			per_page: 100
-		});
-		Logger.debug(`Fetch comments of PR #${pullRequest.prNumber} - done`, PullRequestManager.ID);
-
-		return reviewData.data.map((comment: any) => this.addCommentPermissions(convertPullRequestsGetCommentsResponseItemToComment(comment, githubRepository), remote));
 	}
 
 	async getPullRequestCommits(pullRequest: PullRequestModel): Promise<Octokit.PullsListCommitsResponseItem[]> {
@@ -901,37 +876,25 @@ export class PullRequestManager implements vscode.Disposable {
 	async getTimelineEvents(pullRequest: PullRequestModel): Promise<TimelineEvent[]> {
 		Logger.debug(`Fetch timeline events of PR #${pullRequest.prNumber} - enter`, PullRequestManager.ID);
 		const githubRepository = pullRequest.githubRepository;
-		const { octokit, query, remote, supportsGraphQl, schema } = await githubRepository.ensure();
+		const { query, remote, schema } = await githubRepository.ensure();
 
-		let ret = [];
-		if (supportsGraphQl) {
-			try {
-				const { data } = await query<TimelineEventsResponse>({
-					query: schema.TimelineEvents,
-					variables: {
-						owner: remote.owner,
-						name: remote.repositoryName,
-						number: pullRequest.prNumber
-					}
-				});
-				ret = data.repository.pullRequest.timelineItems.nodes;
-				const events = parseGraphQLTimelineEvents(ret, githubRepository);
-				await this.addReviewTimelineEventComments(pullRequest, events);
+		try {
+			const { data } = await query<TimelineEventsResponse>({
+				query: schema.TimelineEvents,
+				variables: {
+					owner: remote.owner,
+					name: remote.repositoryName,
+					number: pullRequest.prNumber
+				}
+			});
+			const ret = data.repository.pullRequest.timelineItems.nodes;
+			const events = parseGraphQLTimelineEvents(ret, githubRepository);
+			await this.addReviewTimelineEventComments(pullRequest, events);
 
-				return events;
-			} catch (e) {
-				console.log(e);
-				return [];
-			}
-		} else {
-			ret = (await octokit.issues.listEventsForTimeline({
-				owner: remote.owner,
-				repo: remote.repositoryName,
-				issue_number: pullRequest.prNumber,
-				per_page: 100
-			})).data;
-			Logger.debug(`Fetch timeline events of PR #${pullRequest.prNumber} - done`, PullRequestManager.ID);
-			return convertRESTTimelineEvents(await this.parseRESTTimelineEvents(pullRequest, remote, ret));
+			return events;
+		} catch (e) {
+			console.log(e);
+			return [];
 		}
 	}
 
@@ -1051,17 +1014,13 @@ export class PullRequestManager implements vscode.Disposable {
 			return undefined;
 		}
 
-		if (!pullRequest.githubRepository.supportsGraphQl) {
-			return;
-		}
-
 		const { query, octokit, schema } = await pullRequest.githubRepository.ensure();
 		const { currentUser = '' } = octokit as any;
 		try {
 			const { data } = await query<PendingReviewIdResponse>({
 				query: schema.GetPendingReviewId,
 				variables: {
-					pullRequestId: (pullRequest as PullRequestModel).prItem.graphNodeId,
+					pullRequestId: pullRequest.prItem.graphNodeId,
 					author: currentUser.login
 				}
 			});
@@ -1718,12 +1677,6 @@ export class PullRequestManager implements vscode.Disposable {
 
 	async setReadyForReview(pullRequest: PullRequestModel): Promise<any> {
 		try {
-			if (!pullRequest.githubRepository.supportsGraphQl) {
-				// currently the REST api doesn't support updating PR draft status
-				vscode.window.showWarningMessage('"Ready for Review" operation failed: requires GitHub GraphQL API support');
-				return;
-			}
-
 			const { mutate, schema } = await pullRequest.githubRepository.ensure();
 
 			const { data } = await mutate<MarkPullRequestReadyForReviewResponse>({
@@ -2057,47 +2010,6 @@ export class PullRequestManager implements vscode.Disposable {
 			// Ensures that pending comments made in reply to other reviews are included for the pending review
 			pendingReview.comments = reviewComments.filter(c => c.isDraft);
 		}
-	}
-
-	private async fixCommitAttribution(pullRequest: PullRequestModel, events: TimelineEvent[]): Promise<void> {
-		const commits = await this.getPullRequestCommits(pullRequest);
-		const commitEvents = events.filter(isCommitEvent);
-		for (const commitEvent of commitEvents) {
-			const matchingCommits = commits.filter(commit => commit.sha === commitEvent.sha);
-			if (matchingCommits.length === 1) {
-				const author = matchingCommits[0].author;
-				// There is not necessarily a GitHub account associated with the commit.
-				if (author !== null) {
-					if (pullRequest.githubRepository.isGitHubDotCom) {
-						commitEvent.author.avatarUrl = author.avatar_url;
-					}
-
-					commitEvent.author.login = author.login;
-					commitEvent.author.url = author.html_url;
-				}
-			}
-		}
-	}
-
-	private async parseRESTTimelineEvents(pullRequest: PullRequestModel, remote: Remote, events: any[]): Promise<TimelineEvent[]> {
-		events.forEach(event => {
-			const type = getEventType(event.event);
-			event.event = type;
-			return event;
-		});
-
-		events.forEach(event => {
-			if (event.event === EventType.Commented) {
-				this.addCommentPermissions(event, remote);
-			}
-		});
-
-		await Promise.all([
-			this.addReviewTimelineEventComments(pullRequest, events),
-			this.fixCommitAttribution(pullRequest, events)
-		]);
-
-		return events;
 	}
 
 	createGitHubRepository(remote: Remote, credentialStore: CredentialStore): GitHubRepository {

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -228,7 +228,6 @@ export class PullRequestOverviewPanel {
 			const isCurrentlyCheckedOut = pullRequestModel.equals(this._pullRequestManager.activePullRequest);
 			const canEdit = hasWritePermission || this._pullRequestManager.canEditPullRequest(this._pullRequest);
 			const preferredMergeMethod = vscode.workspace.getConfiguration('githubPullRequests').get<MergeMethod>('defaultMergeMethod');
-			const supportsGraphQl = pullRequestModel.githubRepository.supportsGraphQl;
 			const defaultMergeMethod = getDetaultMergeMethod(mergeMethodsAvailability, preferredMergeMethod);
 
 			Logger.debug('pr.initialize', PullRequestOverviewPanel.ID);
@@ -262,7 +261,6 @@ export class PullRequestOverviewPanel {
 					isDraft: this._pullRequest.isDraft,
 					mergeMethodsAvailability,
 					defaultMergeMethod,
-					supportsGraphQl,
 				}
 			});
 		}).catch(e => {

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -466,26 +466,6 @@ export function parseGraphQLTimelineEvents(events: (GraphQL.MergedEvent | GraphQ
 	return normalizedEvents;
 }
 
-export function convertRESTTimelineEvents(events: any[]): Common.TimelineEvent[] {
-	events.forEach(event => {
-		if (event.event === Common.EventType.Commented) {
-
-		}
-
-		if (event.event === Common.EventType.Reviewed) {
-			event.submittedAt = event.submitted_at;
-			event.htmlUrl = event.html_url;
-			event.authorAssociation = event.user.type;
-		}
-
-		if (event.event === Common.EventType.Committed) {
-			event.htmlUrl = event.html_url;
-		}
-	});
-
-	return events;
-}
-
 export function getReactionGroup(): { title: string; label: string; icon?: vscode.Uri }[] {
 	const ret = [
 		{

--- a/src/test/mocks/mockGitHubRepository.ts
+++ b/src/test/mocks/mockGitHubRepository.ts
@@ -10,11 +10,6 @@ import { UserBuilder } from '../builders/rest/userBuilder';
 import { ManagedGraphQLPullRequestBuilder, ManagedRESTPullRequestBuilder, ManagedPullRequest } from '../builders/managedPullRequestBuilder';
 const queries = require('../../github/queries.gql');
 
-interface IMockGitHubRepositoryOptions {
-	failAuthentication?: boolean;
-	noGraphQL?: boolean;
-}
-
 export class MockGitHubRepository extends GitHubRepository {
 	readonly queryProvider: QueryProvider;
 
@@ -22,7 +17,6 @@ export class MockGitHubRepository extends GitHubRepository {
 		remote: Remote,
 		credentialStore: CredentialStore,
 		sinon: SinonSandbox,
-		private _options: IMockGitHubRepositoryOptions = {},
 	) {
 		super(remote, credentialStore);
 
@@ -44,10 +38,6 @@ export class MockGitHubRepository extends GitHubRepository {
 
 	async ensure() {
 		return this;
-	}
-
-	get supportsGraphQl() {
-		return !this._options.noGraphQL;
 	}
 
 	query = async <T>(query: QueryOptions): Promise<ApolloQueryResult<T>> => this.queryProvider.emulateGraphQLQuery(query);


### PR DESCRIPTION
https://github.com/microsoft/vscode-pull-request-github/issues/1431

Removes the checks for supportsGraphQl, since it should now always be true. There are still a mix of REST and graphql calls, so I only removed a small portion of the code normalizing responses to common types.