### PR TITLE
Implement quick self assign link as available on .com (#3382)

### DIFF
--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -308,6 +308,8 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				return this.addMilestone(message);
 			case 'pr.add-assignees':
 				return this.addAssignees(message);
+			case 'pr.add-assignee-yourself':
+				return this.addAssigneeYourself(message);
 			case 'pr.remove-reviewer':
 				return this.removeReviewer(message);
 			case 'pr.remove-assignee':
@@ -543,6 +545,22 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 					added: addedAssignees,
 				});
 			}
+		} catch (e) {
+			vscode.window.showErrorMessage(formatError(e));
+		}
+	}
+
+	private async addAssigneeYourself(message: IRequestMessage<void>): Promise<void> {
+		try {
+			const currentUser = this._folderRepositoryManager.getCurrentUser();
+
+			this._item.assignees = this._item.assignees?.concat(currentUser);
+
+			await this._item.updateAssignees([currentUser.login]);
+
+			this._replyMessage(message, {
+				added: [currentUser],
+			});
 		} catch (e) {
 			vscode.window.showErrorMessage(formatError(e));
 		}

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -67,6 +67,7 @@ export class PRContext {
 	public addMilestone = () => this.postMessage({ command: 'pr.add-milestone' });
 	public removeMilestone = () => this.postMessage({ command: 'pr.remove-milestone' });
 	public addAssignees = () => this.postMessage({ command: 'pr.add-assignees' });
+	public addAssigneeYourself = () => this.postMessage({ command: 'pr.add-assignee-yourself' });
 	public addLabels = () => this.postMessage({ command: 'pr.add-labels' });
 
 	public deleteComment = async (args: { id: number; pullRequestReviewId?: number }) => {

--- a/webviews/components/sidebar.tsx
+++ b/webviews/components/sidebar.tsx
@@ -16,6 +16,7 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 	const {
 		addReviewers,
 		addAssignees,
+		addAssigneeYourself,
 		addMilestone,
 		addLabels,
 		updatePR,
@@ -92,7 +93,14 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 						);
 					})
 				) : (
-					<div className="section-placeholder">None yet</div>
+					<div className="section-placeholder">
+						None yet—<a
+							onClick={async () => {
+								const currentUser = await addAssigneeYourself();
+								updatePR({ assignees: pr.assignees.concat(currentUser.added) });
+							}}
+						>assign yourself</a>
+					</div>
 				)}
 			</div>
 

--- a/webviews/components/sidebar.tsx
+++ b/webviews/components/sidebar.tsx
@@ -94,12 +94,15 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 					})
 				) : (
 					<div className="section-placeholder">
-						None yet—<a
-							onClick={async () => {
-								const currentUser = await addAssigneeYourself();
-								updatePR({ assignees: pr.assignees.concat(currentUser.added) });
-							}}
-						>assign yourself</a>
+							None yet{pr.canEdit ? (
+								<>
+									&mdash;
+									<a onClick={async () => {
+										const currentUser = await addAssigneeYourself();
+										updatePR({ assignees: pr.assignees.concat(currentUser.added) });
+									}}>assign yourself</a>
+								</>)
+								: null}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
This does not exactly implement what has been suggested in #3382 , but instead implements the one-click button to self-assign that is also available on github.com. This streamlines the self-assign process even further than the suggested feature.
A further change might be to also implement what was originally suggested (i.e. putting yourself on top of the picker list).