### PR TITLE
Show pull request's close button for author

### DIFF
--- a/webviews/components/comment.tsx
+++ b/webviews/components/comment.tsx
@@ -309,7 +309,7 @@ export function AddComment({
 				placeholder="Leave a comment"
 			/>
 			<div className="form-actions">
-				{hasWritePermission && !isIssue ? (
+				{(hasWritePermission || isAuthor) && !isIssue ? (
 					<button
 						id="close"
 						className="secondary"


### PR DESCRIPTION
It's possible to create a pull request when the
author has no write permission in a repository.
In this case, the author should be ablt to see
the close button.