### PR TITLE
Use correct permission to show 'assign yourself' in PR view sidebar

### DIFF
--- a/webviews/components/sidebar.tsx
+++ b/webviews/components/sidebar.tsx
@@ -84,7 +84,7 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 				) : (
 					<div className="section-placeholder">
 						None yet
-							{pr.hasWritePermission ? (
+						{pr.hasWritePermission ? (
 							<>
 								&mdash;
 								<a

--- a/webviews/components/sidebar.tsx
+++ b/webviews/components/sidebar.tsx
@@ -84,7 +84,7 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 				) : (
 					<div className="section-placeholder">
 						None yet
-						{pr.canEdit ? (
+							{pr.hasWritePermission ? (
 							<>
 								&mdash;
 								<a


### PR DESCRIPTION
Currently, a person that created a PR is able to see the 'assign yourself' link, even if the user doesn't have the permission to assign. As a result, the user sees an error message: "Must have admin rights to Repository."