### PR TITLE
Resolves ssh config issue resolving host

### DIFF
--- a/src/common/protocol.ts
+++ b/src/common/protocol.ts
@@ -70,8 +70,8 @@ export class Protocol {
 	private parseSshProtocol(uriString: string): boolean {
 		const sshConfig = resolve(uriString);
 		if (!sshConfig) { return false; }
-		const { HostName, path } = sshConfig;
-		this.host = HostName;
+		const { Hostname, HostName, path } = sshConfig;
+		this.host = HostName || Hostname;
 		this.owner = this.getOwnerName(path) || '';
 		this.repositoryName = this.getRepositoryName(path) || '';
 		this.type = ProtocolType.SSH;

--- a/src/common/ssh.ts
+++ b/src/common/ssh.ts
@@ -87,7 +87,7 @@ const parse = (url: string): Config | undefined => {
 function baseResolver(config: Config) {
 	return {
 		...config,
-		HostName: config.Host,
+		Hostname: config.Host,
 	};
 }
 

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -10,7 +10,7 @@ import { Protocol, ProtocolType } from '../../common/protocol';
 const SSH_CONFIG_WITH_HOST_ALIASES = `
 Host gh
   User git
-  HostName github.com
+  Hostname github.com
 `;
 
 const str = (x: any) => JSON.stringify(x);

--- a/src/test/common/protocol.test.ts
+++ b/src/test/common/protocol.test.ts
@@ -8,9 +8,13 @@ import * as ssh from '../../common/ssh';
 import { Protocol, ProtocolType } from '../../common/protocol';
 
 const SSH_CONFIG_WITH_HOST_ALIASES = `
-Host gh
+Host gh_nocap
   User git
   Hostname github.com
+
+Host gh_cap
+  User git
+  HostName github.com
 `;
 
 const str = (x: any) => JSON.stringify(x);
@@ -120,7 +124,15 @@ describe('Protocol', () => {
 			ssh.Resolvers.current = ssh.Resolvers.default);
 
 		testRemote({
-			uri: 'gh:queerviolet/vscode',
+			uri: 'gh_cap:queerviolet/vscode',
+			expectedType: ProtocolType.SSH,
+			expectedHost: 'github.com',
+			expectedOwner: 'queerviolet',
+			expectedRepositoryName: 'vscode'
+		});
+
+		testRemote({
+			uri: 'gh_nocap:queerviolet/vscode',
 			expectedType: ProtocolType.SSH,
 			expectedHost: 'github.com',
 			expectedOwner: 'queerviolet',


### PR DESCRIPTION
# SSH Config issues

## Background

When configuring a ssh host in the `.ssh/config` with a entry to resolve github.com e.g.)

```
Host MY-GITHUB-ALIAS
   Hostname github.com
   IdentityFile my_authentication_identity
``` 
The extension fails to resolve the host name and displays the following error in the log

```
[Info] GitHubServer> No response from host https://MY-GITHUB-ALIAS/xxxxx/repo: getaddrinfo ENOTFOUND MY-GITHUB-ALIAS
```

## Root cause

The ssh config file was ignoring the `Hostname` property in favour of `HostName` in `protocol.ts`. The man pages for ssh config define the entry a `Hostname` and the result was the wrong value was being assigned to host in `parseSshProtocol()`.

## Resolution

Align with the ssh config specification as defined by

- [SSH_CONFIG(5) ](http://man7.org/linux/man-pages/man5/ssh_config.5.html)

To avoid configuration brittleness `Hostname` or `HostName` will now resolve correctly.

## Related Issues

- Fixes #1541