### PR TITLE
Make "rename" action more clear in review mode

### DIFF
--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -33,6 +33,7 @@ export interface PRUriParams {
 	prNumber: number;
 	status: GitChangeType;
 	remoteName: string;
+	previousFileName?: string;
 }
 
 export function fromPRUri(uri: vscode.Uri): PRUriParams | undefined {
@@ -185,14 +186,16 @@ export function toReviewUri(
 export interface FileChangeNodeUriParams {
 	prNumber: number;
 	fileName: string;
+	previousFileName?: string;
 	status?: GitChangeType;
 }
 
-export function toResourceUri(uri: vscode.Uri, prNumber: number, fileName: string, status: GitChangeType) {
-	const params = {
-		prNumber: prNumber,
-		fileName: fileName,
-		status: status,
+export function toResourceUri(uri: vscode.Uri, prNumber: number, fileName: string, status: GitChangeType, previousFileName?: string) {
+	const params: FileChangeNodeUriParams = {
+		prNumber,
+		fileName,
+		status,
+		previousFileName
 	};
 
 	return uri.with({
@@ -215,6 +218,7 @@ export function toPRUri(
 	fileName: string,
 	base: boolean,
 	status: GitChangeType,
+	previousFileName?: string
 ): vscode.Uri {
 	const params: PRUriParams = {
 		baseCommit: baseCommit,
@@ -224,6 +228,7 @@ export function toPRUri(
 		prNumber: pullRequestModel.number,
 		status: status,
 		remoteName: pullRequestModel.githubRepository.remote.remoteName,
+		previousFileName
 	};
 
 	const path = uri.path;

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -1174,6 +1174,7 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 				change.fileName,
 				false,
 				change.status,
+				change.previousFileName
 			);
 			baseUri = toPRUri(
 				vscode.Uri.file(resolvePath(folderManager.repository.rootUri, parentFileName)),
@@ -1183,6 +1184,7 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 				change.fileName,
 				true,
 				change.status,
+				change.previousFileName
 			);
 		} else {
 			const uri = vscode.Uri.file(path.resolve(folderManager.repository.rootUri.fsPath, change.fileName));

--- a/src/view/fileChangeModel.ts
+++ b/src/view/fileChangeModel.ts
@@ -68,7 +68,7 @@ export abstract class FileChangeModel {
 	constructor(public readonly pullRequest: PullRequestModel,
 		protected readonly folderRepoManager: FolderRepositoryManager,
 		public readonly change: SimpleFileChange,
-		public readonly sha?: string) {	}
+		public readonly sha?: string) { }
 }
 
 export class GitFileChangeModel extends FileChangeModel {
@@ -145,6 +145,7 @@ export class InMemFileChangeModel extends FileChangeModel {
 				change.fileName,
 				false,
 				change.status,
+				change.previousFileName
 			);
 		this._parentFilePath = isCurrentPR ? (toReviewUri(
 			parentPath,
@@ -162,6 +163,7 @@ export class InMemFileChangeModel extends FileChangeModel {
 			change.fileName,
 			true,
 			change.status,
+			change.previousFileName
 		);
 	}
 }
@@ -196,6 +198,7 @@ export class RemoteFileChangeModel extends FileChangeModel {
 			change.fileName,
 			false,
 			change.status,
+			change.previousFileName
 		);
 		this._parentFilePath = toPRUri(
 			vscode.Uri.file(
@@ -207,6 +210,7 @@ export class RemoteFileChangeModel extends FileChangeModel {
 			change.fileName,
 			true,
 			change.status,
+			change.previousFileName
 		);
 	}
 }

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { IComment, ViewedState } from '../../common/comment';
-import { GitChangeType } from '../../common/file';
+import { GitChangeType, InMemFileChange } from '../../common/file';
 import { FILE_LIST_LAYOUT } from '../../common/settingKeys';
 import { asImageDataURI, EMPTY_IMAGE_URI, fromReviewUri, ReviewUriParams, Schemes, toResourceUri } from '../../common/uri';
 import { groupBy } from '../../common/utils';
@@ -93,6 +93,10 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 		return this.changeModel.sha;
 	}
 
+	get tooltip(): string {
+		return this.resourceUri.fsPath;
+	}
+
 	constructor(
 		public readonly parent: TreeNodeParent,
 		protected readonly pullRequestManager: FolderRepositoryManager,
@@ -114,6 +118,7 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 			this.pullRequest.number,
 			this.changeModel.fileName,
 			this.changeModel.status,
+			this.changeModel.change instanceof InMemFileChange ? this.changeModel.change.previousFileName : undefined
 		);
 		this.updateViewed(viewed);
 
@@ -222,7 +227,7 @@ export class RemoteFileChangeNode extends FileChangeNode implements vscode.TreeI
 		changeModel: RemoteFileChangeModel
 	) {
 		super(parent, folderRepositoryManager, pullRequest, changeModel);
-		this.fileChangeResourceUri = toResourceUri(vscode.Uri.parse(changeModel.blobUrl), changeModel.pullRequest.number, changeModel.fileName, changeModel.status);
+		this.fileChangeResourceUri = toResourceUri(vscode.Uri.parse(changeModel.blobUrl), changeModel.pullRequest.number, changeModel.fileName, changeModel.status, changeModel.previousFileName);
 		this.command = {
 			command: 'pr.openFileOnGitHub',
 			title: 'Open File on GitHub',


### PR DESCRIPTION
- Add a tooltip to the node so that the tree view doesn't assume it needs to be resolved. This lets decorations work on the tooltip (https://github.com/microsoft/vscode/pull/158593)
- Add a tooltip to the decoration
Fixes #3644