### PR TITLE
Auto reveal files in changes in pull request tree

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -588,10 +588,6 @@ export function registerCommands(context: vscode.ExtensionContext, reposManager:
 	context.subscriptions.push(vscode.commands.registerCommand('review.openFile', (value: GitFileChangeNode | vscode.Uri) => {
 		const uri = value instanceof GitFileChangeNode ? value.filePath : value;
 
-		if (value instanceof GitFileChangeNode) {
-			value.reveal(value, { select: true, focus: true });
-		}
-
 		const activeTextEditor = vscode.window.activeTextEditor;
 		const opts: vscode.TextDocumentShowOptions = {
 			preserveFocus: true,

--- a/src/view/treeNodes/descriptionNode.ts
+++ b/src/view/treeNodes/descriptionNode.ts
@@ -24,7 +24,7 @@ export class DescriptionNode extends TreeNode implements vscode.TreeItem {
 		};
 
 		this.contextValue = 'description';
-		this.tooltip = `Description of pull request #${pullRequestModel.number}`
+		this.tooltip = `Description of pull request #${pullRequestModel.number}`;
 	}
 
 	getTreeItem(): vscode.TreeItem {

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -150,8 +150,6 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 		const filePath = this.filePath;
 		const opts = this.opts;
 
-		this.reveal(this, { select: true, focus: true });
-
 		let parentURI = await asImageDataURI(parentFilePath, folderManager.repository) || parentFilePath;
 		let headURI = await asImageDataURI(filePath, folderManager.repository) || filePath;
 		if (parentURI.scheme === 'data' || headURI.scheme === 'data') {


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-pull-request-github/pull/2250

Adds back the "reveal" behavior in the "Changes in Pull Request" tree when navigating from a link on the description page to a file. Behaves like the file explorer's reveal, where the file is revealed in the tree when the active editor changes