### PR TITLE
Not able to checkout after checkout has failed once

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -86,6 +86,10 @@ export class GitHubRepository implements vscode.Disposable {
 		return this._hub;
 	}
 
+	public equals(repo: GitHubRepository): boolean {
+		return this.remote.equals(repo.remote);
+	}
+
 	public async ensureCommentsController(): Promise<void> {
 		try {
 			if (this.commentsController) {

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -878,7 +878,7 @@ export class ReviewManager {
 	}
 
 	static getReviewManagerForRepository(reviewManagers: ReviewManager[], repository: GitHubRepository): ReviewManager | undefined {
-		return reviewManagers.find(reviewManager => reviewManager._folderRepoManager.gitHubRepositories.includes(repository));
+		return reviewManagers.find(reviewManager => reviewManager._folderRepoManager.gitHubRepositories.some(repo => repo.equals(repository)));
 	}
 
 	static getReviewManagerForFolderManager(reviewManagers: ReviewManager[], folderManager: FolderRepositoryManager): ReviewManager | undefined {


### PR DESCRIPTION
Fixes #2123

I didn't find what exactly was being mutated that made `includes` no longer find the exact github repo, but comparing based on remote seems safer