### PR TITLE
Error message for milestones

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -185,7 +185,7 @@ export function formatError(e: HookError | any): string {
 				return `Value "${error.value}" cannot be set for field ${error.field} (code: ${error.code})`;
 			})
 			.join(', ');
-	} else if (e.message.startsWith('Validation Failed')) {
+	} else if (e.message.startsWith('Validation Failed:')) {
 		return e.message;
 	} else if (isHookError(e) && e.errors) {
 		return e.errors

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -185,6 +185,8 @@ export function formatError(e: HookError | any): string {
 				return `Value "${error.value}" cannot be set for field ${error.field} (code: ${error.code})`;
 			})
 			.join(', ');
+	} else if (e.message.startsWith('Validation Failed')) {
+		return e.message;
 	} else if (isHookError(e) && e.errors) {
 		return e.errors
 			.map((error: any) => {

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { default as assert } from 'assert';
 import * as utils from '../../common/utils';
 import { EventEmitter } from 'vscode';
@@ -24,6 +29,11 @@ describe('utils', () => {
 				{ message: 'user_id can only have one pending review per pull request' },
 			]);
 			assert.strictEqual(utils.formatError(error), 'user_id can only have one pending review per pull request');
+		});
+
+		it('should not format when error message contains all information', () => {
+			const error = new HookError('Validation Failed: Some Validation error', []);
+			assert.strictEqual(utils.formatError(error), 'Validation Failed: Some Validation error information');
 		});
 
 		it('should format an error with submessages that are strings', () => {

--- a/src/test/common/utils.test.ts
+++ b/src/test/common/utils.test.ts
@@ -33,7 +33,7 @@ describe('utils', () => {
 
 		it('should not format when error message contains all information', () => {
 			const error = new HookError('Validation Failed: Some Validation error', []);
-			assert.strictEqual(utils.formatError(error), 'Validation Failed: Some Validation error information');
+			assert.strictEqual(utils.formatError(error), 'Validation Failed: Some Validation error');
 		});
 
 		it('should format an error with submessages that are strings', () => {


### PR DESCRIPTION
The `formatError` function does not consider some of the Validation Errors and returns an empty string error.

When creating a milestone with a name that is already taken but closed it can be very confusing. I added an Error message for that case. It could be done a bit more elegantly by also requesting closed milestones, however, this would require some more changes that I don't want to force into this release.

We could also consider lateron to give the option to reopen a milestone if the user enters a name for an already existing but closed milestone.