### PR TITLE
Create commit select horizontal padding is too high

### DIFF
--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -70,7 +70,7 @@ input[type='text']::placeholder {
 select {
 	display: block;
 	box-sizing: border-box;
-	padding: 4px 12px;
+	padding: 4px 8px;
 	border-radius: 0;
 	font-size: 13px;
 	border: 1px solid var(--vscode-dropdown-border);


### PR DESCRIPTION
Fixes #2958

The current select inherits from the global select style. I'm thinking if we change it here, we change it everywhere to stay consistent.