### PR TITLE
Remove hard extensionDependency on auth extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "onFileSystem:newIssue"
   ],
   "extensionDependencies": [
-    "vscode.git",
-    "vscode.github-authentication"
+    "vscode.git"
   ],
   "main": "./media/extension",
   "contributes": {


### PR DESCRIPTION
Kind of a weird change, the reasoning is that I need to move the GitHub Auth Provider extension to be a UI instead of Workspace extension. The auth provider API will make sure that regardless of what side the auth provider extension is on, calls to it go through. For Codespaces, the resolver extension is on the UI side, and it needs to get auth information at start up, before the Workspace extension host is even up. (Also, it makes sense for the auth provider to be on the local machine since that's where it's storing credentials).

Anyway, if GHPRI directly depends on it and is a workspace extension, it will fail to activate since the auth provider isn't on the same side. Since we don't actually need the extension to be in the same extension host, we shouldn't set it as a dependency