### PR TITLE
Narrow types in TimelineEvent so that it may be treated as a tagged union

### DIFF
--- a/src/common/timelineEvent.ts
+++ b/src/common/timelineEvent.ts
@@ -105,31 +105,3 @@ export interface HeadRefDeleteEvent {
 }
 
 export type TimelineEvent = CommitEvent | ReviewEvent | CommentEvent | NewCommitsSinceReviewEvent | MergedEvent | AssignEvent | HeadRefDeleteEvent;
-
-export function isReviewEvent(event: TimelineEvent): event is ReviewEvent {
-	return event.event === EventType.Reviewed;
-}
-
-export function isCommitEvent(event: TimelineEvent): event is CommitEvent {
-	return event.event === EventType.Committed;
-}
-
-export function isNewCommitsSinceReviewEvent(event: TimelineEvent): event is NewCommitsSinceReviewEvent {
-	return event.event === EventType.NewCommitsSinceReview;
-}
-
-export function isCommentEvent(event: TimelineEvent): event is CommentEvent {
-	return event.event === EventType.Commented;
-}
-
-export function isMergedEvent(event: TimelineEvent): event is MergedEvent {
-	return event.event === EventType.Merged;
-}
-
-export function isAssignEvent(event: TimelineEvent): event is AssignEvent {
-	return event.event === EventType.Assigned;
-}
-
-export function isHeadDeleteEvent(event: TimelineEvent): event is HeadRefDeleteEvent {
-	return event.event === EventType.HeadRefDeleted;
-}

