### PR TITLE
Show warning when both nightly and stable versions are enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<GitApi
 	if (path.basename(context.globalStorageUri.fsPath) === 'github.vscode-pull-request-github-insiders') {
 		const stable = vscode.extensions.getExtension('github.vscode-pull-request-github');
 		if (stable !== null) {
-			throw new Error('GitHub Pull Requests and Issues Nightly cannot be used while GitHub Pull Requests and Issues is also enabled. Please ensure that only one version of the extension is enabled.');
+			throw new Error('GitHub Pull Requests and Issues Nightly cannot be used while GitHub Pull Requests and Issues is also installed. Please ensure that only one version of the extension is installed.');
 		}
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { Repository } from './api/api';
 import { GitApiImpl } from './api/api1';
@@ -160,6 +161,13 @@ async function init(context: vscode.ExtensionContext, git: GitApiImpl, credentia
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<GitApiImpl> {
+	if (path.basename(context.globalStorageUri.fsPath) === 'github.vscode-pull-request-github-insiders') {
+		const stable = vscode.extensions.getExtension('github.vscode-pull-request-github');
+		if (stable !== null) {
+			throw new Error('GitHub Pull Requests and Issues Nightly cannot be used while GitHub Pull Requests and Issues is also enabled. Please ensure that only one version of the extension is enabled.');
+		}
+	}
+
 	// initialize resources
 	Resource.initialize(context);
 	const apiImpl = new GitApiImpl();


### PR DESCRIPTION
Fixes #1782

Even if the nightly extension doesn't activate, stuff in the package.json still seems to get registered so it still ends up in a state with duplicated buttons everywhere. But hopefully this message will be noticable