### PR TITLE
Parallel API requests

### DIFF
--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -783,7 +783,7 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 
 			this.diffThreads(reviewThreads);
 			this._reviewThreadsCache = reviewThreads;
-
+			this._onDidChangeReviewThreads.fire({ added: reviewThreads, changed: [], removed: [] });
 			return reviewThreads;
 		} catch (e) {
 			Logger.appendLine(`Failed to get pull request review comments: ${e}`);


### PR DESCRIPTION
All 5 requests are now performed in parallel. I have not seen any reason why they should have some sort of dependency between each other. By paralyzing the requests, a 3-4-fold speedup can be gained. It's now also caching the current user by accessing the `CredentialStore`