### PR TITLE
Show all files affected by a PR, not just the top 300

### DIFF
--- a/src/github/pullRequestManager.ts
+++ b/src/github/pullRequestManager.ts
@@ -1918,9 +1918,6 @@ export class PullRequestManager implements vscode.Disposable {
 				pull_number: pullRequest.number,
 				repo: remote.repositoryName,
 				per_page: 100
-			}, (r) => {
-				Logger.debug(`Fetched another batch of ${r.data.length} file changes for PR #${pullRequest.number}`, PullRequestManager.ID);
-				return r;
 			});
 		} else {
 			// if we're under the limit, just use the result from compareCommits, don't make additional API calls.


### PR DESCRIPTION
Uses octokit.pulls.listFiles to fetch the file changes, instead of using the `files` member of `compareCommits`. This API isn't limited to the top 300 files affected.

Note that I'd prefer to use octokit pagination wrapper as described [here](https://github.com/octokit/plugin-paginate-rest.js/#octokitpaginate) instead of a do..while loop, but this doesn't seem to compile in typescript unfortunately.

Addresses https://github.com/microsoft/vscode-pull-request-github/issues/1613