### PR TITLE
Add a diff view to the create PR flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,6 +405,12 @@
           "name": "Create Pull Request",
           "when": "github:createPullRequest",
           "visibility": "visible"
+        },
+        {
+          "id": "github:compareChanges",
+          "name": "Compare Changes",
+          "when": "github:createPullRequest",
+          "visibility": "visible"
         }
       ]
     },
@@ -753,6 +759,16 @@
         "view": "github:login",
         "when": "ReposManagerStateContext == NeedsAuthentication",
         "contents": "You have not yet signed in with GitHub\n[Sign in](command:pr.signin)"
+      },
+      {
+        "view": "github:compareChanges",
+        "when": "github:noUpstream",
+        "contents": "The current branch has no upstream remote\n[Publish branch](command:git.publish)"
+      },
+      {
+        "view": "github:compareChanges",
+        "when": "github:noCommitDifference",
+        "contents": "The are no commits between the base branch and the current branch"
       }
     ],
     "keybindings": [

--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -40,6 +40,17 @@ export function fromPRUri(uri: Uri): PRUriParams | undefined {
 	} catch (e) { }
 }
 
+export interface GitHubUriParams {
+	fileName: string;
+	branch: string;
+	isEmpty?: boolean;
+}
+export function fromGitHubURI(uri: Uri): GitHubUriParams | undefined {
+	try {
+		return JSON.parse(uri.query) as GitHubUriParams;
+	} catch (e) { }
+}
+
 export interface GitUriOptions {
 	replaceFileExtension?: boolean;
 	submoduleOf?: string;

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { byRemoteName, DetachedHeadError, FolderRepositoryManager, titleAndBodyFrom } from './folderRepositoryManager';
+import { byRemoteName, DetachedHeadError, FolderRepositoryManager, PullRequestDefaults, titleAndBodyFrom } from './folderRepositoryManager';
 import webviewContent from '../../media/createPR-webviewIndex.js';
 import { getNonce, IRequestMessage, WebviewBase } from '../common/webview';
 import { PR_SETTINGS_NAMESPACE, PR_TITLE } from '../common/settingKeys';
 import { OctokitCommon } from './common';
 import { PullRequestModel } from './pullRequestModel';
 import Logger from '../common/logger';
+import { PullRequestGitHelper } from './pullRequestGitHelper';
 
 export type PullRequestTitleSource = 'commit' | 'branch' | 'custom' | 'ask';
 
@@ -40,12 +41,19 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 
 	private _webviewView: vscode.WebviewView;
 
-	private _onDone = new vscode.EventEmitter<PullRequestModel | undefined> ();
+	private _onDone = new vscode.EventEmitter<PullRequestModel | undefined>();
 	readonly onDone: vscode.Event<PullRequestModel | undefined> = this._onDone.event;
+
+	private _onDidChangeSelectedRemote = new vscode.EventEmitter<RemoteInfo>();
+	readonly onDidChangeSelectedRemote: vscode.Event<RemoteInfo> = this._onDidChangeSelectedRemote.event;
+
+	private _onDidChangeSelectedBranch = new vscode.EventEmitter<string>();
+	readonly onDidChangeSelectedBranch: vscode.Event<string> = this._onDidChangeSelectedBranch.event;
 
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
 		private readonly _folderRepositoryManager: FolderRepositoryManager,
+		private readonly _pullRequestDefaults: PullRequestDefaults,
 		private readonly _isDraft: boolean
 	) {
 		super();
@@ -78,7 +86,7 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 		this._webviewView.show();
 	}
 
