### PR TITLE
Add an ability to update PR from other plugins on creation

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -5,6 +5,7 @@
 
 import { Uri, Event, Disposable } from 'vscode';
 import { APIState } from '../typings/git';
+import { PullRequest } from '../github/interface';
 
 export const enum RefType {
 	Head,
@@ -256,4 +257,16 @@ export interface API {
 	 * @return A git provider or `undefined`
 	 */
 	getGitProvider(uri: Uri): IGit | undefined;
+
+	/**
+	 * Event that is called when a pull request is created.
+	 */
+	onPullRequestCreated: Event<PullRequest>;
+
+	/**
+	 * Update pull request body.
+	 * @param body The body of the pull request.
+	 * @param prNumber The number of the pull request.
+	 */
+	updatePullRequestBody(body: string, prNumber: number): void;
 }

--- a/src/api/api1.ts
+++ b/src/api/api1.ts
@@ -7,6 +7,8 @@ import * as vscode from 'vscode';
 import { API, IGit, Repository } from './api';
 import { TernarySearchTree } from '../common/utils';
 import { APIState } from '../typings/git';
+import { PRType, PullRequest } from '../github/interface';
+import { PullRequestManager } from '../github/pullRequestManager';
 
 export class ApiImpl implements API, IGit, vscode.Disposable {
 	private static _handlePool: number = 0;
@@ -47,6 +49,8 @@ export class ApiImpl implements API, IGit, vscode.Disposable {
 	constructor() {
 		this._disposables = [];
 	}
+
+	public pullRequestManager: PullRequestManager;
 
 	registerGitProvider(provider: IGit): vscode.Disposable {
 		const handler = this._nextHandle();
@@ -96,5 +100,21 @@ export class ApiImpl implements API, IGit, vscode.Disposable {
 
 	dispose() {
 		this._disposables.forEach(disposable => disposable.dispose());
+	}
+
+	readonly onPullRequestCreatedEmitter = new vscode.EventEmitter<PullRequest>();
+	get onPullRequestCreated(): vscode.Event<PullRequest> {
+		return this.onPullRequestCreatedEmitter.event;
+	}
+
+	updatePullRequestBody(body: string, prNumber: number): void {
+		this.pullRequestManager.getPullRequests(PRType.All).then(result => {
+			const pr = result.pullRequests.find(pullRequest => pullRequest.prNumber === prNumber);
+			if (pr) {
+				this.pullRequestManager.editPullRequest(pr, { body });
+			} else {
+				throw new Error('Pull request with number ' + prNumber + ' not found!');
+			}
+		});
 	}
 }

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -108,6 +108,7 @@ export interface PullRequestDefaults {
 export class PullRequestManager implements vscode.Disposable {
 	static ID = 'PullRequestManager';
 
+	private api: ApiImpl;
 	private _subs: vscode.Disposable[];
 	private _activePullRequest?: PullRequestModel;
 	private _githubRepositories: GitHubRepository[];
@@ -1275,6 +1276,36 @@ export class PullRequestManager implements vscode.Disposable {
 			const branchNameSeparatorIndex = params.head.indexOf(':');
 			const branchName = params.head.slice(branchNameSeparatorIndex + 1);
 			await PullRequestGitHelper.associateBranchWithPullRequest(this._repository, pullRequestModel, branchName);
+			const pullRequest: PullRequest = {
+				suggestedReviewers: [],
+				graphNodeId: data.node_id,
+				mergeable: data.mergeable ? PullRequestMergeability.Mergeable : PullRequestMergeability.NotMergeable,
+				id: data.id,
+				url: data.url,
+				number: data.number,
+				state: data.state,
+				body: data.body,
+				title: data.title,
+				assignee: data.assignee,
+				createdAt: data.created_at,
+				updatedAt: data.updated_at,
+				head: {
+					label: data.head.label,
+					ref: data.head.ref,
+					sha: data.head.sha,
+					repo: { cloneUrl: data.head.repo.clone_url }
+				},
+				base: {
+					label: data.base.label,
+					ref: data.base.ref,
+					sha: data.base.sha,
+					repo: { cloneUrl: data.base.repo.clone_url }
+				},
+				user: data.user,
+				labels: data.labels,
+				merged: false
+			};
+			this.api.onPullRequestCreatedEmitter.fire(pullRequest);
 
 			/* __GDPR__
 				"pr.create.success" : {


### PR DESCRIPTION
Extend the plugins Api with 'pull-request created' event and updatePullRequestBody() function. I am going to create a plugin that would be used in [Eclipse-Che](https://github.com/eclipse/che). The plugin would catch the event and add a special link to the PR's description.

This will allow to set up the PR's description from other extensions. It can be helpful for other extensions that can provide some links or other data that is important for the pull request.