### PR TITLE
Fix broken pull request files pagination

### DIFF
--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -372,10 +372,10 @@ query PullRequest($owner: String!, $name: String!, $number: Int!) {
 	}
 }
 
-query PullRequestFiles($owner: String!, $name: String!, $number: Int!) {
+query PullRequestFiles($owner: String!, $name: String!, $number: Int!, $after: String) {
 	repository(owner: $owner, name: $name) {
 		pullRequest(number: $number) {
-			files(first: 100) {
+			files(first: 100, after: $after) {
 				nodes {
 					path
 					viewerViewedState


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pull-request-github/issues/2741.

Pagination was broken causing infinite loop of paging requests for PRs with more than 100 files.