### PR TITLE
Force nowrap for all timestamps in description

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -709,6 +709,7 @@ code {
 .timestamp,
 .timestamp:hover {
 	color: inherit;
+	white-space: nowrap;
 }
 
 /** Theming */


### PR DESCRIPTION
Fixes #2339

@RMacfarlane regarding https://github.com/microsoft/vscode-pull-request-github/issues/2339#issuecomment-754111029 
Looks like there were already 2 places that had `nowrap` for timestamps (PR/Description header and comment header) and overflow most likely be caused by long author name and not only in headers but also in reviewers, PR header etc.
<details>
<summary>Overflow demo (large size from High DPI display 😢)</summary>

![image](https://user-images.githubusercontent.com/1312662/103718728-1e97f880-4fd0-11eb-9989-7ee23baea686.png)

</details>

To keep this PR small and focused on single problem I haven't include updated to author name caused overflows since different places have different problems (overlap with icon that is shown on hover, hiding commit message etc.). I will try to look on author name overflow and overflows in headers for line comment later.