### PR TITLE
Simplify credentials, create only one octokit

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -8,7 +8,6 @@ import { ApolloClient, InMemoryCache, NormalizedCacheObject } from 'apollo-boost
 import { setContext } from 'apollo-link-context';
 import * as vscode from 'vscode';
 import { agent } from '../common/net';
-import { Remote } from '../common/remote';
 import Logger from '../common/logger';
 import * as PersistentState from '../common/persistentState';
 import { createHttpLink } from 'apollo-link-http';
@@ -20,6 +19,7 @@ const SIGNIN_COMMAND = 'Sign in';
 const IGNORE_COMMAND = 'Don\'t show again';
 
 const PROMPT_FOR_SIGN_IN_SCOPE = 'prompt for sign in';
+const PROMPT_FOR_SIGN_IN_STORAGE_KEY = 'login';
 
 const AUTH_PROVIDER_ID = 'github';
 const SCOPES = ['read:user', 'user:email', 'repo', 'write:discussion'];
@@ -34,23 +34,16 @@ export interface GitHub {
 }
 
 export class CredentialStore {
-	private _octokits: Map<string, GitHub | undefined>;
+	private _octokit: GitHub | undefined;
 
-	constructor(private readonly _telemetry: ITelemetry) {
-		this._octokits = new Map<string, GitHub>();
-	}
+	constructor(private readonly _telemetry: ITelemetry) { }
 
 	public reset() {
-		this._octokits = new Map<string, GitHub>();
+		this._octokit = undefined;
 	}
 
-	public async hasOctokit(remote: Remote): Promise<boolean> {
-		// the remote url might be http[s]/git/ssh but we always go through https for the api
-		// so use a normalized http[s] url regardless of the original protocol
-		const normalizedUri = remote.gitProtocol.normalizeUri()!;
-		const host = `${normalizedUri.scheme}://${normalizedUri.authority}`;
-
-		if (this._octokits.has(host)) {
+	public async hasOctokit(): Promise<boolean> {
+		if (this._octokit) {
 			return true;
 		}
 
@@ -59,49 +52,43 @@ export class CredentialStore {
 		if (existingSessions.length) {
 			const token = await existingSessions[0].getAccessToken();
 			const octokit = await this.createHub(token);
-			this._octokits.set(host, octokit);
+			this._octokit = octokit;
 			await this.setCurrentUser(octokit.octokit);
 		} else {
-			Logger.debug(`No token found for host ${host}.`, 'Authentication');
+			Logger.debug(`No token found.`, 'Authentication');
 		}
 
-		return this._octokits.has(host);
+		return !!this._octokit;
 	}
 
-	public getHub(remote: Remote): GitHub | undefined {
-		const normalizedUri = remote.gitProtocol.normalizeUri()!;
-		const host = `${normalizedUri.scheme}://${normalizedUri.authority}`;
-		return this._octokits.get(host);
+	public getHub(): GitHub | undefined {
+		return this._octokit;
 	}
 
-	public getOctokit(remote: Remote): AnnotatedOctokit | undefined {
-		const hub = this.getHub(remote);
+	public getOctokit(): AnnotatedOctokit | undefined {
+		const hub = this.getHub();
 		return hub && hub.octokit;
 	}
 
-	public getGraphQL(remote: Remote) {
-		const hub = this.getHub(remote);
+	public getGraphQL() {
+		const hub = this.getHub();
 		return hub && hub.graphql;
 	}
 
-	public async loginWithConfirmation(remote: Remote): Promise<GitHub | undefined> {
-		const normalizedUri = remote.gitProtocol.normalizeUri()!;
-		const storageKey = `${normalizedUri.scheme}://${normalizedUri.authority}`;
-
-		if (PersistentState.fetch(PROMPT_FOR_SIGN_IN_SCOPE, storageKey) === false) {
+	public async loginWithConfirmation(): Promise<GitHub | undefined> {
+		if (PersistentState.fetch(PROMPT_FOR_SIGN_IN_SCOPE, PROMPT_FOR_SIGN_IN_STORAGE_KEY) === false) {
 			return;
 		}
 
 		const result = await vscode.window.showInformationMessage(
-			`In order to use the Pull Requests functionality, you must sign in to ${normalizedUri.authority}`,
+			`In order to use the Pull Requests functionality, you must sign in to GitHub`,
 			SIGNIN_COMMAND, IGNORE_COMMAND);
 
 		if (result === SIGNIN_COMMAND) {
-			return await this.login(remote);
+			return await this.login();
 		} else {
-			this._octokits.set(storageKey, undefined);
 			// user cancelled sign in, remember that and don't ask again
-			PersistentState.store(PROMPT_FOR_SIGN_IN_SCOPE, storageKey, false);
+			PersistentState.store(PROMPT_FOR_SIGN_IN_SCOPE, PROMPT_FOR_SIGN_IN_STORAGE_KEY, false);
 
 			/* __GDPR__
 				"auth.cancel" : {}
@@ -120,17 +107,12 @@ export class CredentialStore {
 		}
 	}
 
-	public async login(remote: Remote): Promise<GitHub | undefined> {
+	public async login(): Promise<GitHub | undefined> {
 
 		/* __GDPR__
 			"auth.start" : {}
 		*/
 		this._telemetry.sendTelemetryEvent('auth.start');
-
-		// the remote url might be http[s]/git/ssh but we always go through https for the api
-		// so use a normalized http[s] url regardless of the original protocol
-		const { scheme, authority } = remote.gitProtocol.normalizeUri()!;
-		const host = `${scheme}://${authority}`;
 
 		let retry: boolean = true;
 		let octokit: GitHub | undefined = undefined;
@@ -140,7 +122,7 @@ export class CredentialStore {
 				const token = await this.getSessionOrLogin();
 				octokit = await this.createHub(token);
 			} catch (e) {
-				Logger.appendLine(`Error signing in to ${authority}: ${e}`);
+				Logger.appendLine(`Error signing in to GitHub: ${e}`);
 				if (e instanceof Error && e.stack) {
 					Logger.appendLine(e.stack);
 				}
@@ -149,12 +131,12 @@ export class CredentialStore {
 			if (octokit) {
 				retry = false;
 			} else {
-				retry = (await vscode.window.showErrorMessage(`Error signing in to ${authority}`, TRY_AGAIN)) === TRY_AGAIN;
+				retry = (await vscode.window.showErrorMessage(`Error signing in to GitHub`, TRY_AGAIN)) === TRY_AGAIN;
 			}
 		}
 
 		if (octokit) {
-			this._octokits.set(host, octokit);
+			this._octokit = octokit;
 			await this.setCurrentUser(octokit.octokit);
 
 			/* __GDPR__
@@ -171,8 +153,8 @@ export class CredentialStore {
 		return octokit;
 	}
 
-	public isCurrentUser(username: string, remote: Remote): boolean {
-		const octokit = this.getOctokit(remote);
+	public isCurrentUser(username: string): boolean {
+		const octokit = this.getOctokit();
 		return !!octokit && !!octokit.currentUser && octokit.currentUser.login === username;
 	}
 
@@ -181,8 +163,8 @@ export class CredentialStore {
 		octokit.currentUser = user.data;
 	}
 
-	public getCurrentUser(remote: Remote): Octokit.PullsGetResponseUser {
-		const octokit = this.getOctokit(remote);
+	public getCurrentUser(): Octokit.PullsGetResponseUser {
+		const octokit = this.getOctokit();
 		// TODO remove cast
 		return octokit && (octokit as any).currentUser;
 	}

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -163,10 +163,10 @@ export class GitHubRepository implements vscode.Disposable {
 	async ensure(): Promise<GitHubRepository> {
 		this._initialized = true;
 
-		if (!await this._credentialStore.hasOctokit(this.remote)) {
-			this._hub = await this._credentialStore.loginWithConfirmation(this.remote);
+		if (!await this._credentialStore.hasOctokit()) {
+			this._hub = await this._credentialStore.loginWithConfirmation();
 		} else {
-			this._hub = await this._credentialStore.getHub(this.remote);
+			this._hub = await this._credentialStore.getHub();
 		}
 
 		return this;
@@ -286,7 +286,7 @@ export class GitHubRepository implements vscode.Disposable {
 				variables: {
 					owner: remote.owner,
 					name: remote.repositoryName,
-					assignee: this._credentialStore.getCurrentUser(remote).login
+					assignee: this._credentialStore.getCurrentUser().login
 				}
 			});
 			Logger.debug(`Fetch all issues - done`, GitHubRepository.ID);
@@ -323,7 +323,7 @@ export class GitHubRepository implements vscode.Disposable {
 				variables: {
 					owner: remote.owner,
 					name: remote.repositoryName,
-					assignee: this._credentialStore.getCurrentUser(remote).login
+					assignee: this._credentialStore.getCurrentUser().login
 				}
 			});
 			Logger.debug(`Fetch issues without milestone - done`, GitHubRepository.ID);

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -176,16 +176,13 @@ export class PullRequestManager implements vscode.Disposable {
 		}
 	}
 
-	// Check if the remotes are authenticated and show a prompt if not, but don't block on user's response
+	// Check if authenticated and show a prompt if not, but don't block on user's response
 	private async showLoginPrompt(): Promise<void> {
-		const activeRemotes = await this.getActiveRemotes();
-		for (const server of uniqBy(activeRemotes, remote => remote.gitProtocol.normalizeUri()!.authority)) {
-			this._credentialStore.hasOctokit(server).then(authd => {
-				if (!authd) {
-					this._credentialStore.loginWithConfirmation(server);
-				}
-			});
-		}
+		this._credentialStore.hasOctokit().then(authd => {
+			if (!authd) {
+				this._credentialStore.loginWithConfirmation();
+			}
+		});
 
 		return Promise.resolve();
 	}
@@ -441,35 +438,13 @@ export class PullRequestManager implements vscode.Disposable {
 		}
 
 		const activeRemotes = await this.getActiveRemotes();
-
-		const serverAuthPromises: Promise<boolean>[] = [];
-		const authenticatedRemotes: Remote[] = [];
-
-		const activeRemotesByAuthority = groupBy(activeRemotes, remote => remote.gitProtocol.normalizeUri()!.authority);
-		for (const authority of Object.keys(activeRemotesByAuthority)) {
-			const remotesForAuthority = activeRemotesByAuthority[authority];
-			serverAuthPromises.push(this._credentialStore.hasOctokit(remotesForAuthority[0]).then(authd => {
-				if (!authd) {
-					return false;
-				} else {
-					authenticatedRemotes.push(...remotesForAuthority);
-					return true;
-				}
-			}));
-		}
-
-		let hasAuthenticated = false;
-		await Promise.all(serverAuthPromises).then(authenticationResult => {
-			hasAuthenticated = authenticationResult.some(isAuthd => isAuthd);
-			vscode.commands.executeCommand('setContext', 'github:authenticated', hasAuthenticated);
-		}).catch(e => {
-			Logger.appendLine(`serverAuthPromises failed: ${e}`);
-		});
+		const isAuthenticated = await this._credentialStore.hasOctokit();
+		vscode.commands.executeCommand('setContext', 'github:authenticated', isAuthenticated);
 
 		const repositories: GitHubRepository[] = [];
 		const resolveRemotePromises: Promise<void>[] = [];
 
-		authenticatedRemotes.forEach(remote => {
+		activeRemotes.forEach(remote => {
 			const repository = this.createGitHubRepository(remote, this._credentialStore);
 			resolveRemotePromises.push(repository.resolveRemote());
 			repositories.push(repository);
@@ -485,7 +460,7 @@ export class PullRequestManager implements vscode.Disposable {
 
 			this.getMentionableUsers(repositoriesChanged);
 			this.getAssignableUsers(repositoriesChanged);
-			this.state = hasAuthenticated || !activeRemotes.length ? PRManagerState.RepositoriesLoaded : PRManagerState.NeedsAuthentication;
+			this.state = isAuthenticated || !activeRemotes.length ? PRManagerState.RepositoriesLoaded : PRManagerState.NeedsAuthentication;
 			return Promise.resolve();
 		});
 	}
@@ -570,17 +545,7 @@ export class PullRequestManager implements vscode.Disposable {
 	}
 
 	async authenticate(): Promise<boolean> {
-		let wasSuccessful = false;
-		const activeRemotes = await this.getActiveGitHubRemotes(this._allGitHubRemotes);
-
-		const promises = uniqBy(activeRemotes, x => x.normalizedHost).map(async remote => {
-			wasSuccessful = !!(await this._credentialStore.login(remote)) || wasSuccessful;
-			return;
-		});
-
-		return Promise.all(promises).then(_ => {
-			return wasSuccessful;
-		});
+		return !!(await this._credentialStore.login());
 	}
 
 	async getLocalPullRequests(): Promise<PullRequestModel[]> {
@@ -1033,7 +998,7 @@ export class PullRequestManager implements vscode.Disposable {
 				in_reply_to: Number(reply_to.id)
 			});
 
-			return this.addCommentPermissions(convertPullRequestsGetCommentsResponseItemToComment(ret.data, githubRepository), remote);
+			return this.addCommentPermissions(convertPullRequestsGetCommentsResponseItemToComment(ret.data, githubRepository));
 		} catch (e) {
 			this.handleError(e);
 		}
@@ -1197,7 +1162,7 @@ export class PullRequestManager implements vscode.Disposable {
 				position: position
 			});
 
-			return this.addCommentPermissions(convertPullRequestsGetCommentsResponseItemToComment(ret.data, githubRepository), remote);
+			return this.addCommentPermissions(convertPullRequestsGetCommentsResponseItemToComment(ret.data, githubRepository));
 		} catch (e) {
 			this.handleError(e);
 		}
@@ -1453,15 +1418,15 @@ export class PullRequestManager implements vscode.Disposable {
 
 	canEditPullRequest(issueModel: IssueModel): boolean {
 		const username = issueModel.author && issueModel.author.login;
-		return this._credentialStore.isCurrentUser(username, issueModel.remote);
+		return this._credentialStore.isCurrentUser(username);
 	}
 
 	getCurrentUser(issueModel: IssueModel): IAccount {
-		return convertRESTUserToAccount(this._credentialStore.getCurrentUser(issueModel.remote), issueModel.githubRepository);
+		return convertRESTUserToAccount(this._credentialStore.getCurrentUser(), issueModel.githubRepository);
 	}
 
-	private addCommentPermissions(rawComment: IComment, remote: Remote): IComment {
-		const isCurrentUser = this._credentialStore.isCurrentUser(rawComment.user!.login, remote);
+	private addCommentPermissions(rawComment: IComment): IComment {
+		const isCurrentUser = this._credentialStore.isCurrentUser(rawComment.user!.login);
 		const notOutdated = rawComment.position !== null;
 		rawComment.canEdit = isCurrentUser && notOutdated;
 		rawComment.canDelete = isCurrentUser && notOutdated;

--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -444,7 +444,8 @@ export class PullRequestManager implements vscode.Disposable {
 		const repositories: GitHubRepository[] = [];
 		const resolveRemotePromises: Promise<void>[] = [];
 
-		activeRemotes.forEach(remote => {
+		const authenticatedRemotes = isAuthenticated ? activeRemotes : [];
+		authenticatedRemotes.forEach(remote => {
 			const repository = this.createGitHubRepository(remote, this._credentialStore);
 			resolveRemotePromises.push(repository.resolveRemote());
 			repositories.push(repository);

--- a/src/issues/stateManager.ts
+++ b/src/issues/stateManager.ts
@@ -154,13 +154,8 @@ export class StateManager {
 		}
 	}
 
-	private async getCurrentUser(defaults: PullRequestDefaults): Promise<string | undefined> {
-		const remotes = this.manager.getGitHubRemotes();
-		for (const remote of remotes) {
-			if (remote.owner === defaults.owner && remote.repositoryName === defaults.repo) {
-				return (await this.manager.credentialStore.getCurrentUser(remote)).login;
-			}
-		}
+	private async getCurrentUser(): Promise<string | undefined> {
+		return (await this.manager.credentialStore.getCurrentUser()).login;
 	}
 
 	private async setIssueData() {
@@ -176,7 +171,7 @@ export class StateManager {
 					defaults = await this.manager.getPullRequestDefaults();
 				}
 				if (!user) {
-					user = await this.getCurrentUser(defaults);
+					user = await this.getCurrentUser();
 				}
 				items = this.setIssues(await variableSubstitution(query.query, undefined, defaults, user));
 			}

--- a/src/test/view/prsTree.test.ts
+++ b/src/test/view/prsTree.test.ts
@@ -39,7 +39,7 @@ describe('GitHub Pull Requests view', function() {
 
 		// For tree view unit tests, we don't test the authentication flow, so `loginWithConfirmation` returns
 		// a dummy GitHub/Octokit object.
-		sinon.stub(credentialStore, 'loginWithConfirmation').callsFake(async (remote) => {
+		sinon.stub(credentialStore, 'loginWithConfirmation').callsFake(async () => {
 			const github: GitHub = {
 				octokit: new Octokit({
 					request: {},


### PR DESCRIPTION
Previously, we created octokits for each domain in a folder's github remotes. This allowed separate octokits for github.com vs. different github enterprise endpoints. Since we will now only support github.com with the new authentication API, we can just create one octokit for it.