### PR TITLE
README - sign into privately hosted Github repo's

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It's easy to get started with GitHub Pull Requests for Visual Studio Code. Simpl
 1. Open your desired GitHub repository.
 1. If you're using version 0.5.0 of the extension or higher, a new viewlet should be added to the bottom of the activity bar. For older versions, the `GitHub Pull Requests` treeview will appear in the SCM Viewlet.
 1. You may need to configure the `githubPullRequests.remotes` setting, by default the extension will look for PRs for `origin` and `upstream`. If you have different remotes, add them to the remotes list.
-1. A notification should appear asking you to sign in to GitHub; follow the directions to authenticate.
+1. A notification should appear asking you to sign in to GitHub; follow the directions to authenticate. For privately (not internet accessible) hosted Github Enterprise repositories, see: [PAT Authentication](https://github.com/Microsoft/vscode-pull-request-github/wiki#personal-access-token-authentication)
 1. You should be good to go!
 
 # Configuring the extension


### PR DESCRIPTION
Just thought I'd add a note about the ability to sign in using a personal authentication token, as I'd imagine a lot of people using this extension are using it in the workplace!