### PR TITLE
Update @vscode/test-electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -1804,7 +1804,7 @@
 		"@types/webpack-env": "^1.16.0",
 		"@typescript-eslint/eslint-plugin": "4.18.0",
 		"@typescript-eslint/parser": "4.18.0",
-		"@vscode/test-electron": "^1.6.1",
+		"@vscode/test-electron": "^2.1.5",
 		"@vscode/test-web": "^0.0.22",
 		"assert": "^2.0.0",
 		"buffer": "^6.0.3",

--- a/src/@types/vscode.proposed.contribViewSize.d.ts
+++ b/src/@types/vscode.proposed.contribViewSize.d.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// empty placeholder for view size
+
+// https://github.com/microsoft/vscode/issues/122283 @alexr00
+
+/**
+ * View contributions can include a `size`, which can be a number. A number works similar to the css flex property.
+ *
+ * For example, if you have 3 views, with sizes 1, 1, and 2, the views of size 1 will together take up the same amount of space as the view of size 2.
+ *
+ * A number value will only be used as an initial size. After a user has changed the size of the view, the user's choice will be restored.
+*/
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,10 +599,10 @@
     "@microsoft/1ds-core-js" "^3.2.3"
     "@microsoft/1ds-post-js" "^3.2.3"
 
-"@vscode/test-electron@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-1.6.1.tgz#2b282154097e250ee9b94b6a284eb5804e53a3d7"
-  integrity sha512-WTs+OK9YrKSVJNZ9IjytNibHSJG2YslZXuS3pw9gedF25TgYF/+FQhQYL0ZPX4uupS0SGAPKzMnhYDkjPDxowA==
+"@vscode/test-electron@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.1.5.tgz#ac98f8f445ea4590753f5fa0c7f6e4298f08c3b7"
+  integrity sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==
   dependencies:
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"


### PR DESCRIPTION
We get a lot of:
```
Downloading VS Code insiders from https://update.code.visualstudio.com/latest/darwin/insiderevents.js:377
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
```
in CI. Let's see if updating the test module fixes it.