### PR TITLE
`RepositoryChangesNode` has a reference to ReviewManager

### DIFF
--- a/src/view/prChangesTreeDataProvider.ts
+++ b/src/view/prChangesTreeDataProvider.ts
@@ -11,7 +11,7 @@ import { FILE_LIST_LAYOUT } from '../common/settingKeys';
 import { FolderRepositoryManager, SETTINGS_NAMESPACE } from '../github/folderRepositoryManager';
 import { PullRequestModel } from '../github/pullRequestModel';
 import { RepositoriesManager } from '../github/repositoriesManager';
-import { ReviewManager } from './reviewManager';
+import { ProgressHelper } from './progress';
 import { ReviewModel } from './reviewModel';
 import { DescriptionNode } from './treeNodes/descriptionNode';
 import { GitFileChangeNode } from './treeNodes/fileChangeNode';
@@ -76,7 +76,7 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 		pullRequestModel: PullRequestModel,
 		reviewModel: ReviewModel,
 		shouldReveal: boolean,
-		reviewManager: ReviewManager
+		progress: ProgressHelper
 	) {
 		Logger.appendLine(`Adding PR #${pullRequestModel.number} to tree`, PR_TREE);
 		if (this._pullRequestManagerMap.has(pullRequestManager)) {
@@ -93,7 +93,7 @@ export class PullRequestChangesTreeDataProvider extends vscode.Disposable implem
 			pullRequestModel,
 			pullRequestManager,
 			reviewModel,
-			reviewManager
+			progress
 		);
 		this._pullRequestManagerMap.set(pullRequestManager, node);
 		this.updateViewTitle();

--- a/src/view/progress.ts
+++ b/src/view/progress.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class ProgressHelper {
+	private _progress: Promise<void> = Promise.resolve();
+	private _endProgress: vscode.EventEmitter<void> = new vscode.EventEmitter();
+
+	get progress(): Promise<void> {
+		return this._progress;
+	}
+	startProgress() {
+		this.endProgress();
+		this._progress = new Promise(resolve => {
+			const disposable = this._endProgress.event(() => {
+				disposable.dispose();
+				resolve();
+			});
+		});
+	}
+
+	endProgress() {
+		this._endProgress.fire();
+	}
+}

--- a/src/view/treeNodes/repositoryChangesNode.ts
+++ b/src/view/treeNodes/repositoryChangesNode.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import Logger, { PR_TREE } from '../../common/logger';
 import { FolderRepositoryManager } from '../../github/folderRepositoryManager';
 import { PullRequestModel } from '../../github/pullRequestModel';
-import { ReviewManager } from '../reviewManager';
+import { ProgressHelper } from '../progress';
 import { ReviewModel } from '../reviewModel';
 import { CommitsNode } from './commitsCategoryNode';
 import { DescriptionNode } from './descriptionNode';
@@ -26,7 +26,7 @@ export class RepositoryChangesNode extends DescriptionNode implements vscode.Tre
 		private _pullRequest: PullRequestModel,
 		private _pullRequestManager: FolderRepositoryManager,
 		private _reviewModel: ReviewModel,
-		private _reviewManager: ReviewManager
+		private _progress: ProgressHelper
 	) {
 		super(parent, _pullRequest.title, _pullRequest.userAvatarUri!, _pullRequest, _pullRequestManager.repository);
 		// Cause tree values to be filled
@@ -63,7 +63,7 @@ export class RepositoryChangesNode extends DescriptionNode implements vscode.Tre
 	}
 
 	async getChildren(): Promise<TreeNode[]> {
-		await this._reviewManager.refreshSinceReview;
+		await this._progress.progress;
 		if (!this._filesCategoryNode || !this._commitsCategoryNode) {
 			Logger.appendLine(`Creating file and commit nodes for PR #${this.pullRequestModel.number}`, PR_TREE);
 			this._filesCategoryNode = new FilesCategoryNode(this.parent, this._reviewModel, this._pullRequest);


### PR DESCRIPTION
I was hoping I could find some way to listen on an event to trigger the progress from within the `RepositoryChangesNode`, but I didn't find a nice way to do that. The solution I ended up on isn't idea, but it's better then the cycle we have currently.
Fixes #3792