### PR TITLE
Removed TSLint recommendation and mentions left

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
 	"recommendations": [
-		"ms-vscode.vscode-typescript-tslint-plugin",
+		"dbaeumer.vscode-eslint",
 		"eamodio.tsl-problem-matcher",
 		"esbenp.prettier-vscode"
 	]

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,7 +21,6 @@ webviews/**
 azure-pipeline.*
 **/tsconfig*.json
 *.tsbuildinfo
-tslint.json
 **/webpack.config*.js
 yarn.lock
 **/*.map
@@ -31,4 +30,3 @@ yarn.lock
 **/*.bak
 package.insiders.json
 README.insiders.md
-

--- a/src/test/mocks/mockCommandRegistry.ts
+++ b/src/test/mocks/mockCommandRegistry.ts
@@ -33,7 +33,6 @@ export class MockCommandRegistry {
 	private _commands: { [commandName: string]: (args: any[]) => any } = {};
 
 	static install(sinon: SinonSandbox) {
-		// tslint:disable-next-line: no-unused-expression
 		new this(sinon);
 	}
 


### PR DESCRIPTION
Fixes #2757

@eamodio did amzaing job in migrating TSLint to ESLint in #2518 and I was a bit suprised when on another PC I've got recommndation to install TSLint extension for this repo.

This PR changes recommended extension from TSLint to ESLint.
Also removes last mentions on TSLint:
1. one ignore comment (neither `@typescript-eslint/no-unused-expressions` nor `@typescript-eslint/no-unused-expressions` handle  construstions with `new`)
2. `tslint.json` is no longer in repo

Please let me know if last commit should be removed from PR

P.S. Is it intentional that lint checks are not included in PR builds?