### PR TITLE
Remove write:discussion scope

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -23,7 +23,7 @@ const PROMPT_FOR_SIGN_IN_SCOPE = 'prompt for sign in';
 const PROMPT_FOR_SIGN_IN_STORAGE_KEY = 'login';
 
 const AUTH_PROVIDER_ID = 'github';
-const SCOPES = ['read:user', 'user:email', 'repo', 'write:discussion'];
+const SCOPES = ['read:user', 'user:email', 'repo'];
 
 export interface AnnotatedOctokit extends Octokit {
 	currentUser?: Octokit.PullsGetResponseUser;


### PR DESCRIPTION
I believe this scope was added in error a long time ago - I've always thought it had to do with adding comments to issues. We don't use any APIs of features related to "Team discussions" to my knowledge.

![image](https://user-images.githubusercontent.com/3672607/80039250-3bc18100-84ac-11ea-8722-01d18099b9ef.png)

I've tried using the extension without it and it seems to be fine.