--- a/src/common/timelineEvent.ts
+++ b/src/common/timelineEvent.ts
@@ -29,11 +29,12 @@ export interface Committer {
 
 export interface CommentEvent {
 	id: number;
+	graphNodeId: string;
 	htmlUrl: string;
 	body: string;
 	bodyHTML?: string;
 	user: IAccount;
-	event: EventType;
+	event: EventType.Commented;
 	canEdit?: boolean;
 	canDelete?: boolean;
 	createdAt: string;
@@ -49,7 +50,7 @@ export interface ReviewResolveInfo {
 export interface ReviewEvent {
 	id: number;
 	reviewThread?: ReviewResolveInfo
-	event: EventType;
+	event: EventType.Reviewed;
 	comments: IComment[];
 	submittedAt: string;
 	body: string;
@@ -63,7 +64,7 @@ export interface ReviewEvent {
 export interface CommitEvent {
 	id: string;
 	author: IAccount;
-	event: EventType;
+	event: EventType.Committed;
 	sha: string;
 	htmlUrl: string;
 	message: string;
@@ -73,7 +74,7 @@ export interface CommitEvent {
 
 export interface NewCommitsSinceReviewEvent {
 	id: string;
-	event: EventType;
+	event: EventType.NewCommitsSinceReview;
 }
 
 export interface MergedEvent {
@@ -84,20 +85,20 @@ export interface MergedEvent {
 	mergeRef: string;
 	sha: string;
 	commitUrl: string;
-	event: EventType;
+	event: EventType.Merged;
 	url: string;
 }
 
 export interface AssignEvent {
 	id: number;
-	event: EventType;
+	event: EventType.Assigned;
 	user: IAccount;
 	actor: IAccount;
 }
 
 export interface HeadRefDeleteEvent {
 	id: string;
-	event: EventType;
+	event: EventType.HeadRefDeleted;
 	actor: IAccount;
 	createdAt: string;
 	headRef: string;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -140,6 +140,12 @@ export function groupBy<T>(arr: T[], fn: (el: T) => string): { [key: string]: T[
 	}, Object.create(null));
 }
 
+export class UnreachableCaseError extends Error {
+	constructor(val: never) {
+		super(`Unreachable case: ${val}`);
+	}
+}
+
 interface HookError extends Error {
 	errors: any;
 }

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -15,7 +15,7 @@ import { GitHubRef } from '../common/githubRef';
 import Logger from '../common/logger';
 import { Remote } from '../common/remote';
 import { ITelemetry } from '../common/telemetry';
-import { ReviewEvent as CommonReviewEvent, isReviewEvent, TimelineEvent } from '../common/timelineEvent';
+import { ReviewEvent as CommonReviewEvent, EventType, TimelineEvent } from '../common/timelineEvent';
 import { resolvePath, toPRUri, toReviewUri } from '../common/uri';
 import { formatError } from '../common/utils';
 import { OctokitCommon } from './common';
@@ -992,7 +992,7 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 			childComments?: CommentNode[];
 		}
 
-		const reviewEvents = events.filter(isReviewEvent);
+		const reviewEvents = events.filter((e): e is CommonReviewEvent => e.event === EventType.Reviewed);
 		const reviewComments = reviewThreads.reduce((previous, current) => (previous as IComment[]).concat(current.comments), []);
 
 		const reviewEventsById = reviewEvents.reduce((index, evt) => {

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -956,21 +956,21 @@ export function getRelatedUsersFromTimelineEvents(
 	const ret: { login: string; name: string }[] = [];
 
 	timelineEvents.forEach(event => {
-		if (Common.isCommitEvent(event)) {
+		if (event.event === Common.EventType.Committed) {
 			ret.push({
 				login: event.author.login,
 				name: event.author.name || '',
 			});
 		}
 
-		if (Common.isReviewEvent(event)) {
+		if (event.event === Common.EventType.Reviewed) {
 			ret.push({
 				login: event.user.login,
 				name: event.user.name ?? event.user.login,
 			});
 		}
 
-		if (Common.isCommentEvent(event)) {
+		if (event.event === Common.EventType.Commented) {
 			ret.push({
 				login: event.user.login,
 				name: event.user.name ?? event.user.login,
@@ -1023,7 +1023,7 @@ export function parseReviewers(
 	timelineEvents: Common.TimelineEvent[],
 	author: IAccount,
 ): ReviewState[] {
-	const reviewEvents = timelineEvents.filter(Common.isReviewEvent).filter(event => event.state !== 'PENDING');
+	const reviewEvents = timelineEvents.filter((e): e is Common.ReviewEvent => e.event === Common.EventType.Reviewed).filter(event => event.state !== 'PENDING');
 	let reviewers: ReviewState[] = [];
 	const seen = new Map<string, boolean>();
 

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -5,7 +5,7 @@
 
 import { createContext } from 'react';
 import { IComment } from '../../src/common/comment';
-import { EventType, isReviewEvent, ReviewEvent, TimelineEvent } from '../../src/common/timelineEvent';
+import { EventType, ReviewEvent, TimelineEvent } from '../../src/common/timelineEvent';
 import { MergeMethod, ReviewState } from '../../src/github/interface';
 import { getState, PullRequest, setState, updateState } from './cache';
 import { getMessageHandler, MessageHandler } from './message';
@@ -154,14 +154,14 @@ export class PRContext {
 
 	private appendReview({ review, reviewers }: { review: ReviewEvent, reviewers: ReviewState[] }) {
 		const state = this.pr;
-		const events = state.events.filter(e => !isReviewEvent(e) || e.state.toLowerCase() !== 'pending');
+		const events = state.events.filter(e => e.event !== EventType.Reviewed || e.state.toLowerCase() !== 'pending');
 		events.forEach(event => {
-			if (isReviewEvent(event)) {
+			if (event.event === EventType.Reviewed) {
 				event.comments.forEach(c => (c.isDraft = false));
 			}
 		});
 		state.reviewers = reviewers;
-		state.events = [...state.events.filter(e => (isReviewEvent(e) ? e.state !== 'PENDING' : e)), review];
+		state.events = [...state.events.filter(e => (e.event === EventType.Reviewed ? e.state !== 'PENDING' : e)), review];
 		state.currentUserReviewState = review.state;
 		this.updatePR(state);
 	}

--- a/webviews/components/timeline.tsx
+++ b/webviews/components/timeline.tsx
@@ -10,19 +10,13 @@ import {
 	AssignEvent,
 	CommentEvent,
 	CommitEvent,
+	EventType,
 	HeadRefDeleteEvent,
-	isAssignEvent,
-	isCommentEvent,
-	isCommitEvent,
-	isHeadDeleteEvent,
-	isMergedEvent,
-	isNewCommitsSinceReviewEvent,
-	isReviewEvent,
 	MergedEvent,
 	ReviewEvent,
 	TimelineEvent,
 } from '../../src/common/timelineEvent';
-import { groupBy } from '../../src/common/utils';
+import { groupBy, UnreachableCaseError } from '../../src/common/utils';
 import PullRequestContext from '../common/context';
 import { CommentBody, CommentView } from './comment';
 import Diff from './diff';
@@ -33,24 +27,26 @@ import { AuthorLink, Avatar } from './user';
 
 export const Timeline = ({ events }: { events: TimelineEvent[] }) => (
 	<>
-		{events.map(event =>
-			// TODO: Maybe make TimelineEvent a tagged union type?
-			isCommitEvent(event) ? (
-				<CommitEventView key={`commit${event.id}`} {...event} />
-			) : isReviewEvent(event) ? (
-				<ReviewEventView key={`review${event.id}`} {...event} />
-			) : isCommentEvent(event) ? (
-				<CommentEventView key={`comment${event.id}`} {...event} />
-			) : isMergedEvent(event) ? (
-				<MergedEventView key={`merged${event.id}`} {...event} />
-			) : isAssignEvent(event) ? (
-				<AssignEventView key={`assign${event.id}`} {...event} />
-			) : isHeadDeleteEvent(event) ? (
-				<HeadDeleteEventView key={`head${event.id}`} {...event} />
-			) : isNewCommitsSinceReviewEvent(event) ? (
-				<NewCommitsSinceReviewEventView key={`newCommits${event.id}`} />
-			) : null,
-		)}
+	{events.map(event => {
+		switch (event.event) {
+			case EventType.Committed:
+				return <CommitEventView key={`commit${event.id}`} {...event} />;
+			case EventType.Reviewed:
+				return <ReviewEventView key={`review${event.id}`} {...event} />;
+			case EventType.Commented:
+				return <CommentEventView key={`comment${event.id}`} {...event} />;
+			case EventType.Merged:
+				return <MergedEventView key={`merged${event.id}`} {...event} />;
+			case EventType.Assigned:
+				return <AssignEventView key={`assign${event.id}`} {...event} />;
+			case EventType.HeadRefDeleted:
+				return <HeadDeleteEventView key={`head${event.id}`} {...event} />;
+			case EventType.NewCommitsSinceReview:
+				return <NewCommitsSinceReviewEventView key={`newCommits${event.id}`} />;
+			default:
+				throw new UnreachableCaseError(event);
+		}
+	})}
 	</>
 );
 


### PR DESCRIPTION
This PR narrows the types in `TimelineEvent` a bit by being explicit about the event types. This means that we can treat `TimelineEvent` as a tagged union, which results in improved type safety and fewer lines of code.