### PR TITLE
Change icon to more representative icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
         {
           "id": "github-pull-requests",
           "title": "GitHub",
-          "icon": "resources/icons/pull-request.png"
+          "icon": "resources/icons/dark/github.svg"
         }
       ]
     },


### PR DESCRIPTION
Fixes #2280 

`pull-request.png` was extremely similar to the standard "Source Control" tab in vscode, this changes it to one that is much more github.

Dark theme: 
![image](https://user-images.githubusercontent.com/1731430/99217581-99ddea80-2795-11eb-968a-1fc7fa062eb2.png)

Light theme:
![image](https://user-images.githubusercontent.com/1731430/99217601-ad895100-2795-11eb-8c9d-e01d331512ab.png)

Light sidebar:
![image](https://user-images.githubusercontent.com/1731430/99217636-c560d500-2795-11eb-8b8b-ef63a0eb9d3b.png)
