### PR TITLE
Add back sign out command

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,6 +393,11 @@
         "category": "GitHub Pull Requests"
       },
       {
+        "command": "auth.signout",
+        "title": "Sign out of GitHub",
+        "category": "GitHub Pull Requests"
+      },
+      {
         "command": "pr.pick",
         "title": "Checkout Pull Request",
         "category": "GitHub Pull Requests"
@@ -713,6 +718,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "auth.signout",
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated"
+        },
         {
           "command": "pr.configureRemotes",
           "when": "gitOpenRepositoryCount != 0"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -49,8 +49,11 @@ function ensurePR(prManager: PullRequestManager, pr?: PRNode | PullRequestModel)
 	}
 }
 
-export function registerCommands(context: vscode.ExtensionContext, prManager: PullRequestManager,
-	reviewManager: ReviewManager, telemetry: ITelemetry) {
+export function registerCommands(context: vscode.ExtensionContext, prManager: PullRequestManager, reviewManager: ReviewManager, telemetry: ITelemetry, credentialStore: CredentialStore) {
+
+	context.subscriptions.push(vscode.commands.registerCommand('auth.signout', async () => {
+		credentialStore.logout();
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.openPullRequestInGitHub', (e: PRNode | DescriptionNode | PullRequestModel) => {
 		if (!e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ async function init(context: vscode.ExtensionContext, git: ApiImpl, gitAPI: GitA
 
 	const reviewManager = new ReviewManager(context, repository, prManager, tree, telemetry);
 	tree.initialize(prManager);
-	registerCommands(context, prManager, reviewManager, telemetry);
+	registerCommands(context, prManager, reviewManager, telemetry, credentialStore);
 
 	git.onDidChangeState(() => {
 		reviewManager.updateState();

--- a/src/typings/vscode.proposed.d.ts
+++ b/src/typings/vscode.proposed.d.ts
@@ -126,6 +126,14 @@ declare module 'vscode' {
 		export function login(providerId: string, scopes: string[]): Thenable<AuthenticationSession>;
 
 		/**
+		* Logout of a specific session.
+		* @param providerId The id of the provider to use
+		* @param sessionId The session id to remove
+		* provider
+		*/
+		export function logout(providerId: string, sessionId: string): Thenable<void>;
+
+		/**
 		* An [event](#Event) which fires when the array of sessions has changed, or data
 		* within a session has changed for a provider. Fires with the ids of the providers
 		* that have had session data change.

--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -60,7 +60,8 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 		this._childrenDisposables = [];
 
 		this._disposables.push(vscode.commands.registerCommand('pr.configurePRViewlet', async () => {
-			const configuration = await vscode.window.showQuickPick(['Configure Remotes...', 'Configure Queries...']);
+			const isLoggedIn = this._prManager.state === PRManagerState.RepositoriesLoaded;
+			const configuration = await vscode.window.showQuickPick(['Configure Remotes...', 'Configure Queries...', ...isLoggedIn ? ['Sign out of GitHub...'] : []]);
 
 			const { name, publisher } = require('../../package.json') as { name: string, publisher: string };
 			const extensionId = `${publisher}.${name}`;
@@ -70,6 +71,8 @@ export class PullRequestsTreeDataProvider implements vscode.TreeDataProvider<Tre
 					return vscode.commands.executeCommand('workbench.action.openSettings', `@ext:${extensionId} queries`);
 				case 'Configure Remotes...':
 					return vscode.commands.executeCommand('workbench.action.openSettings', `@ext:${extensionId} remotes`);
+				case 'Sign out of GitHub...':
+					return vscode.commands.executeCommand('auth.signout');
 				default:
 					return;
 			}


### PR DESCRIPTION
Settings sync is going to remain in insiders still, so the account UI will also not be visible. Since this was the only place you could sign out from, I'm now adding back the sign out command to the extension itself.