### PR TITLE
Fix false positive during Stable build detections

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,7 @@ async function init(context: vscode.ExtensionContext, git: GitApiImpl, credentia
 export async function activate(context: vscode.ExtensionContext): Promise<GitApiImpl> {
 	if (path.basename(context.globalStorageUri.fsPath) === 'github.vscode-pull-request-github-insiders') {
 		const stable = vscode.extensions.getExtension('github.vscode-pull-request-github');
-		if (stable !== null) {
+		if (stable !== undefined) {
 			throw new Error('GitHub Pull Requests and Issues Nightly cannot be used while GitHub Pull Requests and Issues is also installed. Please ensure that only one version of the extension is installed.');
 		}
 	}


### PR DESCRIPTION
Fixes #2493

[`vscode.extensions`](https://code.visualstudio.com/api/references/vscode-api#extensions)`.getExtension()` returns `undefiend` instead of `null`

This PR changes comparison from `null` to `undefined`. Alternative can be using non strict comparison with `null`.