### PR TITLE
Pull selected branch only when checking out PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"version": "0.26.0",
 	"publisher": "GitHub",
 	"engines": {
-		"vscode": "^1.55.0"
+		"vscode": "^1.57.0"
 	},
 	"categories": [
 		"Other"

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -122,6 +122,12 @@ export interface FetchOptions {
 	depth?: number;
 }
 
+export interface PullOptions {
+	remote?: string;
+	ref?: string;
+	unshallow?: boolean;
+}
+
 export interface BranchQuery {
 	readonly remote?: boolean;
 	readonly pattern?: string;
@@ -212,6 +218,7 @@ export interface Repository {
 
 	fetch(options?: FetchOptions): Promise<void>;
 	fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
+	pull(options?: PullOptions): Promise<void>;
 	pull(unshallow?: boolean): Promise<void>;
 	push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
 

--- a/src/test/github/pullRequestGitHelper.test.ts
+++ b/src/test/github/pullRequestGitHelper.test.ts
@@ -56,7 +56,7 @@ describe('PullRequestGitHelper', function () {
 			);
 
 			repository.expectFetch('you', 'my-branch:pr/me/100', 1);
-			repository.expectPull(true);
+			repository.expectPull('you', 'my-branch:pr/me/100', true);
 
 			const pullRequest = new PullRequestModel(telemetry, gitHubRepository, remote, prItem);
 


### PR DESCRIPTION
Change pull behavior during unshallowing step to only pull and unshallow selected branch.
This PR requires an update to the VS Code Git extension API: https://github.com/microsoft/vscode/pull/123954

Fixes #2030