### PR TITLE
Update nightly build yml to always build even when no changes

### DIFF
--- a/azure-pipeline.nightly.yml
+++ b/azure-pipeline.nightly.yml
@@ -2,6 +2,14 @@
 trigger: none
 pr: none
 
+schedules:
+- chron: "0 9 * * Mon-Thu"
+  displayName: Nightly Release schedule
+  always: true
+  branches:
+    include:
+    - master
+
 jobs:
 - job: nightly_release
   displayName: Nightly Release


### PR DESCRIPTION
When proposed API changes but there have been no changes in vscode-pull-request-github then we don't get notified that there's a break. If we always build, even when there are no changes, then this should help us catch such problems earlier.