### PR TITLE
Add a button to fetch when viewing partial content

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -153,6 +153,7 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openDiffView', async (fileChangeNode: GitFileChangeNode | InMemFileChangeNode) => {
 		const GIT_FETCH_COMMAND = 'Run \'git fetch\'';
+		const TITLE = "GitHub Pull Requests";
 
 		const parentFilePath = fileChangeNode.parentFilePath;
 		const filePath = fileChangeNode.filePath;
@@ -177,13 +178,12 @@ export function registerCommands(context: vscode.ExtensionContext, prManager: Pu
 		if (isPartial) {
 			const selection = await vscode.window.showInformationMessage('Your local repository is not up to date. Fetch the PR base branch to show full content.', GIT_FETCH_COMMAND);
 			if (selection === GIT_FETCH_COMMAND) {
-				const { remote: { remoteName }, base: { ref } } = fileChangeNode.pullRequest;
 				const prNode = getPRNode();
 				await vscode.window.withProgress({
 					location: vscode.ProgressLocation.Notification,
-					title: `Running 'git fetch ${remoteName} ${ref}'`,
+					title: TITLE,
 					cancellable: false
-				}, progress => prNode.fetchBaseBranchAndReload(prManager.repository, remoteName, ref, progress));
+				}, progress => prNode.fetchBaseBranchAndReload(progress));
 
 				function getPRNode(): PRNode {
 					let parent: TreeNode | undefined;

--- a/src/view/inMemPRContentProvider.ts
+++ b/src/view/inMemPRContentProvider.ts
@@ -11,6 +11,10 @@ export class InMemPRContentProvider implements vscode.TextDocumentContentProvide
 	private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
 	get onDidChange(): vscode.Event<vscode.Uri> { return this._onDidChange.event; }
 
+	fireDidChange(uri: vscode.Uri) {
+		this._onDidChange.fire(uri);
+	}
+
 	private _prFileChangeContentProviders: {[key: number]: (uri: vscode.Uri) => Promise<string>} = {};
 
 	constructor() {}

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -77,7 +77,7 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 		public readonly blobUrl: string | undefined,
 		public readonly filePath: vscode.Uri,
 		public readonly parentFilePath: vscode.Uri,
-		public readonly isPartial: boolean,
+		public isPartial: boolean,
 		public readonly diffHunks: DiffHunk[],
 		public comments: IComment[],
 		public readonly sha?: string
@@ -168,7 +168,7 @@ export class InMemFileChangeNode extends FileChangeNode implements vscode.TreeIt
 		public readonly blobUrl: string,
 		public readonly filePath: vscode.Uri,
 		public readonly parentFilePath: vscode.Uri,
-		public readonly isPartial: boolean,
+		public isPartial: boolean,
 		public readonly patch: string,
 		public readonly diffHunks: DiffHunk[],
 		public comments: IComment[],

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -316,7 +316,7 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 				const remainingEditors = initiallyVisibleEditors.slice();
 
 				const handler = (document: vscode.TextDocument) => {
-					const index = remainingEditors.findIndex(editor => editor.document == document);
+					const index = remainingEditors.findIndex(editor => editor.document === document);
 					if (index !== -1) {
 						remainingEditors.splice(index, 1);
 						progress.report({ message: PROGRESS_MESSAGE, increment: documentChangedIncrement });


### PR DESCRIPTION
Resolves #1462

This currently works by running a 'git fetch' and then reloading the whole window. I would appreciate some guidance on how to refresh things in a more granular way.

questions I have:
- do comment caches need to be cleared after the fetch? I thought maybe they do if the comments are associated with the line numbers of the partial content.
- do we need to re-resolve all file changes for the current PR? or maybe for all loaded PRs with the same base branch? It looks like the file change information is written right into the tree nodes, so it's difficult to refresh it without recreating the tree and maybe the associated diff views. but I wasn't 100% sure of what I was looking at.
- haven't looked into automated testing yet, should I add some tests for this change?
