### PR TITLE
Diff from PR's file gets erroneously opened when working on the PR's branch

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -363,7 +363,7 @@ export class ReviewManager {
 		Logger.appendLine(`Review> display pull request status bar indicator and refresh pull request tree view.`);
 		this.statusBarItem.show();
 		vscode.commands.executeCommand('pr.refreshList');
-		if (!silent && this._context.workspaceState.get(FOCUS_REVIEW_MODE)) {
+		if (!silent && this._context.workspaceState.get(FOCUS_REVIEW_MODE) && vscode.env.remoteName === 'codespaces') {
 			if (this.localFileChanges.length > 0) {
 				let fileChangeToShow: GitFileChangeNode | undefined;
 				for (const fileChange of this.localFileChanges) {


### PR DESCRIPTION
Fixes #2295

Scopes down the diff opening to codespaces - do you think this is reasonable? There have already been a couple of issues about this since turning on "Focused Mode" so I think it would be good to open the diff less frequently