### PR TITLE
Support creating `insiders.vscode.dev` permalinks

### DIFF
--- a/src/issues/issueFeatureRegistrar.ts
+++ b/src/issues/issueFeatureRegistrar.ts
@@ -1119,7 +1119,7 @@ ${body ?? ''}\n
 			// asExternalUri can throw when in the browser and the embedder doesn't set a uri resolver.
 			return link;
 		}
-		const authority = (uri.scheme === 'https' && /^(vscode|github)\./.test(uri.authority)) ? uri.authority : undefined;
+		const authority = (uri.scheme === 'https' && /^(insiders\.vscode|vscode|github)\./.test(uri.authority)) ? uri.authority : undefined;
 		if (!authority) {
 			return link;
 		}


### PR DESCRIPTION
Currently on insiders.vscode.dev, Copy GitHub Permalink generates a github.com URL. On vscode.dev it generates vscode.dev URLs, and on github.dev it generates github.dev URLs.