### PR TITLE
Update embedded video styles

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -838,6 +838,24 @@ code {
 	font-family: Menlo, Monaco, Consolas, 'Droid Sans Mono', 'Courier New', monospace, 'Droid Sans Fallback';
 }
 
+.comment-body video {
+	width: 100%;
+	border: 1px solid var(--vscode-editorWidget-border);
+	border-radius: 4px;
+}
+
+.comment-body summary {
+	margin-bottom: 8px;
+}
+
+.comment-body details summary::marker {
+	display: flex;
+}
+
+.comment-body details summary svg {
+	margin-left: 8px;
+}
+
 .comment-body body.wordWrap pre {
 	white-space: pre-wrap;
 }


### PR DESCRIPTION
Note that I haven't yet figured out how to properly style the collapsible `summary` at the top. Just doing an initial pass here to get the video sized properly.

## Before

<img width="940" alt="CleanShot 2022-10-19 at 09 52 05@2x" src="https://user-images.githubusercontent.com/25163139/196757677-d50d820a-b5fc-436e-bf0a-ace93b1a33ad.png">

## After

<img width="937" alt="CleanShot 2022-10-19 at 10 05 38@2x" src="https://user-images.githubusercontent.com/25163139/196758681-3433e736-c344-46fe-b716-39822f99319b.png">
