### PR TITLE
fix: use ssh url for ssh protocol upstream

### DIFF
--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -601,7 +601,7 @@ export class FolderRepositoryManager implements vscode.Disposable {
 						// check the remotes to see what protocol is being used
 						const isSSH = this.gitHubRepositories[0].remote.gitProtocol.type === ProtocolType.SSH;
 						if (isSSH) {
-							await this.repository.addRemote(remoteName, metadata.parent.git_url);
+							await this.repository.addRemote(remoteName, metadata.parent.ssh_url);
 						} else {
 							await this.repository.addRemote(remoteName, metadata.parent.clone_url);
 						}


### PR DESCRIPTION
The git protocol is not supported by GitHub, see: https://github.blog/2021-09-01-improving-git-protocol-security-github/

When we use this extension in a repo which is using ssh protocol (such as: `git@github.com:microsoft/vscode-pull-request-github`), the upstream will be set as `git://xxxxxx`. But it's not supported on GitHub.

We should set ssh protocol instead.

## Steps to reproduce

1. Clone a fork to locale with ssh protocol `git clone git@github.com:<user>/vscode-pull-request-github.git`
2. Open this fork folder in vs code with vscode-pull-request-github extension
3. open file `.git/config`, we can see the upstream url is set to `git://github.com/microsoft/vscode-pull-request-github.git` (with git protocol which is not supported by GitHub now. And I think it should be ssh protocol which is the same as the fork's protocol)