### PR TITLE
Provide option to toggle between tree view and flat list view in "Changes in Pull Request" 

### DIFF
--- a/package.json
+++ b/package.json
@@ -512,9 +512,15 @@
         "category": "GitHub Pull Requests"
       },
       {
-        "command": "pr.toggleFileListLayout",
-        "title": "Toggle File List Layout",
-        "icon": "$(gear)",
+        "command": "pr.setFileListLayoutAsTree",
+        "title": "Toggle View Mode",
+        "icon": "$(list-tree)",
+        "category": "GitHub Pull Requests"
+      },
+      {
+        "command": "pr.setFileListLayoutAsFlat",
+        "title": "Toggle View Mode",
+        "icon": "$(list-flat)",
         "category": "GitHub Pull Requests"
       },
       {
@@ -996,8 +1002,13 @@
           "group": "navigation"
         },
         {
-          "command": "pr.toggleFileListLayout",
-          "when": "view =~ /prStatus/",
+          "command": "pr.setFileListLayoutAsTree",
+          "when": "view =~ /prStatus/ && fileListLayout:flat",
+          "group": "navigation"
+        },
+        {
+          "command": "pr.setFileListLayoutAsFlat",
+          "when": "view =~ /prStatus/ && !fileListLayout:flat",
           "group": "navigation"
         },
         {

--- a/package.json
+++ b/package.json
@@ -844,6 +844,14 @@
           "when": "gitOpenRepositoryCount != 0 && github:authenticated && github:hasGitHubRemotes"
         },
         {
+          "command": "pr.setFileListLayoutAsTree",
+          "when": "false"
+        },
+        {
+          "command": "pr.setFileListLayoutAsFlat",
+          "when": "false"
+        },
+        {
           "command": "pr.refreshChanges",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -512,6 +512,12 @@
         "category": "GitHub Pull Requests"
       },
       {
+        "command": "pr.toggleFileListLayout",
+        "title": "Toggle File List Layout",
+        "icon": "$(gear)",
+        "category": "GitHub Pull Requests"
+      },
+      {
         "command": "pr.refreshChanges",
         "title": "Refresh",
         "icon": "$(refresh)",
@@ -986,6 +992,11 @@
         },
         {
           "command": "pr.refreshChanges",
+          "when": "view =~ /prStatus/",
+          "group": "navigation"
+        },
+        {
+          "command": "pr.toggleFileListLayout",
           "when": "view =~ /prStatus/",
           "group": "navigation"
         },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -594,14 +594,22 @@ export function registerCommands(context: vscode.ExtensionContext, reposManager:
 		});
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('pr.toggleFileListLayout', _ => {
-		const config = vscode.workspace.getConfiguration('githubPullRequests');
-		const layout = config.get<string>('fileListLayout');
-		if (layout === 'tree') {
-			config.update('fileListLayout', 'flat');
-		} else {
-			config.update('fileListLayout', 'tree');
-		}
+	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsTree', async _ => {
+		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'tree');
+		await vscode.commands.executeCommand(
+			'setContext',
+			'fileListLayout:flat',
+			false
+		);
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsFlat', async _ => {
+		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'flat');
+		await vscode.commands.executeCommand(
+			'setContext',
+			'fileListLayout:flat',
+			true
+		);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.refreshPullRequest', (prNode: PRNode) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -594,6 +594,16 @@ export function registerCommands(context: vscode.ExtensionContext, reposManager:
 		});
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('pr.toggleFileListLayout', _ => {
+		const config = vscode.workspace.getConfiguration('githubPullRequests');
+		const layout = config.get<string>('fileListLayout');
+		if (layout === 'tree') {
+			config.update('fileListLayout', 'flat');
+		} else {
+			config.update('fileListLayout', 'tree');
+		}
+	}));
+
 	context.subscriptions.push(vscode.commands.registerCommand('pr.refreshPullRequest', (prNode: PRNode) => {
 		const folderManager = reposManager.getManagerForIssueModel(prNode.pullRequestModel);
 		if (folderManager && prNode.pullRequestModel.equals(folderManager?.activePullRequest)) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -594,22 +594,12 @@ export function registerCommands(context: vscode.ExtensionContext, reposManager:
 		});
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsTree', async _ => {
+	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsTree', _ => {
 		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'tree');
-		await vscode.commands.executeCommand(
-			'setContext',
-			'fileListLayout:flat',
-			false
-		);
 	}));
 
