### PR TITLE
Separate view containers for PR and issues list and the active pull request

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,6 +364,11 @@
         {
           "id": "github-pull-requests",
           "title": "GitHub",
+          "icon": "resources/icons/dark/github.svg"
+        },
+        {
+          "id": "github-pull-request",
+          "title": "GitHub Pull Request",
           "icon": "resources/icons/pull-request.png"
         }
       ]
@@ -377,30 +382,19 @@
           "icon": "resources/icons/pull-request.png"
         },
         {
-          "id": "prStatus:github",
-          "name": "Changes In Pull Request",
-          "when": "github:inReviewMode",
-          "icon": "resources/icons/pull-request.png",
-          "visibility": "visible"
-        },
-        {
           "id": "pr:github",
           "name": "Pull Requests",
-          "when": "ReposManagerStateContext != NeedsAuthentication && !github:focusedReview && !github:createPullRequest",
+          "when": "ReposManagerStateContext != NeedsAuthentication",
           "icon": "resources/icons/pull-request.png"
-        },
-        {
-          "id": "github:activePullRequest",
-          "type": "webview",
-          "name": "Active Pull Request",
-          "when": "github:focusedReview"
         },
         {
           "id": "issues:github",
           "name": "Issues",
-          "when": "ReposManagerStateContext != NeedsAuthentication && !github:focusedReview &&!github:createPullRequest",
+          "when": "ReposManagerStateContext != NeedsAuthentication",
           "icon": "resources/icons/issues.png"
-        },
+        }
+      ],
+      "github-pull-request": [
         {
           "id": "github:createPullRequest",
           "type": "webview",
@@ -413,6 +407,19 @@
           "name": "Compare Changes",
           "when": "github:createPullRequest",
           "visibility": "visible"
+        },
+        {
+          "id": "prStatus:github",
+          "name": "Changes In Pull Request",
+          "when": "github:inReviewMode",
+          "icon": "resources/icons/pull-request.png",
+          "visibility": "visible"
+        },
+        {
+          "id": "github:activePullRequest",
+          "type": "webview",
+          "name": "Active Pull Request",
+          "when": "github:focusedReview"
         }
       ]
     },

--- a/src/view/prChangesTreeDataProvider.ts
+++ b/src/view/prChangesTreeDataProvider.ts
@@ -58,7 +58,7 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 		this._view.title = pullRequestNumber ? `Changes in Pull Request #${pullRequestNumber}` : 'Changes in Pull Request';
 	}
 
-	async addPrToView(pullRequestManager: FolderRepositoryManager, pullRequest: PullRequestModel, localFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[], comments: IComment[]) {
+	async addPrToView(pullRequestManager: FolderRepositoryManager, pullRequest: PullRequestModel, localFileChanges: (GitFileChangeNode | RemoteFileChangeNode)[], comments: IComment[], shouldReveal: boolean) {
 		const node: RepositoryChangesNode = new RepositoryChangesNode(this._view, pullRequest, pullRequestManager, comments, localFileChanges);
 		this._pullRequestManagerMap.set(pullRequestManager, node);
 		this.updateViewTitle();
@@ -69,6 +69,10 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 			true
 		);
 		this._onDidChangeTreeData.fire();
+
+		if (shouldReveal) {
+			this._view.reveal(node);
+		}
 	}
 
 	async removePrFromView(pullRequestManager: FolderRepositoryManager) {

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -55,6 +55,13 @@ export class ReviewManager {
 
 	private _switchingToReviewMode: boolean;
 
+	/**
+	 * Flag set when the "Checkout" action is used and cleared on the next git
+	 * state update, once review mode has been entered. Used to disambiguate
+	 * explicit user action from something like reloading on an existing PR branch.
+	 */
+	private justSwitchedToRevieMode: boolean = false;
+
 	public get switchingToReviewMode(): boolean {
 		return this._switchingToReviewMode;
 	}
@@ -275,7 +282,8 @@ export class ReviewManager {
 
 		Logger.appendLine('Review> Fetching pull request data');
 		await this.getPullRequestData(pr);
-		await this.changesInPrDataProvider.addPrToView(this._folderRepoManager, pr, this._localFileChanges, this._comments);
+		await this.changesInPrDataProvider.addPrToView(this._folderRepoManager, pr, this._localFileChanges, this._comments, this.justSwitchedToRevieMode);
+		this.justSwitchedToRevieMode = false;
 
 		Logger.appendLine(`Review> register comments provider`);
 		await this.registerCommentController();
@@ -511,6 +519,7 @@ export class ReviewManager {
 			Logger.appendLine(`Review> switch to Pull Request #${pr.number} - done`, ReviewManager.ID);
 		} finally {
 			this.switchingToReviewMode = false;
+			this.justSwitchedToRevieMode = true;
 			this.statusBarItem.text = `Pull Request #${pr.number}`;
 			this.statusBarItem.command = undefined;
 			this.statusBarItem.show();


### PR DESCRIPTION
Fixes #2371

Adds a new view container. This view container gets automatically focused when checking out a PR, or starting to create a PR. If the view container is removed (i.e. user exists review mode or cancels create), focus moves to the file explorer by default. Not sure if focusing the main view container then would be better, but wanted to avoid changing focus around too much since that could be disruptive. Let me know what you think!