### PR TITLE
Ensure rendered markdown is shown on edit on description page

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -303,6 +303,16 @@ export interface DeleteReactionResponse {
 	};
 }
 
+export interface UpdatePullRequestResponse {
+	updatePullRequest: {
+		pullRequest: {
+			body: string;
+			bodyHTML: string;
+			title: string;
+		};
+	};
+}
+
 export interface Ref {
 	name: string;
 	repository: {

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -21,7 +21,7 @@ import Logger from '../common/logger';
 import { EXTENSION_ID } from '../constants';
 import { fromPRUri } from '../common/uri';
 import { convertRESTPullRequestToRawPullRequest, convertPullRequestsGetCommentsResponseItemToComment, convertIssuesCreateCommentResponseToComment, parseGraphQLTimelineEvents, convertRESTTimelineEvents, getRelatedUsersFromTimelineEvents, parseGraphQLComment, getReactionGroup, convertRESTUserToAccount, convertRESTReviewEvent, parseGraphQLReviewEvent, loginComparator } from './utils';
-import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse, EditCommentResponse, DeleteReactionResponse, AddReactionResponse, MarkPullRequestReadyForReviewResponse, PullRequestState } from './graphql';
+import { PendingReviewIdResponse, TimelineEventsResponse, PullRequestCommentsResponse, AddCommentResponse, SubmitReviewResponse, DeleteReviewResponse, EditCommentResponse, DeleteReactionResponse, AddReactionResponse, MarkPullRequestReadyForReviewResponse, PullRequestState, UpdatePullRequestResponse } from './graphql';
 import { ITelemetry } from '../common/telemetry';
 import { ApiImpl } from '../api/api1';
 
@@ -1319,35 +1319,13 @@ export class PullRequestManager implements vscode.Disposable {
 	}
 
 	async editReviewComment(pullRequest: PullRequestModel, comment: IComment, text: string): Promise<IComment> {
-		try {
-			if (comment.isDraft) {
-				return this.editPendingReviewComment(pullRequest, comment.graphNodeId, text);
-			}
-
-			const githubRepository = pullRequest.githubRepository;
-			const { octokit, remote } = await githubRepository.ensure();
-
-			const ret = await octokit.pulls.updateComment({
-				owner: remote.owner,
-				repo: remote.repositoryName,
-				body: text,
-				comment_id: comment.id
-			});
-
-			return this.addCommentPermissions(convertPullRequestsGetCommentsResponseItemToComment(ret.data, githubRepository), remote);
-		} catch (e) {
-			throw new Error(formatError(e));
-		}
-	}
-
-	private async editPendingReviewComment(pullRequest: PullRequestModel, commentNodeId: string, text: string): Promise<IComment> {
 		const { mutate, schema } = await pullRequest.githubRepository.ensure();
 
 		const { data } = await mutate<EditCommentResponse>({
 			mutation: schema.EditComment,
 			variables: {
 				input: {
-					pullRequestReviewCommentId: commentNodeId,
+					pullRequestReviewCommentId: comment.graphNodeId,
 					body: text
 				}
 			}
@@ -1415,17 +1393,22 @@ export class PullRequestManager implements vscode.Disposable {
 		return [ret.data, pullRequest.githubRepository];
 	}
 
-	async editPullRequest(pullRequest: PullRequestModel, toEdit: IPullRequestEditData): Promise<Octokit.PullsUpdateResponse> {
+	async editPullRequest(pullRequest: PullRequestModel, toEdit: IPullRequestEditData): Promise<{ body: string, bodyHTML: string, title: string }> {
 		try {
-			const { octokit, remote } = await pullRequest.githubRepository.ensure();
-			const { data } = await octokit.pulls.update({
-				owner: remote.owner,
-				repo: remote.repositoryName,
-				pull_number: pullRequest.prNumber,
-				body: toEdit.body,
-				title: toEdit.title
+			const { mutate, schema } = await pullRequest.githubRepository.ensure();
+
+			const { data } = await mutate<UpdatePullRequestResponse>({
+				mutation: schema.UpdatePullRequest,
+				variables: {
+					input: {
+						pullRequestId: pullRequest.graphNodeId,
+						body: toEdit.body,
+						title: toEdit.title
+					}
+				}
 			});
-			return data;
+
+			return data!.updatePullRequest.pullRequest;
 		} catch (e) {
 			throw new Error(formatError(e));
 		}

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -540,7 +540,7 @@ export class PullRequestOverviewPanel {
 
 	private editDescription(message: IRequestMessage<{ text: string }>) {
 		this._pullRequestManager.editPullRequest(this._pullRequest, { body: message.args.text }).then(result => {
-			this._replyMessage(message, { body: result.body, bodyHTML: result.body });
+			this._replyMessage(message, { body: result.body, bodyHTML: result.bodyHTML });
 		}).catch(e => {
 			this._throwError(message, e);
 			vscode.window.showErrorMessage(`Editing description failed: ${formatError(e)}`);
@@ -565,7 +565,7 @@ export class PullRequestOverviewPanel {
 		editCommentPromise.then(result => {
 			this._replyMessage(message, {
 				body: result.body,
-				bodyHTML: result.body
+				bodyHTML: result.bodyHTML
 			});
 		}).catch(e => {
 			this._throwError(message, e);

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -158,6 +158,7 @@ fragment ReviewComment on PullRequestReviewComment {
 	}
 	path originalPosition
 	body
+	bodyHTML
 	diffHunk
 	position
 	state
@@ -368,6 +369,16 @@ mutation DeleteReaction($input: RemoveReactionInput!){
 		}
 		subject {
 			...Reactable
+		}
+	}
+}
+
+mutation UpdatePullRequest($input: UpdatePullRequestInput!) {
+	updatePullRequest(input: $input) {
+		pullRequest {
+			body
+			bodyHTML
+			title
 		}
 	}
 }

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -240,6 +240,7 @@ export function parseGraphQLComment(comment: GraphQL.ReviewComment): IComment {
 		id: comment.databaseId,
 		url: comment.url,
 		body: comment.body,
+		bodyHTML: comment.bodyHTML,
 		path: comment.path,
 		canEdit: comment.viewerCanDelete,
 		canDelete: comment.viewerCanDelete,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/1457

Previously, we were always returning the plaintext body instead of bodyHTML when editing the pull request.

We should be able to move over to the graphQL API to get bodyHTML in all instances, and then be able to get rid of `markdown-it` on the description page.  