### PR TITLE
Description page shows wrong merge status in nightly

### DIFF
--- a/src/github/issueModel.ts
+++ b/src/github/issueModel.ts
@@ -113,6 +113,8 @@ export class IssueModel<TItem extends Issue = Issue> {
 		if (issue.assignees) {
 			this.assignees = issue.assignees;
 		}
+
+		this.item = issue;
 	}
 
 	equals(other: IssueModel<TItem> | undefined): boolean {


### PR DESCRIPTION
Fixes #2618

The issue was caused by the new caching of pull request models, we read mergeability off of the `item` there and it wasn't being updated properly