### PR TITLE
Show "Merge on github" button in codespaces when merge will otherwise fail

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,6 +21,7 @@ import { GHPRComment, TemporaryComment } from './github/prComment';
 import { PullRequestModel } from './github/pullRequestModel';
 import { PullRequestOverviewPanel } from './github/pullRequestOverview';
 import { RepositoriesManager } from './github/repositoriesManager';
+import { isInCodespaces } from './github/utils';
 import { PullRequestsTreeDataProvider } from './view/prsTreeDataProvider';
 import { ReviewManager } from './view/reviewManager';
 import { CommitNode } from './view/treeNodes/commitNode';
@@ -403,6 +404,17 @@ export function registerCommands(
 			}
 			const pullRequest = ensurePR(folderManager, pr);
 			// TODO check is codespaces
+
+			const isCrossRepository =
+				pullRequest.base &&
+				pullRequest.head &&
+				!pullRequest.base.repositoryCloneUrl.equals(pullRequest.head.repositoryCloneUrl);
+
+			const showMergeOnGitHub = isCrossRepository && isInCodespaces();
+			if (showMergeOnGitHub) {
+				return openPullRequestOnGitHub(pullRequest, telemetry);
+			}
+
 			return vscode.window
 				.showWarningMessage(
 					`Are you sure you want to merge this pull request on GitHub?`,

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -129,7 +129,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 				const isCrossRepository =
 					pullRequest.base &&
 					pullRequest.head &&
-					pullRequest.base.repositoryCloneUrl! == pullRequest.head.repositoryCloneUrl;
+					!pullRequest.base.repositoryCloneUrl.equals(pullRequest.head.repositoryCloneUrl);
 
 				const showMergeOnGitHub = isCrossRepository && isInCodespaces();
 

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { openPullRequestOnGitHub } from '../commands';
 import { IComment } from '../common/comment';
 import { ReviewEvent as CommonReviewEvent } from '../common/timelineEvent';
 import { formatError } from '../common/utils';
@@ -12,7 +13,7 @@ import { FolderRepositoryManager } from './folderRepositoryManager';
 import { GithubItemStateEnum, MergeMethod, ReviewEvent, ReviewState } from './interface';
 import { PullRequestModel } from './pullRequestModel';
 import { getDefaultMergeMethod } from './pullRequestOverview';
-import { parseReviewers } from './utils';
+import { isInCodespaces, parseReviewers } from './utils';
 
 export class PullRequestViewProvider extends WebviewViewBase implements vscode.WebviewViewProvider {
 	public readonly viewType = 'github:activePullRequest';
@@ -74,6 +75,8 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 				return this.requestChanges(message);
 			case 'pr.submit':
 				return this.submitReview(message);
+			case 'pr.openOnGitHub':
+				return openPullRequestOnGitHub(this._item, (this._item as any)._telemetry);
 		}
 	}
 
@@ -123,6 +126,13 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 					pullRequest.author,
 				);
 
+				const isCrossRepository =
+					pullRequest.base &&
+					pullRequest.head &&
+					pullRequest.base.repositoryCloneUrl! == pullRequest.head.repositoryCloneUrl;
+
+				const showMergeOnGitHub = isCrossRepository && isInCodespaces();
+
 				this._postMessage({
 					command: 'pr.initialize',
 					pullrequest: {
@@ -154,6 +164,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 						isIssue: false,
 						isAuthor: currentUser.login === pullRequest.author.login,
 						reviewers: this._existingReviewers,
+						showMergeOnGitHub,
 					},
 				});
 			})

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -163,7 +163,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				const isCrossRepository =
 					pullRequest.base &&
 					pullRequest.head &&
-					pullRequest.base.repositoryCloneUrl! == pullRequest.head.repositoryCloneUrl;
+					!pullRequest.base.repositoryCloneUrl.equals(pullRequest.head.repositoryCloneUrl);
 
 				const showMergeOnGitHub = isCrossRepository && isInCodespaces();
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -6,7 +6,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { onDidUpdatePR } from '../commands';
+import { onDidUpdatePR, openPullRequestOnGitHub } from '../commands';
 import { IComment } from '../common/comment';
 import Logger from '../common/logger';
 import { ReviewEvent as CommonReviewEvent } from '../common/timelineEvent';