-	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsFlat', async _ => {
+	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsFlat', _ => {
 		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'flat');
-		await vscode.commands.executeCommand(
-			'setContext',
-			'fileListLayout:flat',
-			true
-		);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.refreshPullRequest', (prNode: PRNode) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -595,11 +595,11 @@ export function registerCommands(context: vscode.ExtensionContext, reposManager:
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsTree', _ => {
-		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'tree');
+		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'tree', true);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.setFileListLayoutAsFlat', _ => {
-		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'flat');
+		vscode.workspace.getConfiguration('githubPullRequests').update('fileListLayout', 'flat', true);
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('pr.refreshPullRequest', (prNode: PRNode) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,12 @@ async function init(context: vscode.ExtensionContext, git: GitApiImpl, credentia
 	context.subscriptions.push(reviewsManager);
 	tree.initialize(reposManager);
 	registerCommands(context, reposManager, reviewManagers, telemetry, credentialStore, tree);
+	const layout = vscode.workspace.getConfiguration('githubPullRequests').get<string>('fileListLayout');
+	if (layout === 'flat') {
+		await vscode.commands.executeCommand('pr.setFileListLayoutAsFlat');
+	} else {
+		await vscode.commands.executeCommand('pr.setFileListLayoutAsTree');
+	}
 
 	git.onDidChangeState(() => {
 		reviewManagers.forEach(reviewManager => reviewManager.updateState());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,11 +91,7 @@ async function init(context: vscode.ExtensionContext, git: GitApiImpl, credentia
 	tree.initialize(reposManager);
 	registerCommands(context, reposManager, reviewManagers, telemetry, credentialStore, tree);
 	const layout = vscode.workspace.getConfiguration('githubPullRequests').get<string>('fileListLayout');
-	if (layout === 'flat') {
-		await vscode.commands.executeCommand('pr.setFileListLayoutAsFlat');
-	} else {
-		await vscode.commands.executeCommand('pr.setFileListLayoutAsTree');
-	}
+	await vscode.commands.executeCommand('setContext', 'fileListLayout:flat', layout === 'flat' ? true : false);
 
 	git.onDidChangeState(() => {
 		reviewManagers.forEach(reviewManager => reviewManager.updateState());

--- a/src/view/prChangesTreeDataProvider.ts
+++ b/src/view/prChangesTreeDataProvider.ts
@@ -32,9 +32,11 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 		});
 		this._context.subscriptions.push(this._view);
 
-		this._disposables.push(vscode.workspace.onDidChangeConfiguration(e => {
+		this._disposables.push(vscode.workspace.onDidChangeConfiguration(async e => {
 			if (e.affectsConfiguration(`${SETTINGS_NAMESPACE}.fileListLayout`)) {
 				this._onDidChangeTreeData.fire();
+				const layout = vscode.workspace.getConfiguration(`${SETTINGS_NAMESPACE}`).get<string>('fileListLayout');
+				await vscode.commands.executeCommand('setContext', 'fileListLayout:flat', layout === 'flat' ? true : false);
 			}
 		}));
 	}


### PR DESCRIPTION
Closes #2177 
The "Changes In Pull Request" view now displays an icon to let users switch between seeing the list of files changed in `tree` or `flat` list view, to match the behavior in the SCM view.

<img width="452" alt="Screen Shot 2020-11-05 at 4 46 23 PM" src="https://user-images.githubusercontent.com/16628240/98442941-21f92b80-20d6-11eb-9058-4cf44e356a22.png">
<img width="449" alt="Screen Shot 2020-11-05 at 4 46 11 PM" src="https://user-images.githubusercontent.com/16628240/98442943-24f41c00-20d6-11eb-93c3-8d27ff53e717.png">

