### PR TITLE
Create only one pull request model per pull request

### DIFF
--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -1076,12 +1076,7 @@ export class FolderRepositoryManager implements vscode.Disposable {
 		}
 
 		try {
-			await repo.ensure();
-
-			// Create PR
-			const { data } = await repo.octokit.pulls.create(params);
-			const item = convertRESTPullRequestToRawPullRequest(data, repo);
-			const pullRequestModel = new PullRequestModel(this._telemetry, repo, repo.remote, item, true);
+			const pullRequestModel = await repo.createPullRequest(params);
 
 			const branchNameSeparatorIndex = params.head.indexOf(':');
 			const branchName = params.head.slice(branchNameSeparatorIndex + 1);


### PR DESCRIPTION
Makes it possible to cache information on the PR model