### PR TITLE
Fix upstream ref reviewManager

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -197,7 +197,13 @@ export class ReviewManager {
 		if (branch) {
 			const remote = branch.upstream ? branch.upstream.remote : null;
 			if (remote) {
-				await this._repository.fetch(remote, this._repository.state.HEAD?.name);
+				const configs = await this._repository.getConfigs();
+
+				const readConfig = (searchKey: string): string | undefined =>
+					configs.filter(({ key: k }) => searchKey === k).map(({ value }) => value)[0];
+
+				const ref = readConfig(`branch.${this._repository.state.HEAD?.name}.merge`);
+				await this._repository.fetch(remote, ref);
 				if (
 					(pr.head.sha !== this._lastCommitSha || (branch.behind !== undefined && branch.behind > 0)) &&
 					!this._updateMessageShown


### PR DESCRIPTION
The `reviewManager` used the branch name to check for updates with `git fetch`. This didn't work, since the extension renames the local copy of the branch to `pr/<remote>/<branch>`.

To fix it, I copied part of the code from `pullRequestGitHelper -> checkoutExistingPullRequestBranch` to get the remote branch name from the repository configs.

https://github.com/microsoft/vscode-pull-request-github/blob/9346269d520d0ecc6fdcf4fd7369ca7eb5f354e1/src/github/pullRequestGitHelper.ts#L150