### PR TITLE
Add comment tooltip descriptions & styling

### DIFF
--- a/preview-src/comment.tsx
+++ b/preview-src/comment.tsx
@@ -63,9 +63,9 @@ export function CommentView(comment: Props) {
 		onMouseLeave={() => setShowActionBar(false)}
 	>{showActionBar
 		? <div className='action-bar comment-actions'>
-			<button onClick={() => emitter.emit('quoteReply', bodyMd)}>{commentIcon}</button>
-			{canEdit ? <button onClick={() => setEditMode(true)}>{editIcon}</button> : null}
-			{canDelete ? <button onClick={() => deleteComment({ id, pullRequestReviewId })}>{deleteIcon}</button> : null}
+			<button title='Quote reply' onClick={() => emitter.emit('quoteReply', bodyMd)}>{commentIcon}</button>
+			{canEdit ? <button title='Edit comment' onClick={() => setEditMode(true)} >{editIcon}</button> : null}
+			{canDelete ? <button title='Delete comment' onClick={() => deleteComment({ id, pullRequestReviewId })} >{deleteIcon}</button> : null}
 		</div>
 		: null
 		}

--- a/preview-src/header.tsx
+++ b/preview-src/header.tsx
@@ -85,7 +85,7 @@ function Title({ title, number, url, canEdit, isCurrentlyCheckedOut, isIssue }: 
 		{
 			(canEdit && showActionBar && !inEditMode)
 				? <div className='flex-action-bar comment-actions'>
-					{<button onClick={() => setEditMode(true)}>{editIcon}</button>}
+					{<button title='Edit' onClick={() => setEditMode(true)}>{editIcon}</button>}
 				</div>
 				: <div className='flex-action-bar comment-actons'></div>
 		}

--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -158,7 +158,7 @@ body .comment-container .review-comment-header {
 
 .comment-actions button {
 	background-color: transparent;
-	padding: 0 6px;
+	padding: 0;
 	line-height: normal;
 	font-size: 11px;
 }


### PR DESCRIPTION
fixes: https://github.com/microsoft/vscode-pull-request-github/issues/2097

## Addresses
1. Tooltip descriptions in _comment_ for: 'quote reply', 'edit', 'delete'
2. Tooltip descriptions in the _header_ for edit
3. Compact styling for buttons 

<img width="143" alt="_Extension_Development_Host__-_Pull_Request__755_—_business-intelligence" src="https://user-images.githubusercontent.com/8232214/94261317-00ecd900-ff75-11ea-8d37-381d9aa15dbe.png">

*_Currently looks like_*
<img width="167" alt="Pull_Request__224_—_dbt" src="https://user-images.githubusercontent.com/8232214/94261405-2d085a00-ff75-11ea-9c27-78d09b47b81e.png">

## Other considerations 
Added more descriptive tooltips that add context to the buttons. This is further to what GitHub web. Happy to shorten it to one word if suggested.