### PR TITLE
Remove reading of package.json and product.json for setting up experimentation service

### DIFF
--- a/src/experimentationService.ts
+++ b/src/experimentationService.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import {
@@ -18,26 +17,6 @@ import {
 		"ABExp.queriedFeature": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	}
 */
-
-interface ProductConfiguration {
-	quality?: 'stable' | 'insider' | 'exploration';
-}
-
-async function getProductConfig(appRoot: string): Promise<ProductConfiguration> {
-	const raw = await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(appRoot, 'product.json')));
-	return JSON.parse(raw.toString());
-}
-
-interface PackageConfiguration {
-	name: string;
-	publisher: string;
-	version: string;
-}
-
-async function getPackageConfig(packageFolder: string): Promise<PackageConfiguration> {
-	const raw = await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(packageFolder, 'package.json')));
-	return JSON.parse(raw.toString());
-}
 
 export class ExperimentationTelemetry implements IExperimentationTelemetry {
 	private sharedProperties: Record<string, string> = {};
@@ -83,15 +62,15 @@ export class ExperimentationTelemetry implements IExperimentationTelemetry {
 	}
 }
 
-function getTargetPopulation(product: ProductConfiguration): TargetPopulation {
-	switch (product.quality) {
-		case 'stable':
+function getTargetPopulation(): TargetPopulation {
+	switch (vscode.env.uriScheme) {
+		case 'vscode':
 			return TargetPopulation.Public;
-		case 'insider':
+		case 'vscode-insiders':
 			return TargetPopulation.Insiders;
-		case 'exploration':
+		case 'vscode-exploration':
 			return TargetPopulation.Internal;
-		case undefined:
+		case 'code-oss':
 			return TargetPopulation.Team;
 		default:
 			return TargetPopulation.Public;
@@ -129,15 +108,16 @@ export async function createExperimentationService(
 	context: vscode.ExtensionContext,
 	experimentationTelemetry: ExperimentationTelemetry,
 ): Promise<IExperimentationService> {
-	const pkg = await getPackageConfig(context.extensionPath);
-	const product = await getProductConfig(vscode.env.appRoot);
-	const targetPopulation = getTargetPopulation(product);
+	const id = context.extension.id;
+	const name = context.extension.packageJSON['name'];
+	const version = context.extension.packageJSON['version'];
+	const targetPopulation = getTargetPopulation();
 
 	// We only create a real experimentation service for the stable version of the extension, not insiders.
-	return pkg.name === 'vscode-pull-request-github'
+	return name === 'vscode-pull-request-github'
 		? getExperimentationService(
-				`${pkg.publisher}.${pkg.name}`,
-				pkg.version,
+				id,
+				version,
 				targetPopulation,
 				experimentationTelemetry,
 				context.globalState,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,13 +184,14 @@ async function init(
 
 	await vscode.commands.executeCommand('setContext', 'github:initialized', true);
 
+	const experimentationService = await createExperimentationService(context, telemetry);
+	await experimentationService.initializePromise;
+	experimentationService.isCachedFlightEnabled('githubaa');
+
 	/* __GDPR__
 		"startup" : {}
 	*/
 	telemetry.sendTelemetryEvent('startup');
-
-	const experimentationService = await createExperimentationService(context, telemetry);
-	experimentationService.isCachedFlightEnabled('githubaa');
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<GitApiImpl> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -186,7 +186,7 @@ async function init(
 
 	const experimentationService = await createExperimentationService(context, telemetry);
 	await experimentationService.initializePromise;
-	experimentationService.isCachedFlightEnabled('githubaa');
+	await experimentationService.isCachedFlightEnabled('githubaa');
 
 	/* __GDPR__
 		"startup" : {}


### PR DESCRIPTION
Use vscode apis instead of reading these files.