### PR TITLE
Missing gap between label and dropdowns (macos)

### DIFF
--- a/webviews/createPullRequestView/index.css
+++ b/webviews/createPullRequestView/index.css
@@ -75,7 +75,7 @@ body {
 
 .input-label.combo-box {
 	margin-right: 2px;
-	min-width: 43px;
+	min-width: 48px;
 }
 
 .selector-group {


### PR DESCRIPTION
Fixes #4572