### PR TITLE
Fix UI for PR draft status check entry

### DIFF
--- a/webviews/activityBarView/index.css
+++ b/webviews/activityBarView/index.css
@@ -38,11 +38,13 @@ textarea {
 	padding-bottom: 16px;
 }
 
-.ready-for-review-container .select-control {
-	padding-bottom: 16px;
+.ready-for-review-container {
+	display: flex;
+	flex-direction: column-reverse;
+	gap: 8px;
 }
 
-.ready-for-review-container p,
+.ready-for-review-heading,
 .status-section p {
 	line-height: 1.5em;
 	margin: 0;
@@ -52,14 +54,6 @@ textarea {
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-}
-
-.ready-for-review-button {
-	width: 100%;
-}
-
-.ready-for-review-container {
-	padding-bottom: 16px;
 }
 
 .select-control,

--- a/webviews/activityBarView/index.css
+++ b/webviews/activityBarView/index.css
@@ -41,7 +41,8 @@ textarea {
 .ready-for-review-container {
 	display: flex;
 	flex-direction: column-reverse;
-	gap: 8px;
+	gap: 12px;
+	padding-bottom: 16px;
 }
 
 .ready-for-review-heading,

--- a/webviews/activityBarView/index.css
+++ b/webviews/activityBarView/index.css
@@ -40,7 +40,7 @@ textarea {
 
 .ready-for-review-container {
 	display: flex;
-	flex-direction: column-reverse;
+	flex-direction: column;
 	gap: 12px;
 	padding-bottom: 16px;
 }

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -196,14 +196,16 @@ export const ReadyForReview = ({ isSimple }: { isSimple: boolean }) => {
 
 	return (
 		<div className="ready-for-review-container">
-			<div className="select-control">
-				<button className="ready-for-review-button" disabled={isBusy} onClick={markReadyForReview}>
-					Ready for review
-				</button>
+			<div className='ready-for-review-text-wrapper'>
+				<div className="ready-for-review-icon">{isSimple ? null : alertIcon}</div>
+				<div>
+					<div className="ready-for-review-heading">This pull request is still a work in progress.</div>
+					<div className="ready-for-review-meta">Draft pull requests cannot be merged.</div>
+				</div>
 			</div>
-			{isSimple ? '' : <div className="ready-for-review-icon">{alertIcon}</div>}
-			<p className="ready-for-review-heading">This pull request is still a work in progress.</p>
-			<p className="ready-for-review-meta">Draft pull requests cannot be merged.</p>
+			<div className="select-control">
+				<button disabled={isBusy} onClick={markReadyForReview}>Ready for review</button>
+			</div>
 		</div>
 	);
 };

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -203,7 +203,9 @@ export const ReadyForReview = ({ isSimple }: { isSimple: boolean }) => {
 					<div className="ready-for-review-meta">Draft pull requests cannot be merged.</div>
 				</div>
 			</div>
-			<button disabled={isBusy} onClick={markReadyForReview}>Ready for review</button>
+			<div className='button-container'>
+				<button disabled={isBusy} onClick={markReadyForReview}>Ready for review</button>
+			</div>
 		</div>
 	);
 };

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -203,9 +203,7 @@ export const ReadyForReview = ({ isSimple }: { isSimple: boolean }) => {
 					<div className="ready-for-review-meta">Draft pull requests cannot be merged.</div>
 				</div>
 			</div>
-			<div className="select-control">
-				<button disabled={isBusy} onClick={markReadyForReview}>Ready for review</button>
-			</div>
+			<button disabled={isBusy} onClick={markReadyForReview}>Ready for review</button>
 		</div>
 	);
 };

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -212,7 +212,8 @@ body .comment-container .review-comment-header {
 }
 
 .status-item,
-.form-actions {
+.form-actions,
+.ready-for-review-text-wrapper {
 	display: flex;
 	gap: 8px;
 	align-items: center;
@@ -238,12 +239,6 @@ body .comment-container .review-comment-header {
 	border-bottom-right-radius: 3px;
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
-}
-
-.ready-for-review-text-wrapper {
-	display: flex;
-	gap: 8px;
 	align-items: center;
 }
 

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -235,14 +235,20 @@ body .comment-container .review-comment-header {
 	background-color: var(--vscode-editorWidget-background);
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
-.ready-for-review-button {
-	float: right;
+.ready-for-review-text-wrapper {
+	display: flex;
+	gap: 8px;
+	align-items: center;
 }
 
 .ready-for-review-icon {
-	float: left;
+	width: 16px;
+	height: 16px;
 }
 
 .ready-for-review-heading {

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -215,6 +215,7 @@ body .comment-container .review-comment-header {
 .form-actions {
 	display: flex;
 	gap: 8px;
+	align-items: center;
 }
 
 .status-item-detail-text {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/46387399/209586853-535c7a14-4093-4a74-917a-855c66d6c046.png)

After:

![image](https://user-images.githubusercontent.com/46387399/209586803-a22eabdc-0374-4e0c-bdbe-6f48c9ffb4fb.png)

Without icon:

![image](https://user-images.githubusercontent.com/46387399/209586776-ffa662b2-1dde-4edb-806c-12cfe418089d.png)

This screenshot was taken before I figured out that the icon in the first row of status checks was misaligned.
