### PR TITLE
feat: Add origin of upstream for github enterprise on copy head link

### DIFF
--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -568,8 +568,9 @@ export async function createGitHubLink(
 		return { permalink: undefined, error: vscode.l10n.t('Repository does not have any remotes.'), originalFile: undefined };
 	}
 	const pathSegment = uri.path.substring(folderManager.repository.rootUri.path.length);
+	const originOfFetchUrl = getUpstreamOrigin(upstream).replace(/\/$/, '');
 	return {
-		permalink: `https://github.com/${new Protocol(upstream.fetchUrl).nameWithOwner}/blob/${branchName
+		permalink: `${originOfFetchUrl}/${new Protocol(upstream.fetchUrl).nameWithOwner}/blob/${branchName
 			}${pathSegment}${rangeString(range)}`,
 		error: undefined,
 		originalFile: uri


### PR DESCRIPTION
This PR is related to https://github.com/microsoft/vscode-pull-request-github/pull/3460

Support the copied head link for Github Enterprise URL.

<img width="650" alt="스크린샷 2022-10-10 10 35 32" src="https://user-images.githubusercontent.com/35644661/194789201-4f7a8221-41c7-4069-8eb4-aebc289a7035.png">