-	private async getTitle(base: string): Promise<string> {
+	private async getTitle(): Promise<string> {
 		const method = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<PullRequestTitleSource>(PR_TITLE, PullRequestTitleSourceEnum.Ask);
 
 		switch (method) {
@@ -104,7 +112,7 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 					const headRepo = this._folderRepositoryManager.findRepo(byRemoteName(repositoryHead?.upstream.remote));
 					if (headRepo) {
 						const headBranch = `${headRepo.remote.owner}:${repositoryHead.name}`;
-						const commits = await origin.compareCommits(base, headBranch);
+						const commits = await origin.compareCommits(this._pullRequestDefaults.base, headBranch);
 						hasMultipleCommits = commits.total_commits > 1;
 					}
 				}
@@ -158,17 +166,15 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 			throw new DetachedHeadError(this._folderRepositoryManager.repository);
 		}
 
-		const pullRequestDefaults = await this._folderRepositoryManager.getPullRequestDefaults();
-
 		const defaultRemote: RemoteInfo = {
-			owner: pullRequestDefaults.owner,
-			repositoryName: pullRequestDefaults.repo
+			owner: this._pullRequestDefaults.owner,
+			repositoryName: this._pullRequestDefaults.repo
 		};
 
 		Promise.all([
 			this._folderRepositoryManager.getGitHubRemotes(),
-			this._folderRepositoryManager.listBranches(pullRequestDefaults.owner, pullRequestDefaults.repo),
-			this.getTitle(pullRequestDefaults.base),
+			this._folderRepositoryManager.listBranches(this._pullRequestDefaults.owner, this._pullRequestDefaults.repo),
+			this.getTitle(),
 			this.getDescription()
 		]).then(result => {
 			const [githubRemotes, branchesForRemote, defaultTitle, defaultDescription] = result;
@@ -185,7 +191,7 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 				params: {
 					availableRemotes: remotes,
 					defaultRemote,
-					defaultBranch: pullRequestDefaults.base,
+					defaultBranch: this._pullRequestDefaults.base,
 					branchesForRemote,
 					defaultTitle,
 					defaultDescription
@@ -194,7 +200,7 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 		});
 	}
 
-	private async changeRemote(message: IRequestMessage<{ owner: string, repositoryName: string}>): Promise<void> {
+	private async changeRemote(message: IRequestMessage<{ owner: string, repositoryName: string }>): Promise<void> {
 		const { owner, repositoryName } = message.args;
 		const githubRepository = this._folderRepositoryManager.findRepo(repo => owner === repo.remote.owner && repositoryName === repo.remote.repositoryName);
 
@@ -204,12 +210,23 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 
 		const defaultBranch = await githubRepository.getDefaultBranch();
 		const newBranches = await this._folderRepositoryManager.listBranches(owner, repositoryName);
+		this._onDidChangeSelectedRemote.fire({ owner, repositoryName });
 		return this._replyMessage(message, { branches: newBranches, defaultBranch });
 	}
 
 	private async create(message: IRequestMessage<OctokitCommon.PullsCreateParams>): Promise<void> {
 		try {
-			const head = this._folderRepositoryManager.repository.state.HEAD!.name!;
+			if (!this._folderRepositoryManager.repository.state.HEAD!.upstream) {
+				throw new DetachedHeadError(this._folderRepositoryManager.repository);
+			}
+
+			const branchName = this._folderRepositoryManager.repository.state.HEAD!.name!;
+			const headRepo = this._folderRepositoryManager.findRepo(byRemoteName(this._folderRepositoryManager.repository.state.HEAD!.upstream.remote));
+			if (!headRepo) {
+				throw new Error(`Unable to find GitHub repository matching '${this._folderRepositoryManager.repository.state.HEAD!.upstream.remote}'.`);
+			}
+
+			const head = `${headRepo.remote.owner}:${branchName}`;
 			const createdPR = await this._folderRepositoryManager.createPullRequest({ ...message.args, head, draft: this._isDraft });
 
 			// Create was cancelled
@@ -217,6 +234,7 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 				this._throwError(message, undefined);
 			} else {
 				await this._replyMessage(message, {});
+				await PullRequestGitHelper.associateBranchWithPullRequest(this._folderRepositoryManager.repository, createdPR, branchName);
 				this._onDone.fire(createdPR);
 			}
 		} catch (e) {
@@ -243,6 +261,10 @@ export class CreatePullRequestViewProvider extends WebviewBase implements vscode
 
 			case 'pr.changeRemote':
 				return this.changeRemote(message);
+
+			case 'pr.changeBranch':
+				this._onDidChangeSelectedBranch.fire(message.args);
+				return;
 
 			default:
 				// Log error

--- a/src/view/compareChangesTreeDataProvider.ts
+++ b/src/view/compareChangesTreeDataProvider.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Repository } from '../api/api';
+import { getGitChangeType } from '../common/diffHunk';
+import { fromGitHubURI } from '../common/uri';
+import { FolderRepositoryManager } from '../github/folderRepositoryManager';
+import { GitHubFileChangeNode } from './treeNodes/fileChangeNode';
+import { TreeNode } from './treeNodes/treeNode';
+
+export class CompareChangesTreeProvider implements vscode.TreeDataProvider<TreeNode> {
+	private _view: vscode.TreeView<TreeNode>;
+
+	private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode | void>();
+	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+	private _contentProvider: GitHubContentProvider;
+
+	private _disposables: vscode.Disposable[] = [];
+
+	constructor(
+		public readonly repository: Repository,
+		private baseOwner: string,
+		public baseBranchName: string,
+		private folderRepoManager: FolderRepositoryManager
+	) {
+		this._view = vscode.window.createTreeView('github:compareChanges', {
+			treeDataProvider: this
+		});
+
+		this._disposables.push(this._view);
+
+		this._disposables.push(this.repository.state.onDidChange(e => {
+			this._onDidChangeTreeData.fire();
+		}));
+	}
+
+	updateBaseBranch(branch: string): void {
+		this.baseBranchName = branch;
+		this._onDidChangeTreeData.fire();
+	}
+
+	updateBaseOwner(owner: string): void {
+		this.baseOwner = owner;
+		this._onDidChangeTreeData.fire();
+	}
+
+	getTreeItem(element: TreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {
+		return element.getTreeItem();
+	}
+
+	async getChildren() {
+		// If no upstream, show error.
+		if (!this.repository.state.HEAD || !this.repository.state.HEAD.upstream) {
+			vscode.commands.executeCommand('setContext', 'github:noUpstream', true);
+			return [];
+		} else {
+			vscode.commands.executeCommand('setContext', 'github:noUpstream', false);
+		}
+
+		const upstream = this.repository.state.HEAD.upstream.remote;
+
+		if (!this._contentProvider) {
+			this._contentProvider = new GitHubContentProvider(this.folderRepoManager, upstream);
+			this._disposables.push(vscode.workspace.registerTextDocumentContentProvider('github', this._contentProvider));
+		}
+
+		const githubRepository = this.folderRepoManager.gitHubRepositories.find(repo => repo.remote.remoteName === upstream);
+		if (!githubRepository) {
+			return [];
+		}
+
+		const { octokit, remote } = await githubRepository.ensure();
+
+		const { data } = await octokit.repos.compareCommits({
+			repo: remote.repositoryName,
+			owner: remote.owner,
+			base: `${this.baseOwner}:${this.baseBranchName}`,
+			head: `${remote.owner}:${this.repository.state.HEAD.name}`,
+		});
+
+		if (!data.files.length) {
+			vscode.commands.executeCommand('setContext', 'github:noCommitDifference', true);
+		} else {
+			vscode.commands.executeCommand('setContext', 'github:noCommitDifference', false);
+		}
+
+		return data.files.map(file => {
+			// Note: the oktokit typings are slightly incorrect for this data and do not include previous_filename, which is why this cast is here.
+			return new GitHubFileChangeNode(this._view, file.filename, (file as any).previous_filename, getGitChangeType(file.status), this.baseBranchName, this.repository.state.HEAD!.name!);
+		});
+	}
+
+	dispose() {
+		this._disposables.forEach(d => d.dispose());
+	}
+
+}
+
+/**
+ * Provides file contents for documents with 'github' scheme. Contents are fetched from GitHub based on
+ * information in the document's query string.
+ */
+class GitHubContentProvider {
+
+	constructor(private folderRepoManager: FolderRepositoryManager, private upstream: string) { }
+
+	async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
+		const params = fromGitHubURI(uri);
+		if (!params || params.isEmpty) {
+			return '';
+		}
+
+		const githubRepository = this.folderRepoManager.gitHubRepositories.find(repo => repo.remote.remoteName === this.upstream);
+
+		if (!githubRepository) {
+			return '';
+		}
+
+		const { octokit, remote } = await githubRepository.ensure();
+		const fileContent = await octokit.repos.getContent({
+			owner: remote.owner,
+			repo: remote.repositoryName,
+			path: params.fileName,
+			ref: params.branch
+		});
+
+		const contents = fileContent.data.content ?? '';
+		const buff = Buffer.from(contents, <any>fileContent.data.encoding);
+		return buff.toString();
+	}
+}

--- a/src/view/createPullRequestHelper.ts
+++ b/src/view/createPullRequestHelper.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Repository } from '../api/api';
+import { CreatePullRequestViewProvider } from '../github/createPRViewProvider';
+import { FolderRepositoryManager } from '../github/folderRepositoryManager';
+import { PullRequestModel } from '../github/pullRequestModel';
+import { CompareChangesTreeProvider } from './compareChangesTreeDataProvider';
+
+export class CreatePullRequestHelper {
+	private _disposables: vscode.Disposable[] = [];
+	private _createPRViewProvider: CreatePullRequestViewProvider | undefined;
+	private _treeView: CompareChangesTreeProvider | undefined;
+
+	private _onDidCreate = new vscode.EventEmitter<PullRequestModel> ();
+	readonly onDidCreate: vscode.Event<PullRequestModel> = this._onDidCreate.event;
+
+	constructor(private readonly repository: Repository) { }
+
+	private registerListeners() {
+		this._disposables.push(this._createPRViewProvider!.onDone(async createdPR => {
+			vscode.commands.executeCommand('setContext', 'github:createPullRequest', false);
+
+			this._createPRViewProvider?.dispose();
+			this._createPRViewProvider = undefined;
+
+			this._treeView?.dispose();
+			this._treeView = undefined;
+
+			this._disposables.forEach(d => d.dispose());
+
+			if (createdPR) {
+				this._onDidCreate.fire(createdPR);
+			}
+		}));
+
+		this._disposables.push(this._createPRViewProvider!.onDidChangeSelectedBranch(selectedBranch => {
+			this._treeView?.updateBaseBranch(selectedBranch);
+		}));
+
+		this._disposables.push(this._createPRViewProvider!.onDidChangeSelectedRemote(remoteInfo => {
+			this._treeView?.updateBaseOwner(remoteInfo.owner);
+		}));
+	}
+
+	async create(extensionUri: vscode.Uri, folderRepoManager: FolderRepositoryManager, isDraft: boolean) {
+		vscode.commands.executeCommand('setContext', 'github:createPullRequest', true);
+		if (!this._createPRViewProvider) {
+			const pullRequestDefaults = await folderRepoManager.getPullRequestDefaults();
+
+			this._createPRViewProvider = new CreatePullRequestViewProvider(extensionUri, folderRepoManager, pullRequestDefaults, !!isDraft);
+			this._treeView = new CompareChangesTreeProvider(this.repository, pullRequestDefaults.owner, pullRequestDefaults.base, folderRepoManager);
+
+			this.registerListeners();
+
+			this._disposables.push(vscode.window.registerWebviewViewProvider(CreatePullRequestViewProvider.viewType, this._createPRViewProvider));
+		} else {
+			this._createPRViewProvider.show();
+		}
+	}
+}

--- a/webviews/common/createContext.ts
+++ b/webviews/common/createContext.ts
@@ -69,6 +69,10 @@ export class CreatePRContext {
 		this.updateState({ selectedRemote: { owner, repositoryName }, branchesForRemote: response.branches, selectedBranch:  response.defaultBranch });
 	}
 
+	public changeBranch = async (branch: string): Promise<void> => {
+		this.postMessage({ command: 'pr.changeBranch', args: branch });
+	}
+
 	private validate = () => {
 		let isValid = true;
 		if (!this.createParams.pendingTitle) {
@@ -125,10 +129,16 @@ export class CreatePRContext {
 
 				if (this.createParams.selectedRemote === undefined) {
 					message.params.selectedRemote = message.params.defaultRemote;
+				} else {
+					// Notify the extension of the stored selected remote state
+					this.changeRemote(this.createParams.selectedRemote.owner, this.createParams.selectedRemote.repositoryName);
 				}
 
 				if (this.createParams.selectedBranch === undefined) {
 					message.params.selectedBranch = message.params.defaultBranch;
+				} else {
+					// Notify the extension of the stored selected branch state
+					this.changeBranch(this.createParams.selectedBranch);
 				}
 
 				this.updateState(message.params);

--- a/webviews/createPullRequestView/app.tsx
+++ b/webviews/createPullRequestView/app.tsx
@@ -15,6 +15,11 @@ export function main() {
 			const ctx = useContext(PullRequestContext);
 			const [isBusy, setBusy] = useState(false);
 
+			function updateSelectedBranch(branch: string): void {
+				ctx.changeBranch(branch);
+				ctx.updateState({ selectedBranch: branch });
+			}
+
 			function updateTitle(title: string): void {
 				params.validate
 					? ctx.updateState({ pendingTitle: title, showTitleValidationError: !title })
@@ -56,7 +61,7 @@ export function main() {
 				</div>
 
 				<div className='wrapper'>
-					{gitCompareIcon}<select value={params.selectedBranch} onChange={(e) => ctx.updateState({ selectedBranch: e.currentTarget.value })}>
+					{gitCompareIcon}<select value={params.selectedBranch} onChange={(e) => updateSelectedBranch(e.currentTarget.value)}>
 						{params.branchesForRemote.map(branchName =>
 							<option
 								key={branchName}


### PR DESCRIPTION
Adds a new view that shows a diff between the selected and current branch. This adds a "createPullRequestHelper" which keeps track of both views and can send information from the webview to the diff view so that it can refresh information.

Also fixed an issue in create where I was only passing the branch name instead of owner:branchName, which causes issues for forks.