### PR TITLE
PR created x minutes ago is cut off in small tabs

### DIFF
--- a/webviews/components/header.tsx
+++ b/webviews/components/header.tsx
@@ -35,12 +35,9 @@ export function Header({
 				{!isIssue ? <Avatar for={author} /> : null}
 				<span className="author">
 					{!isIssue ? (
-						<Spaced>
-							<AuthorLink for={author} />
-							{getActionText(state)}
-							into<code>{base}</code>
-							from<code>{head}</code>
-						</Spaced>
+						<div>
+							<AuthorLink for={author} /> {getActionText(state)} into <code> {base} </code> from <code> {head} </code>
+						</div>
 					) : null}
 				</span>
 				<span className="created-at">


### PR DESCRIPTION
Fixes #2952

The "Spaced" element is putting forced line breaks in the output which results in an overflow on the div. Removing in favor of a more semantic solution with spacing inline with the output.