### PR TITLE
Do not activate review mode for closed or merged PR

### DIFF
--- a/src/github/issueModel.ts
+++ b/src/github/issueModel.ts
@@ -52,6 +52,10 @@ export class IssueModel<TItem extends Issue = Issue> {
 		return this.state === GithubItemStateEnum.Open;
 	}
 
+	public get isClosed(): boolean {
+		return this.state === GithubItemStateEnum.Closed;
+	}
+
 	public get userAvatar(): string | undefined {
 		if (this.item) {
 			return this.item.user.avatarUrl;

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -314,9 +314,9 @@ export class ReviewManager {
 			return;
 		}
 
-		if(!pr.isOpen){
+		if(pr.isClosed){
 			this.clear(true);
-			Logger.appendLine('Review> This PR is no longer open');
+			Logger.appendLine('Review> This PR is closed');
 			return;
 		}
 

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -314,6 +314,12 @@ export class ReviewManager {
 			return;
 		}
 
+		if(!pr.isOpen){
+			this.clear(true);
+			Logger.appendLine('Review> This PR is no longer open');
+			return;
+		}
+
 		this._folderRepoManager.activePullRequest = pr;
 		this._lastCommitSha = pr.head.sha;
 


### PR DESCRIPTION
Fixes #3009 

Initially I tried to use line 312 `this._prNumber = undefined;` to disable review mode from previously branch, however with `this.clear(true);` all seems to work fine. 

Probably that line should also be changed, but I'm not sure how to make pr "notResolved".


I tested manually those scenarios:
1. Checkout branch with active PR (review activated) => checkout branch with merged PR (review NOT activated)
1. Checkout branch with merged PR (review NOT activated) => checkout branch with merged PR (review NOT activated)
1. Checkout branch with active PR (review activated) => checkout other branch with active PR (review activated for other PR)
1. Open repository whose current branch is active  with VSCode (review activated) 
1. Open repository whose current branch is closed with VSCode (review NOT activated) 