### PR TITLE
Allow to see commits of a PR without checking out to it

### DIFF
--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -134,6 +134,13 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 
 			const filesCategoryNode = new FilesCategoryNode(this.parent, this._fileChanges);
 			const prCommits = await this.pullRequestModel.getReviewComments();
+			await this._folderReposManager.fullfillPullRequestMissingInfo(this.pullRequestModel);
+			const repository = this._folderReposManager.repository;
+			const branchName = this.pullRequestModel.head?.ref;
+			await repository.fetch(this.pullRequestModel.remote.remoteName, branchName, );
+			await repository.pull();
+
+			// await this._folderReposManager.updateRepositories(false);
 			const commitCategoryNode = new CommitsNode(this, this._folderReposManager, this.pullRequestModel, prCommits);
 
 			if (!this._inMemPRContentProvider) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/2201
now you can see the commits without checking out

So I decided to use `files` folder and `commit` folder. 
![image](https://user-images.githubusercontent.com/18569016/97706478-1d8eaa80-1af9-11eb-8e93-f225abbcb24e.png)
