### PR TITLE
Remove unavailable badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ See our [wiki](https://github.com/Microsoft/vscode-pull-request-github/wiki) for
 
 ## Contributing
 
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/Microsoft/vscode-pull-request-github.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Microsoft/vscode-pull-request-github/alerts/)
-
 If you're interested in contributing, or want to explore the source code of this extension yourself, see our [contributing guide](https://github.com/Microsoft/vscode-pull-request-github/wiki/Contributing), which includes:
 
 - [How to Build and Run](https://github.com/Microsoft/vscode-pull-request-github/wiki/Contributing#build-and-run)


### PR DESCRIPTION
lgtm has shut down and the badge can't function anymore, so removing it 