### PR TITLE
Post-Commit Action - Update title and remove the description

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -282,8 +282,7 @@ function registerPostCommitCommandsProvider(reposManager: RepositoriesManager, g
 			Logger.debug(`Found ${found ? 'a repo' : 'no repos'} when getting post commit commands.`, componentId);
 			return found ? [{
 				command: 'pr.create',
-				title: '$(git-pull-request-create) Commit',
-				description: '$(git-pull-request-create) Commit & Create Pull Request',
+				title: '$(git-pull-request-create) Commit & Create Pull Request',
 				tooltip: 'Commit & Create Pull Request'
 			}] : [];
 		}


### PR DESCRIPTION
Just checked in a change that adjusts the layout of the Commit action button to use text overflow instead of hiding content. This means that there is no need to specify both a title and a description.  