### PR TITLE
Limit chunks for extension config too

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -162,6 +162,9 @@ async function getExtensionConfig(target, mode, env) {
 	 * @type WebpackConfig['plugins'] | any
 	 */
 	const plugins = [
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1
+		}),
 		new ForkTsCheckerPlugin({
 			async: false,
 			eslint: {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-pull-request-github/issues/3929

The previous fix for web bundling only covered webviews--I missed that there was a second spot for plugins in the webpack config