### PR TITLE
fix: make pending checks "show" button / link accessible

### DIFF
--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -52,7 +52,7 @@ const StatusChecks = ({ pr }: { pr: PullRequest }) => {
 				<div className="status-item">
 					<StateIcon state={status.state} />
 					<div>{getSummaryLabel(status.statuses)}</div>
-					<a aria-role="button" onClick={toggleDetails}>
+					<a href="javascript:void(0)" aria-role="button" onClick={toggleDetails}>
 						{showDetails ? 'Hide' : 'Show'}
 					</a>
 				</div>


### PR DESCRIPTION
Fix #2973

[More info](https://accessibility.oit.ncsu.edu/it-accessibility-at-nc-state/developers/accessibility-handbook/mouse-and-keyboard-events/links/link-behavior/#:~:text=Do%20not%20use%20an%20anchor%20with%20an%20onclick%20event%20without%20an%20href%20element%20event)

A note: It would be better to use `button` element here and style it as link but this is a quick fix.