### PR TITLE
Turn off triggers when createIssueTriggers is empty

### DIFF
--- a/src/issues/issueTodoProvider.ts
+++ b/src/issues/issueTodoProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { ISSUE_OR_URL_EXPRESSION, MAX_LINE_LENGTH, ISSUES_CONFIGURATION } from './util';
 
 export class IssueTodoProvider implements vscode.CodeActionProvider {
-	private expression: RegExp;
+	private expression: RegExp | undefined;
 
 	constructor(context: vscode.ExtensionContext) {
 		context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
@@ -18,11 +18,11 @@ export class IssueTodoProvider implements vscode.CodeActionProvider {
 
 	private updateTriggers() {
 		const triggers = vscode.workspace.getConfiguration(ISSUES_CONFIGURATION).get('createIssueTriggers', []);
-		this.expression = new RegExp(triggers.join('|'));
+		this.expression = triggers.length > 0 ? new RegExp(triggers.join('|')) : undefined;
 	}
 
 	async provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[]> {
-		if (context.only && context.only !== vscode.CodeActionKind.QuickFix) {
+		if ( this.expression === undefined || (context.only && context.only !== vscode.CodeActionKind.QuickFix)) {
 			return [];
 		}
 		const codeActions: vscode.CodeAction[] = [];


### PR DESCRIPTION

Fixes #1774  

In issueTodoProvider.ts

https://github.com/microsoft/vscode-pull-request-github/blob/master/src/issues/issueTodoProvider.ts#L6-#L35

When ```createIssueTriggers``` is empty then the expression to be searched is initialized with ```/(?:)/``` which results in matching ```"nothing"```, which matches everything. ```There is nothing in everything.``` 🤔. So return an empty array when the expression is ```undefined```.

Let me know if this needs to be fixed in a different way.