### PR TITLE
Improve error formatting

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -8,7 +8,6 @@ import { Event, Disposable } from 'vscode';
 import { sep } from 'path';
 import moment = require('moment');
 import { HookError } from '@octokit/rest';
-import { isArray } from 'util';
 
 export function uniqBy<T>(arr: T[], fn: (el: T) => string): T[] {
 	const seen = Object.create(null);
@@ -101,9 +100,9 @@ function isHookError(e: Error): e is HookError {
 
 function hasFieldErrors(e: any): e is (Error & { errors: { value: string, field: string, code: string }[] }) {
 	let areFieldErrors = true;
-	if (!!e.errors && isArray(e.errors)) {
+	if (!!e.errors && Array.isArray(e.errors)) {
 		for (const error of e.errors) {
-			if (!error.field && !error.value && !error.code) {
+			if (!error.field || !error.value || !error.code) {
 				areFieldErrors = false;
 				break;
 			}

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -28,6 +28,16 @@ describe('utils', () => {
 			const error = new HookError('Validation Failed', ['Can not approve your own pull request']);
 			assert.equal(utils.formatError(error), 'Validation Failed: Can not approve your own pull request');
 		});
+
+		it('should format an error with field errors', () => {
+			const error = new HookError('Validation Failed', [{ field: 'title', value: 'garbage', code: 'custom' }]);
+			assert.equal(utils.formatError(error), 'Validation Failed: Value "garbage" cannot be set for field title (code: custom)');
+		});
+
+		it('should format an error with custom ', () => {
+			const error = new HookError('Validation Failed', [{ message: 'Cannot push to this repo', code: 'custom '}]);
+			assert.equal(utils.formatError(error), 'Validation Failed: Cannot push to this repo');
+		});
 	});
 
 	describe('promiseFromEvent', () => {


### PR DESCRIPTION
There have been some issue reports like https://github.com/microsoft/vscode-pull-request-github/issues/1933 where we format an error with undefined field/value. Making our check for this more strict so that hopefully a better message is surfaced