### PR TITLE
Support the copied permalink for Github Enterprise URL

### DIFF
--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -518,20 +518,21 @@ export async function createGithubPermalink(
 }
 
 function getUpstreamOrigin(upstream: Remote) {
+	let resultHost: string = 'github.com';
 	const enterpriseUri = getEnterpriseUri();
 	if (enterpriseUri && upstream.fetchUrl) {
 		// upstream's origin by https
 		if (upstream.fetchUrl.startsWith('https://') && !upstream.fetchUrl.startsWith('https://github.com/')) {
-			const origin = new URL(upstream.fetchUrl).origin;
-			if (origin === enterpriseUri.authority) return origin;
+			const host = new URL(upstream.fetchUrl).host;
+			if (host === enterpriseUri.authority) resultHost = host;
 		}
 		// upstream's origin by ssh
 		if (upstream.fetchUrl.startsWith('git@') && !upstream.fetchUrl.startsWith('git@github.com')) {
 			const host = upstream.fetchUrl.split('@')[1]?.split(':')[0];
-			if (host === enterpriseUri.authority) return `https://${host}`;
+			if (host === enterpriseUri.authority) resultHost = host;
 		}
 	}
-	return 'https://github.com/';
+	return `https://${resultHost}`;
 }
 
 function rangeString(range: vscode.Range | undefined) {

--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { URLSearchParams } from 'url';
+import { URL, URLSearchParams } from 'url';
 import LRUCache from 'lru-cache';
 import * as marked from 'marked';
 import * as vscode from 'vscode';
@@ -524,12 +524,16 @@ function getUpstreamOrigin(upstream: Remote) {
 		// upstream's origin by https
 		if (upstream.fetchUrl.startsWith('https://') && !upstream.fetchUrl.startsWith('https://github.com/')) {
 			const host = new URL(upstream.fetchUrl).host;
-			if (host === enterpriseUri.authority) resultHost = host;
+			if (host === enterpriseUri.authority) {
+				resultHost = host;
+			}
 		}
 		// upstream's origin by ssh
 		if (upstream.fetchUrl.startsWith('git@') && !upstream.fetchUrl.startsWith('git@github.com')) {
 			const host = upstream.fetchUrl.split('@')[1]?.split(':')[0];
-			if (host === enterpriseUri.authority) resultHost = host;
+			if (host === enterpriseUri.authority) {
+				resultHost = host;
+			}
 		}
 	}
 	return `https://${resultHost}`;


### PR DESCRIPTION
This PR is with respect to issue #3324

## About Copying a Permalink:
- The problem is `copyGithubPermalink` is always copying as a permalink based on `github.com`
- If the remote upstream's fetch url is not based on "github.com", the copied permalink should be started upstream's url origin.
- It helps using Github Enterprise Server.

## Applied Conditions
- You have to fill the Github Enterprise URI on VSCode config.(The attribute's name is `github-enterprise.uri`)
    - <img width="483" alt="image" src="https://user-images.githubusercontent.com/35644661/162569317-ead996ff-05f6-4656-a112-df6f2965e5c9.png">

- The Host  of your git remote repository's upstream equals to the host of Github Enterprise URI
- If the remote url is based on SSH, it checks equality of `host`(`git@myenterprise.com` => `myenterprise.com`) to the host of Github Enterprise URI

**Let me know if there are any problems.**
