### PR TITLE
Clear validation error when initializing create view

### DIFF
--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -268,6 +268,7 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 			defaultTitle,
 			defaultDescription,
 			isDraft: false,
+			createError: ''
 		};
 
 		this._compareBranch = this.defaultCompareBranch.name ?? '';


### PR DESCRIPTION
The webview state persists each time it's loaded so we need to reset the error when it's initialized.