### PR TITLE
GitHub permalinks: Deduplicate the line number if the range is one line.

### DIFF
--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -497,7 +497,7 @@ export async function createGithubPermalink(
 			return '';
 		}
 		let hash = `#L${range.start.line + 1}`;
-		if (range.start.line === range.end.line) {
+		if (range.start.line !== range.end.line) {
 			hash += `-L${range.end.line + 1}`;
 		}
 		return hash;

--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -492,10 +492,19 @@ export async function createGithubPermalink(
 		}
 	}
 	const pathSegment = uri.path.substring(repository.rootUri.path.length);
-	const rangeString = range ? `#L${range.start.line + 1}-L${range.end.line + 1}` : '';
+	const rangeString = () => {
+		if (!range) {
+			return '';
+		}
+		let hash = `#L${range.start.line + 1}`;
+		if (range.start.line === range.end.line) {
+			hash += `-L${range.end.line + 1}`;
+		}
+		return hash;
+	};
 	return {
 		permalink: `https://github.com/${new Protocol(upstream.fetchUrl).nameWithOwner}/blob/${commitHash
-			}${pathSegment}${rangeString}`,
+			}${pathSegment}${rangeString()}`,
 		error: undefined,
 		originalFile: uri
 	};


### PR DESCRIPTION
This will generate URLs like:

`https://github.com/microsoft/vscode-pull-request-github/blob/39d333d9931d685d01078e27c4e6583eda55fc27/src/issues/util.ts#L495`

... instead of:

`https://github.com/microsoft/vscode-pull-request-github/blob/39d333d9931d685d01078e27c4e6583eda55fc27/src/issues/util.ts#L495-L495`
