### PR TITLE
Use repository root URI scheme for added and changed files

### DIFF
--- a/src/view/fileChangeModel.ts
+++ b/src/view/fileChangeModel.ts
@@ -132,26 +132,20 @@ export class InMemFileChangeModel extends FileChangeModel {
 		super(pullRequest, folderRepositoryManager, change);
 		const headCommit = pullRequest.head!.sha;
 		const parentFileName = change.status === GitChangeType.RENAME ? change.previousFileName! : change.fileName;
-		const filePath = vscode.Uri.file(resolvePath(folderRepositoryManager.repository.rootUri, change.fileName));
-		const parentPath = vscode.Uri.file(resolvePath(folderRepositoryManager.repository.rootUri, parentFileName));
-		this._filePath = isCurrentPR ? toReviewUri(
-			parentPath,
-			change.status === GitChangeType.DELETE ? undefined : change.fileName,
-			undefined,
-			change.status === GitChangeType.DELETE ? '' : headCommit,
-			false,
-			{ base: false },
-			folderRepositoryManager.repository.rootUri,
-		) : toPRUri(
-			filePath,
-			pullRequest,
-			change.baseCommit,
-			headCommit,
-			change.fileName,
-			false,
-			change.status,
-			change.previousFileName
-		);
+		const filePath = folderRepositoryManager.repository.rootUri.with({ path: resolvePath(folderRepositoryManager.repository.rootUri, change.fileName) });
+		const parentPath = folderRepositoryManager.repository.rootUri.with({ path: resolvePath(folderRepositoryManager.repository.rootUri, parentFileName) });
+		this._filePath = isCurrentPR ? ((change.status === GitChangeType.DELETE)
+			? toReviewUri(filePath, undefined, undefined, '', false, { base: false }, folderRepositoryManager.repository.rootUri)
+			: filePath) : toPRUri(
+				filePath,
+				pullRequest,
+				change.baseCommit,
+				headCommit,
+				change.fileName,
+				false,
+				change.status,
+				change.previousFileName
+			);
 		this._parentFilePath = isCurrentPR ? (toReviewUri(
 			parentPath,
 			change.status === GitChangeType.RENAME ? change.previousFileName : change.fileName,

--- a/src/view/fileChangeModel.ts
+++ b/src/view/fileChangeModel.ts
@@ -134,19 +134,24 @@ export class InMemFileChangeModel extends FileChangeModel {
 		const parentFileName = change.status === GitChangeType.RENAME ? change.previousFileName! : change.fileName;
 		const filePath = vscode.Uri.file(resolvePath(folderRepositoryManager.repository.rootUri, change.fileName));
 		const parentPath = vscode.Uri.file(resolvePath(folderRepositoryManager.repository.rootUri, parentFileName));
-		this._filePath = isCurrentPR ? ((change.status === GitChangeType.DELETE)
-			? toReviewUri(filePath, undefined, undefined, '', false, { base: false }, folderRepositoryManager.repository.rootUri)
-			: filePath)
-			: toPRUri(
-				filePath,
-				pullRequest,
-				change.baseCommit,
-				headCommit,
-				change.fileName,
-				false,
-				change.status,
-				change.previousFileName
-			);
+		this._filePath = isCurrentPR ? toReviewUri(
+			parentPath,
+			change.status === GitChangeType.DELETE ? undefined : change.fileName,
+			undefined,
+			change.status === GitChangeType.DELETE ? '' : headCommit,
+			false,
+			{ base: false },
+			folderRepositoryManager.repository.rootUri,
+		) : toPRUri(
+			filePath,
+			pullRequest,
+			change.baseCommit,
+			headCommit,
+			change.fileName,
+			false,
+			change.status,
+			change.previousFileName
+		);
 		this._parentFilePath = isCurrentPR ? (toReviewUri(
 			parentPath,
 			change.status === GitChangeType.RENAME ? change.previousFileName : change.fileName,


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-pull-request-github/issues/3935

I tested that this fixes opening PR diffs for added and modified files from the All Open view tree node in both RemoteHub and desktop git repositories.