### PR TITLE
Add an option to configure the default handling of terminal links

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
 					"default": true,
 					"description": "When true, the option to delete the remote will be selected by default when deleting a branch from a pull request."
 				},
-				"githubPullRequests.terminalLinks.default": {
+				"githubPullRequests.terminalLinksHandler": {
 					"type": "string",
 					"enum": [
 						"github",
@@ -201,9 +201,9 @@
 						"ask"
 					],
 					"enumDescriptions": [
-						"Create the PR in github",
-						"Create the PR in VSCode",
-						"Prompt the user for each PR"
+						"Create the pull request on GitHub",
+						"Create the pull request in VS Code",
+						"Ask which method to use"
 					],
 					"default": "ask",
 					"description": "Default handler for terminal links."

--- a/package.json
+++ b/package.json
@@ -193,6 +193,21 @@
 					"default": true,
 					"description": "When true, the option to delete the remote will be selected by default when deleting a branch from a pull request."
 				},
+				"githubPullRequests.terminalLinks.default": {
+					"type": "string",
+					"enum": [
+						"github",
+						"vscode",
+						"ask"
+					],
+					"enumDescriptions": [
+						"Create the PR in github",
+						"Create the PR in VSCode",
+						"Prompt the user for each PR"
+					],
+					"default": "ask",
+					"description": "Default handler for terminal links."
+				},
 				"telemetry.optout": {
 					"type": "boolean",
 					"default": false,

--- a/src/github/createPRLinkProvider.ts
+++ b/src/github/createPRLinkProvider.ts
@@ -60,6 +60,20 @@ export class GitHubCreatePullRequestLinkProvider implements vscode.TerminalLinkP
 	}
 
 	handleTerminalLink(link: GitHubCreateTerminalLink): vscode.ProviderResult<void> {
+		const defaultHandler = vscode.workspace
+			.getConfiguration('githubPullRequests')
+			.get<'vscode' | 'github' | undefined>('terminalLinks.default');
+
+		if (defaultHandler === 'github') {
+			vscode.env.openExternal(vscode.Uri.parse(link.url));
+			return;
+		}
+
+		if (defaultHandler === 'vscode') {
+			this.reviewManager.createPullRequest();
+			return;
+		}
+
 		vscode.window
 			.showInformationMessage(
 				'Do you want to create a pull request using the GitHub Pull Requests and Issues extension?',

--- a/src/github/createPRLinkProvider.ts
+++ b/src/github/createPRLinkProvider.ts
@@ -62,7 +62,7 @@ export class GitHubCreatePullRequestLinkProvider implements vscode.TerminalLinkP
 	handleTerminalLink(link: GitHubCreateTerminalLink): vscode.ProviderResult<void> {
 		const defaultHandler = vscode.workspace
 			.getConfiguration('githubPullRequests')
-			.get<'vscode' | 'github' | undefined>('terminalLinks.default');
+			.get<'vscode' | 'github' | undefined>('terminalLinksHandler');
 
 		if (defaultHandler === 'github') {
 			vscode.env.openExternal(vscode.Uri.parse(link.url));


### PR DESCRIPTION
This PR introduces a new setting `githubPullRequests.terminalLinks.default` which allows to pre-configure the handling o terminal links for all links in the terminal.

3 possible options:

- `github`: Opens the links directly in github. Equivalent to pressing `no`.
- `vscode`: Opens the links directly in vscode. Equivalent to pressing `yes`.
- `ask`: Prompt the user every time they click a link.

