### PR TITLE
Fix README GIF links for VS Code marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This extension allows you to review and manage GitHub pull requests and issues i
 - A "Start working on issue" action which can create a branch for you.
 - Code actions to create issues from "todo" comments.
 
-![PR Demo](.readme/demo.gif)
+![PR Demo](https://raw.githubusercontent.com/microsoft/vscode-pull-request-github/main/.readme/demo.gif)
 
-![Issue Demo](.readme/issueDemo.gif)
+![Issue Demo](https://raw.githubusercontent.com/microsoft/vscode-pull-request-github/main/.readme/issueDemo.gif)
 
 # Getting Started
 


### PR DESCRIPTION
Currently in the marketplace the PR demo and issue demo GIFs don't render for me. 

![image](https://user-images.githubusercontent.com/30305945/138374524-949c2fac-1a5c-4255-abbe-247737143c89.png)

I think this is because they are relative links--providing the link to the raw github content should fix them.

