### PR TITLE
Update high contrast styles for buttons and inputs

### DIFF
--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -122,7 +122,7 @@ body img.avatar {
 }
 
 .avatar-link {
-	flex-shrink: 0;;
+	flex-shrink: 0;
 }
 
 .section-item .avatar-link {
@@ -164,10 +164,15 @@ body img.avatar {
 
 /** Theming */
 
-.vscode-high-contrast button,
+.vscode-high-contrast button {
+	outline: none;
+	background: var(--vscode-button-background);
+	border: 1px solid var(--vscode-contrastBorder);
+}
+
 .vscode-high-contrast input {
 	outline: none;
-	background: none !important;
+	background: var(--vscode-input.background);
 	border: 1px solid var(--vscode-contrastBorder);
 }
 

--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -172,7 +172,7 @@ body img.avatar {
 
 .vscode-high-contrast input {
 	outline: none;
-	background: var(--vscode-input.background);
+	background: var(--vscode-input-background);
 	border: 1px solid var(--vscode-contrastBorder);
 }
 


### PR DESCRIPTION
Fixes #3342

Updates button and input rules of high contrast themes to include the correct background colors for buttons and inputs. 

<img width="211" alt="CleanShot 2022-02-23 at 14 47 20@2x" src="https://user-images.githubusercontent.com/25163139/155423797-42d56c2f-7382-47f3-a84a-4cfbd3ba51aa.png">

<img width="459" alt="CleanShot 2022-02-23 at 14 47 26@2x" src="https://user-images.githubusercontent.com/25163139/155423813-9f2de51f-eb62-4718-b131-62b77bf22aa6.png">

<img width="330" alt="CleanShot 2022-02-23 at 14 49 55@2x" src="https://user-images.githubusercontent.com/25163139/155423844-cc4fb83b-709d-4a4a-bc70-0c10a02e6cf3.png">

No visible difference to the original dark HC theme:

<img width="203" alt="CleanShot 2022-02-23 at 14 47 36@2x" src="https://user-images.githubusercontent.com/25163139/155424108-386159b4-64f1-45c1-9ac3-15a4d60103c9.png">

<img width="453" alt="CleanShot 2022-02-23 at 14 47 38@2x" src="https://user-images.githubusercontent.com/25163139/155424111-3705b30f-9e56-43dd-9523-bbcad89228bc.png">

<img width="329" alt="CleanShot 2022-02-23 at 14 50 01@2x" src="https://user-images.githubusercontent.com/25163139/155424168-b5d5258b-f7a6-489e-b9dd-8e01e99fa90e.png">







