### PR TITLE
Support GitHub's suggested changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -871,6 +871,12 @@
 				"icon": "$(copy)"
 			},
 			{
+				"command": "pr.applySuggestion",
+				"title": "%command.pr.applySuggestion.title%",
+				"category": "%command.pull.request.category%",
+				"icon": "$(gift)"
+			},
+			{
 				"command": "issue.createIssueFromSelection",
 				"title": "%command.issue.createIssueFromSelection.title%",
 				"category": "%command.issues.category%"
@@ -1765,17 +1771,22 @@
 			"comments/comment/title": [
 				{
 					"command": "pr.copyCommentLink",
-					"group": "inline@0",
-					"when": "commentController =~ /^github-(browse|review)/ && comment =~ /canEdit/"
-				},
-				{
-					"command": "pr.editComment",
 					"group": "inline@1",
 					"when": "commentController =~ /^github-(browse|review)/ && comment =~ /canEdit/"
 				},
 				{
-					"command": "pr.deleteComment",
+					"command": "pr.applySuggestion",
+					"group": "inline@0",
+					"when": "commentController =~ /^github-review/ && comment =~ /hasSuggestion/"
+				},
+				{
+					"command": "pr.editComment",
 					"group": "inline@2",
+					"when": "commentController =~ /^github-(browse|review)/ && comment =~ /canEdit/"
+				},
+				{
+					"command": "pr.deleteComment",
+					"group": "inline@3",
 					"when": "commentController =~ /^github-(browse|review)/ && comment =~ /canDelete/"
 				}
 			],

--- a/package.nls.json
+++ b/package.nls.json
@@ -164,6 +164,7 @@
 	"command.pr.goToNextDiffInPr.title": "Go to Next Diff in Pull Request",
 	"command.pr.goToPreviousDiffInPr.title": "Go to Previous Diff in Pull Request",
 	"command.pr.copyCommentLink.title": "Copy Comment Link",
+	"command.pr.applySuggestion.title": "Apply Suggestion",
 	"command.issues.category": "GitHub Issues",
 	"command.issue.createIssueFromSelection.title": "Create Issue From Selection",
 	"command.issue.createIssueFromClipboard.title": "Create Issue From Clipboard",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,6 +25,7 @@ import { PullRequestOverviewPanel } from './github/pullRequestOverview';
 import { RepositoriesManager } from './github/repositoriesManager';
 import { getIssuesUrl, getPullsUrl, isInCodespaces, vscodeDevPrLink } from './github/utils';
 import { PullRequestsTreeDataProvider } from './view/prsTreeDataProvider';
+import { ReviewCommentController } from './view/reviewCommentController';
 import { ReviewManager } from './view/reviewManager';
 import { CategoryTreeNode } from './view/treeNodes/categoryNode';
 import { CommitNode } from './view/treeNodes/commitNode';
@@ -1133,6 +1134,20 @@ export function registerCommands(
 			const githubRepo = await chooseRepoToOpen();
 			if (githubRepo) {
 				vscode.env.openExternal(getIssuesUrl(githubRepo));
+			}
+		}));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('pr.applySuggestion', async (comment: GHPRComment) => {
+			/* __GDPR__
+				"pr.applySuggestion" : {}
+			*/
+			telemetry.sendTelemetryEvent('pr.applySuggestion');
+
+			const handler = resolveCommentHandler(comment.parent);
+
+			if (handler instanceof ReviewCommentController) {
+				handler.applySuggestion(comment);
 			}
 		}));
 

--- a/src/github/prComment.ts
+++ b/src/github/prComment.ts
@@ -215,12 +215,34 @@ export class GHPRComment extends CommentBase {
 			contextValues.push('canDelete');
 		}
 
+		if (this.suggestion) {
+			contextValues.push('hasSuggestion');
+		}
+
 		this.contextValue = contextValues.join(',');
 		this.timestamp = new Date(comment.createdAt);
 	}
 
+	get suggestion(): string | undefined {
+		const suggestionBody = this.rawComment.body.match(/```suggestion(\n|\r\n)(.*)(\n|\r\n)```/);
+		if (suggestionBody?.length === 4) {
+			return suggestionBody[2];
+		}
+	}
+
 	public commentEditId() {
 		return this.commentId;
+	}
+
+	private replaceSuggestion(body: string) {
+		return body.replace(/```suggestion(\n|\r\n)(.*)(\n|\r\n)```/, (_substring: string, ...args: any[]) => {
+			return `***
+Suggested change:
+\`\`\`
+${args[1]}
+\`\`\`
+***`;
+		});
 	}
 
 	set body(body: string | vscode.MarkdownString) {
@@ -228,14 +250,18 @@ export class GHPRComment extends CommentBase {
 	}
 
 	get body(): string | vscode.MarkdownString {
-		if (this._rawBody instanceof vscode.MarkdownString) {
+		if (this.mode === vscode.CommentMode.Editing) {
 			return this._rawBody;
+		}
+		if (this._rawBody instanceof vscode.MarkdownString) {
+			return new vscode.MarkdownString(this.replaceSuggestion(this._rawBody.value));
 		}
 		const linkified = this._rawBody.replace(/([^\[]|^)\@([^\s]+)/, (substring) => {
 			const username = substring.substring(substring.startsWith('@') ? 1 : 2);
 			return `${substring.startsWith('@') ? '' : substring.charAt(0)}[@${username}](${path.dirname(this.rawComment.user!.url)}/${username})`;
 		});
-		return new vscode.MarkdownString(linkified);
+
+		return new vscode.MarkdownString(this.replaceSuggestion(linkified));
 	}
 
 	protected getCancelEditBody() {

--- a/src/view/reviewCommentController.ts
+++ b/src/view/reviewCommentController.ts
@@ -856,6 +856,22 @@ export class ReviewCommentController
 	}
 
 	// #endregion
+
+	async applySuggestion(comment: GHPRComment) {
+		const suggestion = comment.suggestion;
+		if (!suggestion) {
+			throw new Error('Comment doesn\'t contain a suggestion');
+		}
+		const range = comment.parent.range;
+		const editor = vscode.window.visibleTextEditors.find(editor => comment.parent.uri.toString() === editor.document.uri.toString());
+		if (!editor) {
+			throw new Error('Cannot find the editor to apply the suggestion to.');
+		}
+		await editor.edit(builder => {
+			builder.replace(range, suggestion);
+		});
+	}
+
 	public dispose() {
 		unregisterCommentHandler(this._commentHandlerId);
 		this._localToDispose.forEach(d => d.dispose());


### PR DESCRIPTION
Includes better rendering of `suggestion` blocks and an action to apply suggestions.
Adding suggestions requires VS Code API changes and will come in a separate PR.
Part of #603