### PR TITLE
Cancel label promise when another action is taken

### DIFF
--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -655,6 +655,7 @@ export class FolderRepositoryManager implements vscode.Disposable {
 			const result = await octokit.issues.listLabelsForRepo({
 				owner: remote.owner,
 				repo: remote.repositoryName,
+				per_page: 100,
 				page,
 			});
 

--- a/src/github/issueOverview.ts
+++ b/src/github/issueOverview.ts
@@ -235,7 +235,7 @@ export class IssueOverviewPanel<TItem extends IssueModel = IssueModel> extends W
 			}
 
 			const labelsToAdd = await vscode.window.showQuickPick(
-				await getLabelOptions(this._folderRepositoryManager, this._item),
+				getLabelOptions(this._folderRepositoryManager, this._item),
 				{ canPickMany: true },
 			);
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -333,7 +333,6 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				await this._item.requestReview(reviewersToAdd.map(r => r.label));
 				const addedReviewers: ReviewState[] = reviewersToAdd.map(selected => {
 					return {
-						// assumes that suggested reviewers will be a subset of assignable users
 						reviewer: selected.reviewer,
 						state: 'REQUESTED',
 					};


### PR DESCRIPTION
Fixes #2537

The important thing was removing `await` in the quick pick for `getLabels` so that the quickpick showed up immediately. Opening another quickpick then causes it to be cancelled.
