### PR TITLE
prevent description box resize from being too small

### DIFF
--- a/webviews/createPullRequestView/index.css
+++ b/webviews/createPullRequestView/index.css
@@ -13,6 +13,8 @@ select {
 
 textarea {
 	height: 100px;
+	/* 16px = 10px top and bottom padding + 6px of "padding" around the font */
+	min-height: calc(var(--vscode-font-size) + 16px);
 }
 
 .actions {


### PR DESCRIPTION
Fixes #2408

This is the smallest you can make the body now:
![image](https://user-images.githubusercontent.com/2644648/106075046-c1203480-60c1-11eb-9e57-ace947c3fb61.png)
