### PR TITLE
Prompted about updates to PR after pushing to the PR branch

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -202,10 +202,7 @@ export class ReviewManager {
 			if (remote) {
 				await this._repository.fetch(remote, remoteBranch);
 				const canShowNotification = !this._context.globalState.get<boolean>(NEVER_SHOW_PULL_NOTIFICATION, false);
-				if (canShowNotification && !this._updateMessageShown &&
-					((this._lastCommitSha && (pr.head.sha !== this._lastCommitSha))
-						|| (branch.behind !== undefined && branch.behind > 0))
-				) {
+				if (canShowNotification && !this._updateMessageShown &&	(branch.behind !== undefined && branch.behind > 0)) {
 					this._updateMessageShown = true;
 					const pull = 'Pull';
 					const never = 'Never show again';


### PR DESCRIPTION
The check against `this._lastCommitSha` should have been removed at the time that we started checking `branch.behind` directly.

Fixes #3479