### PR TITLE
Fix react warnings in timeline

### DIFF
--- a/src/common/timelineEvent.ts
+++ b/src/common/timelineEvent.ts
@@ -52,7 +52,7 @@ export interface ReviewEvent {
 }
 
 export interface CommitEvent {
-	id: number;
+	id: string;
 	author: IAccount;
 	event: EventType;
 	sha: string;

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -108,7 +108,6 @@ export interface ReviewComment {
 export interface Commit {
 	__typename: string;
 	id: string;
-	databaseId: number;
 	commit: {
 		author: {
 			user: {

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -690,7 +690,7 @@ export function parseGraphQLTimelineEvents(
 			case Common.EventType.Committed:
 				const commitEv = event as GraphQL.Commit;
 				normalizedEvents.push({
-					id: commitEv.databaseId,
+					id: commitEv.id,
 					event: type,
 					sha: commitEv.commit.oid,
 					author: commitEv.commit.author.user


### PR DESCRIPTION
Previously, there's a warning "Each child in a list should have
a unique key prop" in `Timeline.render`, because there's no `databaseId`
field in `CommitEvent`. In this case, we use `CommitEvent.id` instead.

<img width="689" alt="Xnip2021-12-29_07-32-28" src="https://user-images.githubusercontent.com/12689835/147617198-0c30bd2d-7a7d-4453-b183-72e2a648ea9a.png">

<img width="1064" alt="Xnip2021-12-29_07-52-05" src="https://user-images.githubusercontent.com/12689835/147617192-3de23041-c84a-4c60-b16c-22c7dc62e16e.png">
