### PR TITLE
Fix timeline and status checks overflow/alignment

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -69,7 +69,7 @@ textarea:focus,
 .comment-body code,
 .comment-body a,
 span.lineContent {
-	overflow-wrap: break-word;
+	overflow-wrap: anywhere;
 }
 
 #title:empty {
@@ -224,6 +224,10 @@ body .comment-container .review-comment-header {
 
 .status-check-detail-text {
 	margin-right: 8px;
+}
+
+.status-section p {
+	margin: 0;
 }
 
 .form-actions > input[type='submit'] {
@@ -836,6 +840,10 @@ h3 {
 
 code {
 	font-family: Menlo, Monaco, Consolas, 'Droid Sans Mono', 'Courier New', monospace, 'Droid Sans Fallback';
+}
+
+.comment-body .snippet-clipboard-content {
+	display: grid;
 }
 
 .comment-body video {


### PR DESCRIPTION
- Fixes an issue where links would cause the main timeline to expand indefinitely. (Fixes #4067) cc @Thomas1664 
- Fixes an issue where status checks text has extra margin causing a vertical alignment issue

## Before


https://user-images.githubusercontent.com/25163139/196820743-c8690688-439d-4f22-ab1b-e9694d6ad80d.mp4

## After


https://user-images.githubusercontent.com/25163139/196820769-81b36472-8ad2-40e9-bafc-024199ca9649.mp4