@@ -25,7 +25,7 @@ import {
 } from './interface';
 import { IssueOverviewPanel } from './issueOverview';
 import { PullRequestModel } from './pullRequestModel';
-import { parseReviewers } from './utils';
+import { isInCodespaces, parseReviewers } from './utils';
 
 export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestModel> {
 	public static ID: string = 'PullRequestOverviewPanel';
@@ -160,6 +160,13 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				const defaultMergeMethod = getDefaultMergeMethod(mergeMethodsAvailability, preferredMergeMethod);
 				this._existingReviewers = parseReviewers(requestedReviewers!, timelineEvents!, pullRequest.author);
 
+				const isCrossRepository =
+					pullRequest.base &&
+					pullRequest.head &&
+					pullRequest.base.repositoryCloneUrl! == pullRequest.head.repositoryCloneUrl;
+
+				const showMergeOnGitHub = isCrossRepository && isInCodespaces();
+
 				Logger.debug('pr.initialize', PullRequestOverviewPanel.ID);
 				this._postMessage({
 					command: 'pr.initialize',
@@ -194,6 +201,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 						isIssue: false,
 						milestone: pullRequest.milestone,
 						assignees: pullRequest.assignees,
+						showMergeOnGitHub,
 					},
 				});
 			})
@@ -267,6 +275,8 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				return this.removeAssignee(message);
 			case 'pr.copy-prlink':
 				return this.copyPrLink(message);
+			case 'pr.openOnGitHub':
+				return openPullRequestOnGitHub(this._item, (this._item as any)._telemetry);
 		}
 	}
 

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -876,3 +876,7 @@ export function getPRFetchQuery(repo: string, user: string, query: string): stri
 	const filter = query.replace(/\$\{user\}/g, user);
 	return `is:pull-request ${filter} type:pr repo:${repo}`;
 }
+
+export function isInCodespaces(): boolean {
+	return vscode.env.remoteName === 'codespaces' && vscode.env.uiKind === vscode.UIKind.Web;
+}

--- a/webviews/activityBarView/index.css
+++ b/webviews/activityBarView/index.css
@@ -49,11 +49,16 @@ textarea {
 }
 
 .select-control,
+#merge-on-github,
 form {
 	display: flex;
 	margin: auto;
 	max-width: 260px;
 	width: 100%;
+}
+
+#merge-on-github {
+	justify-content: center;
 }
 
 #comment-textarea {

--- a/webviews/common/cache.ts
+++ b/webviews/common/cache.ts
@@ -62,6 +62,7 @@ export interface PullRequest {
 	isIssue: boolean;
 
 	isAuthor?: boolean;
+	showMergeOnGitHub: boolean;
 }
 
 export function getState(): PullRequest {

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -47,6 +47,8 @@ export class PRContext {
 	public merge = (args: { title: string; description: string; method: MergeMethod }) =>
 		this.postMessage({ command: 'pr.merge', args });
 
+	public openOnGitHub = () => this.postMessage({ command: 'pr.openOnGitHub' });
+
 	public deleteBranch = () => this.postMessage({ command: 'pr.deleteBranch' });
 
 	public readyForReview = () => this.postMessage({ command: 'pr.readyForReview' });
@@ -61,16 +63,11 @@ export class PRContext {
 		});
 	};
 
