### PR TITLE
Do not * activate the GHPRI extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"vscode.github-authentication"
 	],
 	"activationEvents": [
-		"*",
 		"onCommand:github.api.preloadPullRequest",
 		"onFileSystem:newIssue",
 		"onFileSystem:pr",


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-pull-request-github/issues/4046

It seems like the original intent of adding the * activation event was to improve the perceived speed of loading the PR diff when the current workspace is a PR, but this has the side effect of activating GHPRI even if the user doesn't have a PR checked out. Additionally, when testing this change with sideloaded GHPRI running out of sources in insiders.vscode.dev, it did not seem like the PR diff took much longer than usual to load. 

This change seems safe to me and worthwhile to test out in insiders because if we can avoid unnecessary extension activation, we can reduce network and web worker extension host contention and hopefully improve overall performance of vscode.dev. Please let me know if I've missed some context!