### PR TITLE
Sanitizing issue titles lowercases text

### DIFF
--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -421,7 +421,8 @@ export function sanitizeIssueTitle(title: string): string {
 	return title
 		.replace(regex, '')
 		.trim()
-		.replace(/\s+/g, '-');
+		.replace(/\s+/g, '-')
+		.toLowerCase();
 }
 
 const VARIABLE_PATTERN = /\$\{(.*?)\}/g;

--- a/src/test/issues/issuesUtils.test.ts
+++ b/src/test/issues/issuesUtils.test.ts
@@ -47,21 +47,21 @@ describe('Issues utilities', function () {
 
 	describe('sanitizeIssueTitle', () => {
 		[
-			{ input: 'Issue', expected: 'Issue' },
-			{ input: 'Issue A', expected: 'Issue-A' },
-			{ input: 'Issue \ A', expected: 'Issue-A' },
-			{ input: 'Issue     A', expected: 'Issue-A' },
-			{ input: 'Issue @ A', expected: 'Issue-A' },
-			{ input: 'Issue \'A\'', expected: 'Issue-A' },
-			{ input: 'Issue "A"', expected: 'Issue-A' },
-			{ input: '@Issue "A"', expected: 'Issue-A' },
-			{ input: 'Issue "A"%', expected: 'Issue-A' },
-			{ input: 'Issue .A', expected: 'Issue-A' },
-			{ input: 'Issue ,A', expected: 'Issue-A' },
-			{ input: 'Issue :A', expected: 'Issue-A' },
-			{ input: 'Issue ;A', expected: 'Issue-A' },
-			{ input: 'Issue ~A', expected: 'Issue-A' },
-			{ input: 'Issue #A', expected: 'Issue-A' },
+			{ input: 'Issue', expected: 'issue' },
+			{ input: 'Issue A', expected: 'issue-a' },
+			{ input: 'Issue \ A', expected: 'issue-a' },
+			{ input: 'Issue     A', expected: 'issue-a' },
+			{ input: 'Issue @ A', expected: 'issue-a' },
+			{ input: 'Issue \'A\'', expected: 'issue-a' },
+			{ input: 'Issue "A"', expected: 'issue-a' },
+			{ input: '@Issue "A"', expected: 'issue-a' },
+			{ input: 'Issue "A"%', expected: 'issue-a' },
+			{ input: 'Issue .A', expected: 'issue-a' },
+			{ input: 'Issue ,A', expected: 'issue-a' },
+			{ input: 'Issue :A', expected: 'issue-a' },
+			{ input: 'Issue ;A', expected: 'issue-a' },
+			{ input: 'Issue ~A', expected: 'issue-a' },
+			{ input: 'Issue #A', expected: 'issue-a' },
 		]
 		.forEach((testCase) => {
 			it(`Transforms '${testCase.input}' into '${testCase.expected}'`, () => {


### PR DESCRIPTION
Branch names created using the `${sanitizedIssueTitle}` variable substitution will have a lowercase title