-	public addReviewers = () =>
-		this.postMessage({ command: 'pr.add-reviewers' })
-	public addMilestone = () =>
-		this.postMessage({ command: 'pr.add-milestone' })
-	public removeMilestone = () =>
-		this.postMessage({ command: 'pr.remove-milestone' })
-	public addAssignees = () =>
-		this.postMessage({ command: 'pr.add-assignees' })
-	public addLabels = () =>
-		this.postMessage({ command: 'pr.add-labels' })
+	public addReviewers = () => this.postMessage({ command: 'pr.add-reviewers' });
+	public addMilestone = () => this.postMessage({ command: 'pr.add-milestone' });
+	public removeMilestone = () => this.postMessage({ command: 'pr.remove-milestone' });
+	public addAssignees = () => this.postMessage({ command: 'pr.add-assignees' });
+	public addLabels = () => this.postMessage({ command: 'pr.add-labels' });
 
 	public deleteComment = async (args: { id: number; pullRequestReviewId?: number }) => {
 		await this.postMessage({ command: 'pr.delete-comment', args });
@@ -139,8 +136,7 @@ export class PRContext {
 		await this.postMessage({ command: 'pr.remove-assignee', args: login });
 		const assignees = this.pr.assignees.filter(a => a.login !== login);
 		this.updatePR({ assignees });
-	}
-
+	};
 
 	public removeLabel = async (label: string) => {
 		await this.postMessage({ command: 'pr.remove-label', args: label });

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -170,20 +170,29 @@ export const Merge = (pr: PullRequest) => {
 };
 
 export const PrActions = ({ pr, isSimple }: { pr: PullRequest; isSimple: boolean }) => {
-	const { hasWritePermission, canEdit, isDraft, mergeable } = pr;
-
-	return isDraft ? (
+	const { hasWritePermission, canEdit, isDraft, mergeable, showMergeOnGitHub } = pr;
+	if (showMergeOnGitHub) {
+		return canEdit ? <MergeOnGitHub /> : null;
+	}
+	if (isDraft) {
 		// Only PR author and users with push rights can mark draft as ready for review
-		canEdit ? (
-			<ReadyForReview isSimple={isSimple} />
-		) : null
-	) : mergeable === PullRequestMergeability.Mergeable && hasWritePermission ? (
-		isSimple ? (
-			<MergeSimple {...pr} />
-		) : (
-			<Merge {...pr} />
-		)
-	) : null;
+		return canEdit ? <ReadyForReview isSimple={isSimple} /> : null;
+	}
+
+	if (mergeable === PullRequestMergeability.Mergeable && hasWritePermission) {
+		return isSimple ? <MergeSimple {...pr} /> : <Merge {...pr} />;
+	}
+
+	return null;
+};
+
+export const MergeOnGitHub = () => {
+	const { openOnGitHub } = useContext(PullRequestContext);
+	return (
+		<button type="submit" onClick={() => openOnGitHub}>
+			Merge on github.com
+		</button>
+	);
 };
 
 export const MergeSimple = (pr: PullRequest) => {

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -189,7 +189,7 @@ export const PrActions = ({ pr, isSimple }: { pr: PullRequest; isSimple: boolean
 export const MergeOnGitHub = () => {
 	const { openOnGitHub } = useContext(PullRequestContext);
 	return (
-		<button type="submit" onClick={() => openOnGitHub}>
+		<button id="merge-on-github" type="submit" onClick={() => openOnGitHub}>
 			Merge on github.com
 		</button>
 	);

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -163,6 +163,10 @@ body .comment-container .review-comment-header {
 	margin-left: 15px;
 }
 
+#merge-on-github {
+	margin-top: 10px;
+}
+
 .status-item,
 .form-actions {
 	display: flex;

--- a/webviews/editorWebview/test/builder/pullRequest.ts
+++ b/webviews/editorWebview/test/builder/pullRequest.ts
@@ -34,4 +34,5 @@ export const PullRequestBuilder = createBuilderClass<PullRequest>()({
 	isIssue: { default: false },
 	assignees: { default: [] },
 	milestone: { default: undefined },
+	showMergeOnGitHub: { default: false },
 });


### PR DESCRIPTION
Workaround for the codespaces issues with permissions - trying to merge a pull request that is cross-repository will fail right now. Still not a good experience, but we can open the PR page in github instead so that the user can merge from there instead