### PR TITLE
Formalize GitHub Authentication dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
 	"categories": [
 		"Other"
 	],
+	"extensionDependencies": [
+		"vscode.github-authentication"
+	],
 	"activationEvents": [
 		"*",
 		"onCommand:github.api.preloadPullRequest",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"version": "0.40.0",
 	"publisher": "GitHub",
 	"engines": {
-		"vscode": "^1.67.0"
+		"vscode": "^1.68.0"
 	},
 	"categories": [
 		"Other"


### PR DESCRIPTION
This change was reverted during endgame because it depends on the built in GitHub Authentication extension using `"api": "none"`, which is now done in insiders.