### PR TITLE
The current repository does not have a push remote for...

### DIFF
--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -349,7 +349,7 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 							return false;
 						}
 						const testRemote = new Remote(localRemote.name, localRemote.pushUrl, new Protocol(localRemote.pushUrl));
-						if ((testRemote.owner === compareOwner) && (testRemote.repositoryName === compareRepositoryName)) {
+						if ((testRemote.owner.toLowerCase() === compareOwner.toLowerCase()) && (testRemote.repositoryName.toLowerCase() === compareRepositoryName.toLowerCase())) {
 							createdPushRemote = testRemote;
 							return true;
 						}


### PR DESCRIPTION
The issue is that the casing of the git push url can sometimes not match the casing of the repo owner and repo name.
Fixes #3517