### PR TITLE
Fix remotes discovery when using ssh.github.com

### DIFF
--- a/src/authentication/configuration.ts
+++ b/src/authentication/configuration.ts
@@ -27,7 +27,7 @@ export const HostHelper = class {
 		}
 
 		const hostUri: vscode.Uri = host instanceof vscode.Uri ? host : vscode.Uri.parse(host.host);
-		if (hostUri.authority === 'github.com') {
+		if (hostUri.authority === 'github.com' || hostUri.authority === 'ssh.github.com') {
 			return vscode.Uri.parse('https://api.github.com');
 		} else {
 			return vscode.Uri.parse(`${hostUri.scheme}://${hostUri.authority}`);
@@ -36,7 +36,7 @@ export const HostHelper = class {
 
 	public static getApiPath(host: IHostConfiguration | vscode.Uri, path: string): string {
 		const hostUri: vscode.Uri = host instanceof vscode.Uri ? host : vscode.Uri.parse(host.host);
-		if (hostUri.authority === 'github.com') {
+		if (hostUri.authority === 'github.com' || hostUri.authority === 'ssh.github.com') {
 			return path;
 		} else {
 			return `/api/v3${path}`;

--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -17,8 +17,9 @@ export class GitHubManager {
 			return false;
 		}
 
-		if (this._servers.has(host.authority)) {
-			return !!this._servers.get(host.authority);
+		let authority = host.authority === 'ssh.github.com' ? 'github.com' : host.authority;
+		if (this._servers.has(authority)) {
+			return !!this._servers.get(authority);
 		}
 
 		const [uri, options] = await GitHubManager.getOptions(host, 'HEAD', '/rate_limit');


### PR DESCRIPTION
Fixes #1656
As explained [here](https://github.com/microsoft/vscode-pull-request-github/issues/1656#issuecomment-845246423), when ssh.github.com is used, the module assume this hostname is a GitHubServer instead of GItHub and because of that the module build a wrong URI to query the API.
I'm not a nodejs developer but I hope this change could inspire a better implementation or a maintainer who understand the architecture.