### PR TITLE
Typo fix: "Open Permalink in GitHub"

### DIFF
--- a/package.json
+++ b/package.json
@@ -590,7 +590,7 @@
       },
       {
         "command": "issue.openGithubPermalink",
-        "title": "Open Permalink in Github",
+        "title": "Open Permalink in GitHub",
         "category": "GitHub Issues"
       },
       {


### PR DESCRIPTION
Just cleaning up a little capitalization typo. ✨ 