### PR TITLE
Remove restriction for creating PR on existing PR branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -767,11 +767,11 @@
         },
         {
           "command": "pr.create",
-          "when": "gitOpenRepositoryCount != 0 && github:authenticated && !github:inReviewMode"
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated"
         },
         {
           "command": "pr.createDraft",
-          "when": "gitOpenRepositoryCount != 0 && github:authenticated && !github:inReviewMode"
+          "when": "gitOpenRepositoryCount != 0 && github:authenticated"
         },
         {
           "command": "pr.merge",


### PR DESCRIPTION
Fixes #2189

There's no GitHub restriction on creating multiple PRs from the same branch