### PR TITLE
Fix check fork details

### DIFF
--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -1778,7 +1778,7 @@ export class FolderRepositoryManager implements vscode.Disposable {
 			if (
 				forkDetails &&
 				forkDetails.isFork &&
-				forkDetails.parent.owner === item.remote.owner &&
+				forkDetails.parent.owner.login === item.remote.owner &&
 				forkDetails.parent.name === item.remote.repositoryName
 			) {
 				const foundforkPermission = await githubRepo.getViewerPermission();

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -74,7 +74,9 @@ export enum ViewerPermission {
 export interface ForkDetails {
 	isFork: boolean;
 	parent: {
-		owner: string;
+		owner: {
+			login: string;
+		};
 		name: string;
 	};
 }
@@ -551,19 +553,19 @@ export class GitHubRepository implements vscode.Disposable {
 
 	async getRepositoryForkDetails(): Promise<ForkDetails | undefined> {
 		try {
-			Logger.debug(`Fetch viewer permission - enter`, GitHubRepository.ID);
+			Logger.debug(`Fetch repository fork details - enter`, GitHubRepository.ID);
 			const { query, remote, schema } = await this.ensure();
 			const { data } = await query<ForkDetailsResponse>({
-				query: schema.GetViewerPermission,
+				query: schema.GetRepositoryForkDetails,
 				variables: {
 					owner: remote.owner,
 					name: remote.repositoryName,
 				},
 			});
-			Logger.debug(`Fetch viewer permission - done`, GitHubRepository.ID);
+			Logger.debug(`Fetch repository fork details - done`, GitHubRepository.ID);
 			return data.repository;
 		} catch (e) {
-			Logger.appendLine(`GithubRepository> Unable to fetch viewer permission: ${e}`);
+			Logger.appendLine(`GithubRepository> Unable to fetch repository fork details: ${e}`);
 			return;
 		}
 	}

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -904,7 +904,9 @@ query GetRepositoryForkDetails($owner: String!, $name: String!) {
 		isFork
 		parent {
 			name
-			owner
+			owner {
+				login
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2805

Due to an error in checking the details of the fork, the prompt for the fork appears repeatedly.