### PR TITLE
No tree view with id 'github:compareChanges' registered.

### DIFF
--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -84,9 +84,11 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 		return this._compareBranch;
 	}
 
-	set compareBranch(compareBranch: Branch) {
-		if (compareBranch && compareBranch.name !== this._compareBranch.name
-			|| compareBranch.upstream?.remote !== this._compareBranch.upstream?.remote) {
+	set compareBranch(compareBranch: Branch | undefined) {
+		if (
+			compareBranch?.name !== this._compareBranch.name ||
+			compareBranch?.upstream?.remote !== this._compareBranch.upstream?.remote
+		) {
 			this._compareBranch = compareBranch;
 			void this.initializeParams(true);
 			this._onDidChangeCompareBranch.fire(this._compareBranch.name!);

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -85,8 +85,9 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 	}
 
 	set compareBranch(compareBranch: Branch) {
-		this._compareBranch = compareBranch;
-		if (compareBranch && compareBranch.name !== this._compareBranch.name) {
+		if (compareBranch && compareBranch.name !== this._compareBranch.name
+			|| compareBranch.upstream?.remote !== this._compareBranch.upstream?.remote) {
+			this._compareBranch = compareBranch;
 			void this.initializeParams(true);
 			this._onDidChangeCompareBranch.fire(this._compareBranch.name!);
 		}

--- a/src/view/compareChangesTreeDataProvider.ts
+++ b/src/view/compareChangesTreeDataProvider.ts
@@ -33,14 +33,6 @@ export class CompareChangesTreeProvider implements vscode.TreeDataProvider<TreeN
 		});
 
 		this._disposables.push(this._view);
-
-		this._disposables.push(
-			this.repository.state.onDidChange(async e => {
-				// Refresh the compare branch stats if the repo changes
-				this.compareBranch = await this.repository.getBranch(this.compareBranch.name!)!;
-				this._onDidChangeTreeData.fire();
-			}),
-		);
 	}
 
 	async updateCompareBranch(branch: string): Promise<void> {


### PR DESCRIPTION
Fixes #2397

I haven't been able to repro the original issue, so this is a tentative fix. I think what's happening is that the git state change listener on the tree is sometimes firing after the tree view has been disposed.