### PR TITLE
Use review threads when fetching timeline events

### DIFF
--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -841,7 +841,8 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 		}
 
 		const reviewEvents = events.filter(isReviewEvent);
-		const reviewComments = (await this.getReviewComments()) as CommentNode[];
+		const reviewThreads = await this.getReviewThreads();
+		const reviewComments = reviewThreads.reduce((previous, current) => previous.concat(current.comments), []);
 
 		const reviewEventsById = reviewEvents.reduce((index, evt) => {
 			index[evt.id] = evt;


### PR DESCRIPTION
Fixes the first part of #2478, when the overview page is opened the review thread cache should be refreshed for everything