### PR TITLE
Improves perceived performance of PR loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -789,17 +789,17 @@
       {
         "view": "pr:github",
         "when": "!github:initialized",
-        "contents": "Loading pull requests..."
+        "contents": "Loading..."
       },
       {
         "view": "issues:github",
         "when": "!github:initialized",
-        "contents": "Loading issues..."
+        "contents": "Loading..."
       },
       {
         "view": "github:activePullRequest:welcome",
         "when": "!github:initialized",
-        "contents": "Loading pull request..."
+        "contents": "Loading..."
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onStartupFinished",
+    "*",
+    "onCommand:pr.preload",
     "onFileSystem:newIssue"
   ],
   "browser": "./dist/browser/extension",
@@ -419,11 +420,21 @@
           "id": "github:activePullRequest",
           "type": "webview",
           "name": "Active Pull Request",
-          "when": "github:focusedReview"
+          "when": "github:initialized && github:focusedReview"
+        },
+        {
+          "id": "github:activePullRequest:welcome",
+          "name": "Active Pull Request",
+          "when": "!github:initialized && github:focusedReview"
         }
       ]
     },
     "commands": [
+      {
+        "command": "pr.preload",
+        "title": "Preload Pull Request",
+        "category": "GitHub Pull Requests"
+      },
       {
         "command": "pr.create",
         "title": "Create Pull Request",
@@ -774,6 +785,21 @@
         "view": "github:compareChanges",
         "when": "github:noUpstream",
         "contents": "The comparing branch has no upstream remote\n[Publish branch](command:git.publish)"
+      },
+      {
+        "view": "pr:github",
+        "when": "!github:initialized",
+        "contents": "Loading pull requests..."
+      },
+      {
+        "view": "issues:github",
+        "when": "!github:initialized",
+        "contents": "Loading issues..."
+      },
+      {
+        "view": "github:activePullRequest:welcome",
+        "when": "!github:initialized",
+        "contents": "Loading pull request..."
       }
     ],
     "keybindings": [
@@ -790,6 +816,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "pr.preload",
+          "when": "false"
+        },
         {
           "command": "auth.signout",
           "when": "gitOpenRepositoryCount != 0 && github:authenticated"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,4 @@ export const VSLS_REQUEST_NAME = 'git';
 export const VSLS_GIT_PR_SESSION_NAME = 'ghpr';
 export const VSLS_REPOSITORY_INITIALIZATION_NAME = 'initialize';
 export const VSLS_STATE_CHANGE_NOFITY_NAME = 'statechange';
+export const FOCUS_REVIEW_MODE = 'github:focusedReview';

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -27,8 +27,7 @@ import { PullRequestGitHelper } from '../github/pullRequestGitHelper';
 import { CreatePullRequestHelper } from './createPullRequestHelper';
 import { openDescription } from '../commands';
 import { GitHubCreatePullRequestLinkProvider } from '../github/createPRLinkProvider';
-
-const FOCUS_REVIEW_MODE = 'github:focusedReview';
+import { FOCUS_REVIEW_MODE } from '../constants';
 
 export class ReviewManager {
 	public static ID = 'Review';


### PR DESCRIPTION
Adds preload command which can be triggered by Codespaces to put the PR extension in a "pr" loading state (e.g. in the correct view with a loading welcome message).

Also defers a lot of activation code until post-activation to improve perceived performance, since views will be show much quicker in a loading state.