### PR TITLE
Add `vscode.git` as extension dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1495,5 +1495,8 @@
 		"vscode-tas-client": "^0.1.17",
 		"vsls": "^0.3.967"
 	},
+	"extensionDependencies": [
+		"vscode.git"
+	],
 	"license": "MIT"
 }


### PR DESCRIPTION
This PR adds `vscode.git` as `extensionDependency` to `package.json` as defined in the [Extension Manifest Docs](https://code.visualstudio.com/api/references/extension-manifest). 

Fixes #2572 
