### PR TITLE
Exclude Activity Bar icon from ignored files

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -15,6 +15,8 @@ dist/browser/*.map
 documentation/**
 .vscode-test/**
 **/*webpack.config.js
-**/*.svg
 scripts/**
 azure-pipeline.*
+**/*.svg
+# include icon for Activity Bar into the package
+!resources/icons/dark/github.svg


### PR DESCRIPTION
Fixes #2495

All other SVG files are bundled by Webpack and ignored from package, but extension icon needs to be included into package because it's used directly.