### PR TITLE
Fix more React warnings of incorrect `props.key`

### DIFF
--- a/src/common/timelineEvent.ts
+++ b/src/common/timelineEvent.ts
@@ -63,7 +63,7 @@ export interface CommitEvent {
 }
 
 export interface MergedEvent {
-	id: number;
+	id: string;
 	graphNodeId: string;
 	user: IAccount;
 	createdAt: string;

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -9,7 +9,6 @@ import { ForkDetails } from './githubRepository';
 export interface MergedEvent {
 	__typename: string;
 	id: string;
-	databaseId: number;
 	actor: {
 		login: string;
 		avatarUrl: string;

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -705,7 +705,7 @@ export function parseGraphQLTimelineEvents(
 				const mergeEv = event as GraphQL.MergedEvent;
 
 				normalizedEvents.push({
-					id: mergeEv.databaseId,
+					id: mergeEv.id,
 					event: type,
 					user: parseAuthor(mergeEv.actor, githubRepository),
 					createdAt: mergeEv.createdAt,

--- a/webviews/components/diff.tsx
+++ b/webviews/components/diff.tsx
@@ -10,8 +10,8 @@ import { DiffChangeType, DiffHunk, DiffLine } from '../../src/common/diffHunk';
 function Diff({ hunks }: { hunks: DiffHunk[] }) {
 	return (
 		<div className="diff">
-			{hunks.map(hunk => (
-				<Hunk hunk={hunk} />
+			{hunks.map((hunk, index) => (
+				<Hunk key={index} hunk={hunk} />
 			))}
 		</div>
 	);

--- a/webviews/components/timeline.tsx
+++ b/webviews/components/timeline.tsx
@@ -132,12 +132,12 @@ const ReviewEventView = (event: ReviewEvent) => {
 	);
 };
 
-function CommentThread({ key, thread, eventId }: { key: string; thread: IComment[]; eventId: number }) {
+function CommentThread({ thread, eventId }: { thread: IComment[]; eventId: number }) {
 	const comment = thread[0];
 	const [revealed, setRevealed] = useState(!comment.isResolved);
 	const { openDiff } = useContext(PullRequestContext);
 	return (
-		<div key={key} className="diff-container">
+		<div key={eventId} className="diff-container">
 			<div className="resolved-container">
 				<div>
 					{comment.position === null ? (
@@ -161,7 +161,7 @@ function CommentThread({ key, thread, eventId }: { key: string; thread: IComment
 				<div>
 					<Diff hunks={comment.diffHunks} />
 					{thread.map(c => (
-						<CommentView {...c} pullRequestReviewId={eventId} />
+						<CommentView key={c.id} {...c} pullRequestReviewId={eventId} />
 					))}
 				</div>
 			) : null}


### PR DESCRIPTION
There are some warnings in `CommentThread` because of misuse of
`props.key`: `CommentThread`/`Diff` had no `key` prop, and
`CommentThread` incorrectly forwareded `key` prop to child component.

<img width="1877" alt="Xnip2021-12-30_13-18-55" src="https://user-images.githubusercontent.com/12689835/147724631-5fe0d80a-e5f3-4d83-88b2-5cd786a11d0e.png">



------

Update: found another missing `key prop` in `MergedEvent`:

![image](https://user-images.githubusercontent.com/12689835/147728230-8798470a-1cba-4b6d-8232-31c44ed9e229.png)

<img width="1050" alt="Xnip2021-12-30_14-41-10" src="https://user-images.githubusercontent.com/12689835/147728148-ee9c8ef6-00ed-4885-b55d-bc3ae254ba54.png">


