### PR TITLE
Render resolved conversations differently on description page

### DIFF
--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -37,4 +37,5 @@ export interface IComment {
 	inReplyToId?: number;
 	graphNodeId: string;
 	reactions?: Reaction[];
+	isResolved?: boolean;
 }

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -194,9 +194,10 @@ export interface PullRequestState {
 export interface PullRequestCommentsResponse {
 	repository: {
 		pullRequest: {
-			reviews: {
+			reviewThreads: {
 				nodes: [
 					{
+						isResolved: boolean;
 						comments: {
 							nodes: ReviewComment[];
 						}

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -282,7 +282,7 @@ export class PullRequestModel extends IssueModel implements IPullRequestModel {
 
 		return {
 			deletedReviewId: databaseId,
-			deletedReviewComments: comments.nodes.map(parseGraphQLComment)
+			deletedReviewComments: comments.nodes.map(comment => parseGraphQLComment(comment, false))
 		};
 	}
 
@@ -312,7 +312,7 @@ export class PullRequestModel extends IssueModel implements IPullRequestModel {
 		this.hasPendingReview = true;
 		await this.updateDraftModeContext();
 
-		return parseGraphQLComment(data.addPullRequestReview.pullRequestReview.comments.nodes[0]);
+		return parseGraphQLComment(data.addPullRequestReview.pullRequestReview.comments.nodes[0], false);
 	}
 
 	/**
@@ -395,7 +395,7 @@ export class PullRequestModel extends IssueModel implements IPullRequestModel {
 		});
 
 		const { comment } = data!.addPullRequestReviewComment;
-		return parseGraphQLComment(comment);
+		return parseGraphQLComment(comment, false);
 	}
 
 	/**
@@ -445,7 +445,7 @@ export class PullRequestModel extends IssueModel implements IPullRequestModel {
 			}
 		});
 
-		return parseGraphQLComment(data!.updatePullRequestReviewComment.pullRequestReviewComment);
+		return parseGraphQLComment(data!.updatePullRequestReviewComment.pullRequestReviewComment, !!comment.isResolved);
 	}
 
 	/**
@@ -524,8 +524,8 @@ export class PullRequestModel extends IssueModel implements IPullRequestModel {
 				}
 			});
 
-			const comments = data.repository.pullRequest.reviews.nodes
-				.map((node: any) => node.comments.nodes.map((comment: any) => parseGraphQLComment(comment), remote))
+			const comments = data.repository.pullRequest.reviewThreads.nodes
+				.map((node: any) => node.comments.nodes.map((comment: any) => parseGraphQLComment(comment, node.isResolved), remote))
 				.reduce((prev: any, curr: any) => prev.concat(curr), [])
 				.sort((a: IComment, b: IComment) => { return a.createdAt > b.createdAt ? 1 : -1; });
 

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -216,8 +216,9 @@ query GetPendingReviewId($pullRequestId: ID!, $author: String!) {
 query PullRequestComments($owner:String!, $name:String!, $number:Int!, $first:Int=100) {
 	repository(owner:$owner, name:$name) {
 		pullRequest(number:$number) {
-			reviews(first:$first) {
+			reviewThreads(first:$first) {
 				nodes {
+					isResolved
 					comments(first:100) {
 						nodes { ...ReviewComment }
 					}

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -255,7 +255,7 @@ export function convertGraphQLEventType(text: string) {
 	}
 }
 
-export function parseGraphQLComment(comment: GraphQL.ReviewComment): IComment {
+export function parseGraphQLComment(comment: GraphQL.ReviewComment, isResolved: boolean): IComment {
 	const c: IComment = {
 		id: comment.databaseId,
 		url: comment.url,
@@ -276,7 +276,8 @@ export function parseGraphQLComment(comment: GraphQL.ReviewComment): IComment {
 		graphNodeId: comment.id,
 		isDraft: comment.state === 'PENDING',
 		inReplyToId: comment.replyTo && comment.replyTo.databaseId,
-		reactions: parseGraphQLReaction(comment.reactionGroups)
+		reactions: parseGraphQLReaction(comment.reactionGroups),
+		isResolved
 	};
 
 	const diffHunks = parseCommentDiffHunk(c);
@@ -491,7 +492,7 @@ export function loginComparator(a: IAccount, b: IAccount) {
 export function parseGraphQLReviewEvent(review: GraphQL.SubmittedReview, githubRepository: GitHubRepository): Common.ReviewEvent {
 	return {
 		event: Common.EventType.Reviewed,
-		comments: review.comments.nodes.map(parseGraphQLComment).filter(c => !c.inReplyToId),
+		comments: review.comments.nodes.map(comment => parseGraphQLComment(comment, false)).filter(c => !c.inReplyToId),
 		submittedAt: review.submittedAt,
 		body: review.body,
 		bodyHTML: review.bodyHTML,

--- a/webviews/components/diff.tsx
+++ b/webviews/components/diff.tsx
@@ -4,22 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react';
-import { useContext } from 'react';
 
-import { IComment } from '../../src/common/comment';
 import { DiffHunk, DiffLine, DiffChangeType } from '../../src/common/diffHunk';
-import PullRequestContext from '../common/context';
 
-function Diff({ comment, hunks, path, outdated=false }: { comment: IComment, hunks: DiffHunk[], outdated: boolean, path: string }) {
-	const { openDiff } = useContext(PullRequestContext);
+function Diff({ hunks }: { hunks: DiffHunk[] }) {
 	return <div className='diff'>
-		<div className='diffHeader'>
-			{
-				outdated
-					? <span><span>{path}</span><span className='outdatedLabel'>Outdated</span></span>
-					: <a className='diffPath' onClick={() => openDiff(comment)}>{path}</a>
-			}
-		</div>
 		{hunks.map(hunk => <Hunk hunk={hunk} />)}
 	</div>;
 }

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -253,7 +253,7 @@ body .merged .merged-message > a {
 }
 
 body .comment-container .review-comment-container .pending-label,
-body .diff .diffHeader .outdatedLabel {
+body .resolved-container .outdatedLabel {
 		border: 1px solid;
 		border-radius: 2px 2px 2px 2px;
 		padding: 0.1rem 0.3rem;
@@ -785,13 +785,16 @@ code {
 	height: 18px;
 }
 
-.diff .diffHeader {
+.resolved-container {
 	padding: 6px 12px;
-	line-height: 1.5;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 	background: var(--vscode-editorGroupHeader-tabsBackground);
+	line-height: 1.5;
 }
 
-.diff .diffHeader .diffPath:hover {
+.resolved-container .diffPath:hover {
 	text-decoration: underline;
 	color: var(--vscode-textLink-activeForeground);
 	cursor: pointer;
@@ -861,7 +864,7 @@ code {
 	background: none;
 }
 
-.vscode-high-contrast .diff .diffHeader {
+.vscode-high-contrast .resolved-container {
 	background: none;
 }
 


### PR DESCRIPTION
Fetch whether review threads are resolved, and show them collapsed on the description page.
![Screen Shot 2021-02-05 at 12 00 45 PM](https://user-images.githubusercontent.com/3672607/107100059-15b16700-67c8-11eb-9b9f-165a20dc56fb.png)

![Screen Shot 2021-02-05 at 12 00 52 PM](https://user-images.githubusercontent.com/3672607/107100136-590bd580-67c8-11eb-8684-009a7cfb4116.png)

First part of https://github.com/microsoft/vscode-pull-request-github/issues/339