### PR TITLE
Enable eslint warnings for unused variables

### DIFF
--- a/.eslintrc.base.json
+++ b/.eslintrc.base.json
@@ -229,7 +229,7 @@
 		"@typescript-eslint/no-unsafe-member-access": "off", // TODO@eamodio revisit
 		"@typescript-eslint/no-unsafe-return": "off", // TODO@eamodio revisit
 		"@typescript-eslint/no-unused-expressions": ["warn", { "allowShortCircuit": true }],
-		"@typescript-eslint/no-unused-vars": "off", // TODO@eamodio revisit
+		"@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
 		// "@typescript-eslint/no-unused-vars": [
 		// 	"warn",
 		// 	{

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -354,7 +354,7 @@ export function registerCommands(
 					location: vscode.ProgressLocation.SourceControl,
 					title: `Switching to Pull Request #${pullRequestModel.number}`,
 				},
-				async (progress, token) => {
+				async () => {
 					await ReviewManager.getReviewManagerForRepository(
 						reviewManagers,
 						pullRequestModel.githubRepository,
@@ -387,7 +387,7 @@ export function registerCommands(
 					location: vscode.ProgressLocation.SourceControl,
 					title: `Exiting Pull Request`,
 				},
-				async (progress, token) => {
+				async () => {
 					const branch = await pullRequestModel.githubRepository.getDefaultBranch();
 					const manager = reposManager.getManagerForIssueModel(pullRequestModel);
 					if (manager) {

--- a/src/env/browser/ssh.ts
+++ b/src/env/browser/ssh.ts
@@ -3,4 +3,4 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const resolve = (url: string) => undefined;
+export const resolve = (_url: string) => undefined;

--- a/src/experimentationService.ts
+++ b/src/experimentationService.ts
@@ -58,7 +58,7 @@ export class ExperimentationTelemetry implements IExperimentationTelemetry {
 	sendTelemetryErrorEvent(
 		eventName: string,
 		properties?: Record<string, string>,
-		measurements?: Record<string, number>,
+		_measurements?: Record<string, number>,
 	) {
 		this.baseReporter.sendTelemetryErrorEvent(eventName, {
 			...this.sharedProperties,
@@ -101,25 +101,25 @@ function getTargetPopulation(product: ProductConfiguration): TargetPopulation {
 class NullExperimentationService implements IExperimentationService {
 	readonly initializePromise: Promise<void> = Promise.resolve();
 
-	isFlightEnabled(flight: string): boolean {
+	isFlightEnabled(_flight: string): boolean {
 		return false;
 	}
 
-	isCachedFlightEnabled(flight: string): Promise<boolean> {
+	isCachedFlightEnabled(_flight: string): Promise<boolean> {
 		return Promise.resolve(false);
 	}
 
-	isFlightEnabledAsync(flight: string): Promise<boolean> {
+	isFlightEnabledAsync(_flight: string): Promise<boolean> {
 		return Promise.resolve(false);
 	}
 
-	getTreatmentVariable<T extends boolean | number | string>(configId: string, name: string): T | undefined {
+	getTreatmentVariable<T extends boolean | number | string>(_configId: string, _name: string): T | undefined {
 		return undefined;
 	}
 
 	getTreatmentVariableAsync<T extends boolean | number | string>(
-		configId: string,
-		name: string,
+		_configId: string,
+		_name: string,
 	): Promise<T | undefined> {
 		return Promise.resolve(undefined);
 	}

--- a/src/gitProviders/vslshost.ts
+++ b/src/gitProviders/vslshost.ts
@@ -46,7 +46,7 @@ export class VSLSHost implements vscode.Disposable {
 			const commandArgs = args.slice(2);
 			if (type === VSLS_REPOSITORY_INITIALIZATION_NAME) {
 				this._disposables.push(
-					localRepository.state.onDidChange((e: any) => {
+					localRepository.state.onDidChange(_ => {
 						this._sharedService!.notify(VSLS_STATE_CHANGE_NOFITY_NAME, {
 							HEAD: localRepository.state.HEAD,
 							remotes: localRepository.state.remotes,

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -30,7 +30,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 
 	public resolveWebviewView(
 		webviewView: vscode.WebviewView,
-		context: vscode.WebviewViewResolveContext,
+		_context: vscode.WebviewViewResolveContext,
 		_token: vscode.CancellationToken,
 	) {
 		this._view = webviewView;

--- a/src/github/createPRLinkProvider.ts
+++ b/src/github/createPRLinkProvider.ts
@@ -19,7 +19,7 @@ export class GitHubCreatePullRequestLinkProvider implements vscode.TerminalLinkP
 
 	provideTerminalLinks(
 		context: vscode.TerminalLinkContext,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): vscode.ProviderResult<GitHubCreateTerminalLink[]> {
 		const startIndex = context.line.indexOf('https://github.com');
 		if (startIndex === -1) {

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -57,7 +57,7 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 
 	public resolveWebviewView(
 		webviewView: vscode.WebviewView,
-		context: vscode.WebviewViewResolveContext,
+		_context: vscode.WebviewViewResolveContext,
 		_token: vscode.CancellationToken,
 	) {
 		this._view = webviewView;

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -205,7 +205,7 @@ export class FolderRepositoryManager implements vscode.Disposable {
 		vscode.languages.registerCompletionItemProvider(
 			{ scheme: 'comment' },
 			{
-				provideCompletionItems: async (document, position, token) => {
+				provideCompletionItems: async (document, position, _token) => {
 					try {
 						const query = JSON.parse(document.uri.query);
 						if (query.extensionId !== EXTENSION_ID) {
@@ -386,7 +386,7 @@ export class FolderRepositoryManager implements vscode.Disposable {
 						return [];
 					}
 				},
-				resolveCompletionItem: async (item: vscode.CompletionItem, token: vscode.CancellationToken) => {
+				resolveCompletionItem: async (item: vscode.CompletionItem, _token: vscode.CancellationToken) => {
 					try {
 						const repo = await this.getPullRequestDefaults();
 						const user: User | undefined = await this.resolveUser(repo.owner, repo.repo, item.label);

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -384,7 +384,7 @@ export class GitHubRepository implements vscode.Disposable {
 		return githubRepository;
 	}
 
-	async getIssuesForUserByMilestone(page?: number): Promise<MilestoneData | undefined> {
+	async getIssuesForUserByMilestone(_page?: number): Promise<MilestoneData | undefined> {
 		try {
 			Logger.debug(`Fetch all issues - enter`, GitHubRepository.ID);
 			const { query, remote, schema } = await this.ensure();
@@ -424,7 +424,7 @@ export class GitHubRepository implements vscode.Disposable {
 		}
 	}
 
-	async getIssuesWithoutMilestone(page?: number): Promise<IssueData | undefined> {
+	async getIssuesWithoutMilestone(_page?: number): Promise<IssueData | undefined> {
 		try {
 			Logger.debug(`Fetch issues without milestone- enter`, GitHubRepository.ID);
 			const { query, remote, schema } = await this.ensure();
@@ -589,7 +589,7 @@ export class GitHubRepository implements vscode.Disposable {
 			const promises: Promise<OctokitTypes.OctokitResponse<OctokitCommon.PullsGetResponseData>>[] = [];
 			data.items.forEach((item: any /** unluckily Octokit.AnyResponse */) => {
 				promises.push(
-					new Promise(async (resolve, reject) => {
+					new Promise(async (resolve, _reject) => {
 						const prData = await octokit.pulls.get({
 							owner: remote.owner,
 							repo: remote.repositoryName,

--- a/src/github/issueModel.ts
+++ b/src/github/issueModel.ts
@@ -13,14 +13,12 @@ import { OctokitCommon } from './common';
 import { GitHubRepository } from './githubRepository';
 import {
 	AddIssueCommentResponse,
-	AddReactionResponse,
-	DeleteReactionResponse,
 	EditIssueCommentResponse,
 	TimelineEventsResponse,
 	UpdatePullRequestResponse,
 } from './graphql';
 import { GithubItemStateEnum, IAccount, IMilestone, IPullRequestEditData, Issue } from './interface';
-import { getReactionGroup, parseGraphQlIssueComment, parseGraphQLTimelineEvents } from './utils';
+import { parseGraphQlIssueComment, parseGraphQLTimelineEvents } from './utils';
 
 export class IssueModel<TItem extends Issue = Issue> {
 	static ID = 'IssueModel';
@@ -70,7 +68,7 @@ export class IssueModel<TItem extends Issue = Issue> {
 
 				// hack, to ensure queries are not wrongly encoded.
 				const originalToStringFn = uri.toString;
-				uri.toString = function (skipEncoding?: boolean | undefined) {
+				uri.toString = function (_skipEncoding?: boolean | undefined) {
 					return originalToStringFn.call(uri, true);
 				};
 

--- a/src/github/issueOverview.ts
+++ b/src/github/issueOverview.ts
@@ -322,7 +322,7 @@ export class IssueOverviewPanel<TItem extends IssueModel = IssueModel> extends W
 			.then(value => {
 				if (value === 'Delete') {
 					this.deleteCommentPromise(message.args)
-						.then(result => {
+						.then(_ => {
 							this._replyMessage(message, {});
 						})
 						.catch(e => {

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -274,7 +274,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 			case 'pr.remove-assignee':
 				return this.removeAssignee(message);
 			case 'pr.copy-prlink':
-				return this.copyPrLink(message);
+				return this.copyPrLink();
 			case 'pr.openOnGitHub':
 				return openPullRequestOnGitHub(this._item, (this._item as any)._telemetry);
 		}
@@ -774,7 +774,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 		);
 	}
 
-	private async copyPrLink(message: IRequestMessage<string>): Promise<void> {
+	private async copyPrLink(): Promise<void> {
 		await vscode.env.clipboard.writeText(this._item.html_url);
 		vscode.window.showInformationMessage(`Copied link to PR ${this._item.title}!`);
 	}

--- a/src/issues/issueCompletionProvider.ts
+++ b/src/issues/issueCompletionProvider.ts
@@ -178,7 +178,7 @@ export class IssueCompletionProvider implements vscode.CompletionItemProvider {
 
 	async resolveCompletionItem(
 		item: vscode.CompletionItem,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.CompletionItem> {
 		if (item instanceof IssueCompletionItem) {
 			item.documentation = await issueMarkdown(item.issue, this.context, this.repositoriesManager);

--- a/src/issues/issueFile.ts
+++ b/src/issues/issueFile.ts
@@ -80,8 +80,8 @@ export class LabelCompletionProvider implements vscode.CompletionItemProvider {
 	async provideCompletionItems(
 		document: vscode.TextDocument,
 		position: vscode.Position,
-		token: vscode.CancellationToken,
-		context: vscode.CompletionContext,
+		_token: vscode.CancellationToken,
+		_context: vscode.CompletionContext,
 	): Promise<vscode.CompletionItem[]> {
 		if (!document.lineAt(position.line).text.startsWith(LABELS)) {
 			return [];

--- a/src/issues/issueHoverProvider.ts
+++ b/src/issues/issueHoverProvider.ts
@@ -28,7 +28,7 @@ export class IssueHoverProvider implements vscode.HoverProvider {
 	async provideHover(
 		document: vscode.TextDocument,
 		position: vscode.Position,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.Hover | undefined> {
 		if (!(await shouldShowHover(document, position))) {
 			return;

--- a/src/issues/issueLinkLookup.ts
+++ b/src/issues/issueLinkLookup.ts
@@ -27,7 +27,7 @@ interface CodeLink {
 export async function findCodeLinkLocally(
 	codeLink: RegExpMatchArray,
 	repositoriesManager: RepositoriesManager,
-	silent: boolean = true,
+	_silent: boolean = true,
 ): Promise<CodeLink | undefined> {
 	const owner = codeLink[2];
 	const repo = codeLink[3];

--- a/src/issues/issueLinkProvider.ts
+++ b/src/issues/issueLinkProvider.ts
@@ -32,7 +32,7 @@ export class IssueLinkProvider implements vscode.DocumentLinkProvider {
 
 	async provideDocumentLinks(
 		document: vscode.TextDocument,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.DocumentLink[]> {
 		const links: vscode.DocumentLink[] = [];
 		const wraps: boolean = vscode.workspace.getConfiguration('editor', document).get('wordWrap', 'off') !== 'off';

--- a/src/issues/issueTodoProvider.ts
+++ b/src/issues/issueTodoProvider.ts
@@ -27,7 +27,7 @@ export class IssueTodoProvider implements vscode.CodeActionProvider {
 		document: vscode.TextDocument,
 		range: vscode.Range | vscode.Selection,
 		context: vscode.CodeActionContext,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.CodeAction[]> {
 		if (this.expression === undefined || (context.only && context.only !== vscode.CodeActionKind.QuickFix)) {
 			return [];

--- a/src/issues/userCompletionProvider.ts
+++ b/src/issues/userCompletionProvider.ts
@@ -14,7 +14,7 @@ export class UserCompletionProvider implements vscode.CompletionItemProvider {
 	constructor(
 		private stateManager: StateManager,
 		private manager: RepositoriesManager,
-		context: vscode.ExtensionContext,
+		_context: vscode.ExtensionContext,
 	) {}
 
 	async provideCompletionItems(
@@ -82,7 +82,7 @@ export class UserCompletionProvider implements vscode.CompletionItemProvider {
 		return completionItems;
 	}
 
-	async resolveCompletionItem(item: UserCompletion, token: vscode.CancellationToken): Promise<vscode.CompletionItem> {
+	async resolveCompletionItem(item: UserCompletion, _token: vscode.CancellationToken): Promise<vscode.CompletionItem> {
 		const folderManager = this.manager.getManagerForFile(item.uri);
 		if (!folderManager) {
 			return item;

--- a/src/issues/userHoverProvider.ts
+++ b/src/issues/userHoverProvider.ts
@@ -14,7 +14,7 @@ export class UserHoverProvider implements vscode.HoverProvider {
 	async provideHover(
 		document: vscode.TextDocument,
 		position: vscode.Position,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.Hover | undefined> {
 		if (!(await shouldShowHover(document, position))) {
 			return;

--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -273,7 +273,7 @@ export async function issueMarkdown(
 		})
 		.trim();
 	markdown.appendMarkdown(
-		`${getIconMarkdown(issue, context)} **${title}** [#${issue.number}](${issue.html_url})  \n`,
+		`${getIconMarkdown(issue)} **${title}** [#${issue.number}](${issue.html_url})  \n`,
 	);
 	let body = marked.parse(issue.body, {
 		renderer: new PlainTextRenderer(),
@@ -332,7 +332,7 @@ function getIconString(issue: IssueModel) {
 	}
 }
 
-function getIconMarkdown(issue: IssueModel, context: vscode.ExtensionContext) {
+function getIconMarkdown(issue: IssueModel) {
 	if (issue instanceof PullRequestModel) {
 		return getIconString(issue);
 	}

--- a/src/view/compareChangesTreeDataProvider.ts
+++ b/src/view/compareChangesTreeDataProvider.ts
@@ -160,7 +160,7 @@ export class CompareChangesTreeProvider implements vscode.TreeDataProvider<TreeN
 class GitHubContentProvider {
 	constructor(public gitHubRepository: GitHubRepository) {}
 
-	async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
+	async provideTextDocumentContent(uri: vscode.Uri, _token: vscode.CancellationToken): Promise<string> {
 		const params = fromGitHubURI(uri);
 		if (!params || params.isEmpty) {
 			return '';

--- a/src/view/fileTypeDecorationProvider.ts
+++ b/src/view/fileTypeDecorationProvider.ts
@@ -17,7 +17,7 @@ export class FileTypeDecorationProvider implements vscode.FileDecorationProvider
 
 	provideFileDecoration(
 		uri: vscode.Uri,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): vscode.ProviderResult<vscode.FileDecoration> {
 		const fileChangeUriParams = fromFileChangeNodeUri(uri);
 		if (fileChangeUriParams && fileChangeUriParams.status !== undefined) {

--- a/src/view/gitContentProvider.ts
+++ b/src/view/gitContentProvider.ts
@@ -20,7 +20,7 @@ export class GitContentProvider implements vscode.TextDocumentContentProvider {
 
 	constructor(private gitAPI: GitApiImpl) {}
 
-	async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
+	async provideTextDocumentContent(uri: vscode.Uri, _token: vscode.CancellationToken): Promise<string> {
 		if (!this._fallback) {
 			return '';
 		}

--- a/src/view/inMemPRContentProvider.ts
+++ b/src/view/inMemPRContentProvider.ts
@@ -21,7 +21,7 @@ export class InMemPRContentProvider implements vscode.TextDocumentContentProvide
 
 	constructor() {}
 
-	async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
+	async provideTextDocumentContent(uri: vscode.Uri, _token: vscode.CancellationToken): Promise<string> {
 		const prUriParams = fromPRUri(uri);
 		if (prUriParams && prUriParams.prNumber) {
 			const provider = this._prFileChangeContentProviders[prUriParams.prNumber];

--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -366,7 +366,7 @@ export class ReviewCommentController
 
 	async provideCommentingRanges(
 		document: vscode.TextDocument,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.Range[] | undefined> {
 		let query: ReviewUriParams | undefined;
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -97,7 +97,7 @@ export class ReviewManager {
 
 	private registerListeners(): void {
 		this._disposables.push(
-			this._repository.state.onDidChange(e => {
+			this._repository.state.onDidChange(_ => {
 				const oldHead = this._previousRepositoryState.HEAD;
 				const newHead = this._repository.state.HEAD;
 

--- a/src/view/treeDecorationProvider.ts
+++ b/src/view/treeDecorationProvider.ts
@@ -24,7 +24,7 @@ class TreeDecorationProvider implements vscode.FileDecorationProvider {
 	onDidChangeFileDecorations: vscode.Event<vscode.Uri | vscode.Uri[]> = this._onDidChangeFileDecorations.event;
 	provideFileDecoration(
 		uri: vscode.Uri,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): vscode.ProviderResult<vscode.FileDecoration> {
 		const query = fromFileChangeNodeUri(uri);
 		if (query) {

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -15,14 +15,11 @@ import Logger from '../../common/logger';
 import { fromPRUri, toPRUri } from '../../common/uri';
 import { groupBy } from '../../common/utils';
 import { FolderRepositoryManager } from '../../github/folderRepositoryManager';
-import { ReactionGroup } from '../../github/graphql';
 import { GHPRComment, GHPRCommentThread, TemporaryComment } from '../../github/prComment';
 import { PullRequestModel, ReviewThreadChangeEvent } from '../../github/pullRequestModel';
 import {
 	CommentReactionHandler,
 	createVSCodeCommentThreadForReviewThread,
-	parseGraphQLReaction,
-	updateCommentReactions,
 	updateCommentReviewState,
 	updateCommentThreadLabel,
 } from '../../github/utils';
@@ -529,7 +526,7 @@ export class PRNode extends TreeNode implements CommentHandler, vscode.Commentin
 
 	async provideCommentingRanges(
 		document: vscode.TextDocument,
-		token: vscode.CancellationToken,
+		_token: vscode.CancellationToken,
 	): Promise<vscode.Range[] | undefined> {
 		if (document.uri.scheme === 'pr') {
 			const params = fromPRUri(document.uri);


### PR DESCRIPTION
Many warnings were about the unused "token" param in vscode api usages, almost all of my fixes are to just prefix with _ to ignore