### PR TITLE
Cannot exit review mode when default branch has same name as head branch of a PR

### DIFF
--- a/src/common/githubRef.ts
+++ b/src/common/githubRef.ts
@@ -7,7 +7,8 @@ import { Protocol } from './protocol';
 
 export class GitHubRef {
 	public repositoryCloneUrl: Protocol;
-	constructor(public ref: string, public label: string, public sha: string, repositoryCloneUrl: string) {
+	constructor(public ref: string, public label: string, public sha: string, repositoryCloneUrl: string,
+		public readonly owner: string, public readonly name: string) {
 		this.repositoryCloneUrl = new Protocol(repositoryCloneUrl);
 	}
 }

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -1800,12 +1800,17 @@ export class FolderRepositoryManager implements vscode.Disposable {
 			return null;
 		}
 
+		const headGitHubRepo = this.gitHubRepositories.find(
+			repo => repo.remote.remoteName === this.repository.state.HEAD?.upstream?.remote,
+		);
+
 		// Search through each github repo to see if it has a PR with this head branch.
 		for (const repo of this.gitHubRepositories) {
 			const matchingPullRequest = await repo.getPullRequestForBranch(
 				this.repository.state.HEAD.upstream.name,
 			);
-			if (matchingPullRequest) {
+			if (matchingPullRequest && (matchingPullRequest.head?.owner === headGitHubRepo?.remote.owner)
+				&& (matchingPullRequest.head?.name === headGitHubRepo?.remote.repositoryName)) {
 				return {
 					owner: repo.remote.owner,
 					repositoryName: repo.remote.repositoryName,

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -62,6 +62,8 @@ export interface MergePullRequest {
 
 export interface IRepository {
 	cloneUrl: string;
+	owner: string;
+	name: string;
 }
 
 export interface IGitHubRef {

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -205,14 +205,14 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 			this.isRemoteHeadDeleted = item.isRemoteHeadDeleted;
 		}
 		if (item.head) {
-			this.head = new GitHubRef(item.head.ref, item.head.label, item.head.sha, item.head.repo.cloneUrl);
+			this.head = new GitHubRef(item.head.ref, item.head.label, item.head.sha, item.head.repo.cloneUrl, item.head.repo.owner, item.head.repo.name);
 		}
 
 		if (item.isRemoteBaseDeleted != null) {
 			this.isRemoteBaseDeleted = item.isRemoteBaseDeleted;
 		}
 		if (item.base) {
-			this.base = new GitHubRef(item.base.ref, item.base!.label, item.base!.sha, item.base!.repo.cloneUrl);
+			this.base = new GitHubRef(item.base.ref, item.base!.label, item.base!.sha, item.base!.repo.cloneUrl, item.base.repo.owner, item.base.repo.name);
 		}
 	}
 

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -534,7 +534,7 @@ query PullRequestState($owner: String!, $name: String!, $number: Int!) {
 
 query PullRequestForHead($owner: String!, $name: String!, $headRefName: String!) {
 	repository(owner: $owner, name: $name) {
-		pullRequests(first: 1, headRefName: $headRefName) {
+		pullRequests(first: 1, headRefName: $headRefName, orderBy: {field: CREATED_AT, direction: DESC}) {
 			nodes {
 				...PullRequestFragment
 			}

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -193,7 +193,11 @@ export function convertRESTHeadToIGitHubRef(head: OctokitCommon.PullsListRespons
 		label: head.label,
 		ref: head.ref,
 		sha: head.sha,
-		repo: { cloneUrl: head.repo.clone_url },
+		repo: {
+			cloneUrl: head.repo.clone_url,
+			owner: head.repo.owner!.login,
+			name: head.repo.name
+		},
 	};
 }
 
@@ -472,6 +476,8 @@ function parseRef(refName: string, oid: string, repository?: GraphQL.RefReposito
 		sha: oid,
 		repo: {
 			cloneUrl: repository.url,
+			owner: repository.owner.login,
+			name: refName
 		},
 	};
 }

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -314,6 +314,7 @@ export class ReviewManager {
 			matchingPullRequestMetadata.prNumber,
 		);
 		if (!pr || !pr.isResolved()) {
+			this.clear(true);
 			this._prNumber = undefined;
 			Logger.appendLine('Review> This PR is no longer valid');
 			return;


### PR DESCRIPTION
I made a recent change that stopped looking for pull requests where the head branch matched `owner:branchName` for forks and instead just used branch name (the old way didn't work, which is why I switched). This is a problem because for common branch names, because now all PRs from a fork on a `main` branch will be found. 

The fix is to look at the owner and repo name of the PR with the matching branch.

Fixes #3525