### PR TITLE
Make the display of PR number in tree view configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -509,6 +509,11 @@
 					],
 					"default": "firstDiff",
 					"description": "%githubPullRequests.focusedMode.description%"
+				},
+				"githubPullRequests.showPullRequestNumberInTree": {
+					"type": "boolean",
+					"default": false,
+					"description": "%githubPullRequests.showPullRequestNumberInTree.description%"
 				}
 			}
 		},

--- a/package.nls.json
+++ b/package.nls.json
@@ -110,6 +110,7 @@
 	"githubIssues.queries.default.recentIssues": "Recent Issues",
 	"githubIssues.assignWhenWorking.description": "Assigns the issue you're working on to you. Only applies when the issue you're working on is in a repo you currently have open.",
 	"githubPullRequests.focusedMode.description": "The layout to use when a pull request is checked out. Set to false to prevent layout changes.",
+	"githubPullRequests.showPullRequestNumberInTree.description": "Shows the pull request number in the tree view.",
 	"view.github.pull.request.name": "GitHub Pull Request",
 	"view.github.login.name": "Login",
 	"view.pr.github.name": "Pull Requests",

--- a/src/common/settingKeys.ts
+++ b/src/common/settingKeys.ts
@@ -22,6 +22,7 @@ export const CREATE_DRAFT = 'createDraft';
 export const QUICK_DIFF_EXP = 'experimental.quickDiff';
 export const QUICK_DIFF = 'quickDiff';
 export const SET_AUTO_MERGE = 'setAutoMerge';
+export const SHOW_PULL_REQUEST_NUMBER_IN_TREE = 'showPullRequestNumberInTree';
 
 // git
 export const GIT = 'git';

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -8,10 +8,10 @@ import { Repository } from '../../api/api';
 import { getCommentingRanges } from '../../common/commentingRanges';
 import { InMemFileChange, SlimFileChange } from '../../common/file';
 import Logger from '../../common/logger';
-import { FILE_LIST_LAYOUT } from '../../common/settingKeys';
+import { FILE_LIST_LAYOUT, PR_SETTINGS_NAMESPACE, SHOW_PULL_REQUEST_NUMBER_IN_TREE } from '../../common/settingKeys';
 import { createPRNodeUri, fromPRUri, Schemes } from '../../common/uri';
 import { dispose } from '../../common/utils';
-import { FolderRepositoryManager, SETTINGS_NAMESPACE } from '../../github/folderRepositoryManager';
+import { FolderRepositoryManager } from '../../github/folderRepositoryManager';
 import { NotificationProvider } from '../../github/notifications';
 import { IResolvedPullRequestModel, PullRequestModel } from '../../github/pullRequestModel';
 import { InMemFileChangeModel, RemoteFileChangeModel } from '../fileChangeModel';
@@ -53,6 +53,7 @@ export class PRNode extends TreeNode implements vscode.CommentingRangeProvider {
 	) {
 		super();
 		this.registerSinceReviewChange();
+		this.registerConfigurationChange();
 		this._disposables.push(this.pullRequestModel.onDidInvalidate(() => this.refresh(this)));
 	}
 
@@ -64,7 +65,7 @@ export class PRNode extends TreeNode implements vscode.CommentingRangeProvider {
 		try {
 			const descriptionNode = new DescriptionNode(
 				this,
-				vscode.l10n.t('Description'),
+				`${vscode.l10n.t('Description')} #${this.pullRequestModel.number}`,
 				new vscode.ThemeIcon('git-pull-request'),
 				this.pullRequestModel,
 				this.repository
@@ -89,7 +90,7 @@ export class PRNode extends TreeNode implements vscode.CommentingRangeProvider {
 			}
 
 			const result: TreeNode[] = [descriptionNode];
-			const layout = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE).get<string>(FILE_LIST_LAYOUT);
+			const layout = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<string>(FILE_LIST_LAYOUT);
 			if (layout === 'tree') {
 				// tree view
 				const dirNode = new DirectoryTreeNode(this, '');
@@ -127,6 +128,16 @@ export class PRNode extends TreeNode implements vscode.CommentingRangeProvider {
 		this._disposables.push(
 			this.pullRequestModel.onDidChangeChangesSinceReview(_ => {
 				if (!this.pullRequestModel.isActive) {
+					this.refresh();
+				}
+			})
+		);
+	}
+
+	protected registerConfigurationChange() {
+		this._disposables.push(
+			vscode.workspace.onDidChangeConfiguration(e => {
+				if (e.affectsConfiguration(`${PR_SETTINGS_NAMESPACE}.${SHOW_PULL_REQUEST_NUMBER_IN_TREE}`)) {
 					this.refresh();
 				}
 			})
@@ -273,9 +284,19 @@ export class PRNode extends TreeNode implements vscode.CommentingRangeProvider {
 
 		const hasNotification = this._notificationProvider.hasNotification(this.pullRequestModel);
 
-		const labelPrefix = currentBranchIsForThisPR ? '✓ ' : '';
-		const tooltipPrefix = currentBranchIsForThisPR ? 'Current Branch * ' : '';
 		const formattedPRNumber = number.toString();
+		let labelPrefix = currentBranchIsForThisPR ? '✓ ' : '';
+		let tooltipPrefix = currentBranchIsForThisPR ? 'Current Branch * ' : '';
+
+		if (
+			vscode.workspace
+				.getConfiguration(PR_SETTINGS_NAMESPACE)
+				.get<boolean>(SHOW_PULL_REQUEST_NUMBER_IN_TREE, false)
+		) {
+			labelPrefix += `#${formattedPRNumber}: `;
+			tooltipPrefix += `#${formattedPRNumber}: `;
+		}
+
 		const label = `${labelPrefix}${isDraft ? '[DRAFT] ' : ''}${title}`;
 		const tooltip = `${tooltipPrefix}${title} by @${login}`;
 		const description = `by @${login}`;

--- a/src/view/treeNodes/pullRequestNode.ts
+++ b/src/view/treeNodes/pullRequestNode.ts
@@ -65,7 +65,7 @@ export class PRNode extends TreeNode implements vscode.CommentingRangeProvider {
 		try {
 			const descriptionNode = new DescriptionNode(
 				this,
-				`${vscode.l10n.t('Description')} #${this.pullRequestModel.number}`,
+				vscode.l10n.t('Description'),
 				new vscode.ThemeIcon('git-pull-request'),
 				this.pullRequestModel,
 				this.repository


### PR DESCRIPTION
Closes #4463

~~Also updates the description node to always show the PR number, rather than just in the tooltip.~~