### PR TITLE
fix: Issues titles contaning " or '.

### DIFF
--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -364,6 +364,15 @@ export async function createGithubPermalink(gitAPI: GitApiImpl, positionInfo?: N
 	return { permalink: `https://github.com/${new Protocol(upstream.fetchUrl).nameWithOwner}/blob/${log[0].hash}${pathSegment}#L${range.start.line + 1}-L${range.end.line + 1}`, error: undefined };
 }
 
+export function sanitizeIssueTitle(title: string): string {
+	const regex = /[~^:;'".,~#?%*[\]@\\{}]|\/\//g;
+
+	return title
+		.replace(regex, '')
+		.trim()
+		.replace(/\s+/g, '-');
+}
+
 const VARIABLE_PATTERN = /\$\{(.*?)\}/g;
 export async function variableSubstitution(value: string, issueModel?: IssueModel, defaults?: PullRequestDefaults, user?: string): Promise<string> {
 	return value.replace(VARIABLE_PATTERN, (match: string, variable: string) => {
@@ -374,7 +383,7 @@ export async function variableSubstitution(value: string, issueModel?: IssueMode
 			case 'issueTitle': return issueModel ? issueModel.title : match;
 			case 'repository': return defaults ? defaults.repo : match;
 			case 'owner': return defaults ? defaults.owner : match;
-			case 'sanitizedIssueTitle': return issueModel ? issueModel.title.replace(/[~^:?*[\]@\\{}]|\/\//g, '').trim().replace(/\s+/g, '-') : match; // check what characters are permitted
+			case 'sanitizedIssueTitle': return issueModel ? sanitizeIssueTitle(issueModel.title) : match; // check what characters are permitted
 			default: return match;
 		}
 	});

--- a/src/test/issues/issuesUtils.test.ts
+++ b/src/test/issues/issuesUtils.test.ts
@@ -1,5 +1,5 @@
 import assert = require('assert');
-import { parseIssueExpressionOutput, ISSUE_OR_URL_EXPRESSION } from '../../issues/util';
+import { parseIssueExpressionOutput, sanitizeIssueTitle, ISSUE_OR_URL_EXPRESSION } from '../../issues/util';
 
 describe('Issues utilities', function () {
 	it('regular expressions', async function () {
@@ -43,5 +43,31 @@ describe('Issues utilities', function () {
 		const notIssue = '#a4';
 		const notIssueParsed = parseIssueExpressionOutput(notIssue.match(ISSUE_OR_URL_EXPRESSION));
 		assert.equal(notIssueParsed, undefined);
+	});
+
+	describe('sanitizeIssueTitle', () => {
+		[
+			{ input: 'Issue', expected: 'Issue' },
+			{ input: 'Issue A', expected: 'Issue-A' },
+			{ input: 'Issue \ A', expected: 'Issue-A' },
+			{ input: 'Issue     A', expected: 'Issue-A' },
+			{ input: 'Issue @ A', expected: 'Issue-A' },
+			{ input: 'Issue \'A\'', expected: 'Issue-A' },
+			{ input: 'Issue "A"', expected: 'Issue-A' },
+			{ input: '@Issue "A"', expected: 'Issue-A' },
+			{ input: 'Issue "A"%', expected: 'Issue-A' },
+			{ input: 'Issue .A', expected: 'Issue-A' },
+			{ input: 'Issue ,A', expected: 'Issue-A' },
+			{ input: 'Issue :A', expected: 'Issue-A' },
+			{ input: 'Issue ;A', expected: 'Issue-A' },
+			{ input: 'Issue ~A', expected: 'Issue-A' },
+			{ input: 'Issue #A', expected: 'Issue-A' },
+		]
+		.forEach((testCase) => {
+			it(`Transforms '${testCase.input}' into '${testCase.expected}'`, () => {
+				const actual = sanitizeIssueTitle(testCase.input);
+				assert.equal(actual, testCase.expected);
+			});
+		});
 	});
 });


### PR DESCRIPTION
The sanitiser function regex wasn't replacing `"` and `'` which break git commands.

The regex has been updated.

Unit tests covering the bug have been added.

Closes #2117