### PR TITLE
When using a branch name as a PR title, ensure the first letter is capitalised

### DIFF
--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -136,8 +136,8 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 		}
 
 		if (useBranchName) {
-			const name  = this.compareBranch?.name;
-			return name != null
+			const name = this.compareBranch?.name;
+			return name
 				? `${name.charAt(0).toUpperCase()}${name.slice(1)}`
 				: '';
 		} else {

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -136,7 +136,10 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 		}
 
 		if (useBranchName) {
-			return this.compareBranch?.name ?? '';
+			const name  = this.compareBranch?.name;
+			return name != null
+				? `${name.charAt(0).toUpperCase()}${name.slice(1)}`
+				: '';
 		} else {
 			return this.compareBranch?.name
 				? titleAndBodyFrom(await this._folderRepositoryManager.getTipCommitMessage(this.compareBranch.name))


### PR DESCRIPTION
Fixes #2847