### PR TITLE
Fix generated branch name requiring quotes in bash

### DIFF
--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -511,7 +511,7 @@ export async function createGithubPermalink(
 }
 
 export function sanitizeIssueTitle(title: string): string {
-	const regex = /[~^:;'".,~#?%*[\]@\\{}]|\/\//g;
+	const regex = /[~^:;'".,~#?%*[\]@\\{}()]|\/\//g;
 
 	return title.replace(regex, '').trim().replace(/\s+/g, '-');
 }


### PR DESCRIPTION
If an issue name contains parenthesis characters, they are currently
added to the generated branch name, causing bash to complain about the
name if it is not quoted.

I.e. `git checkout test/some(other)branch`
bash: syntax error near unexpected token `('

Stripping the parenthesis characters from the branch name fixes this.
