### PR TITLE
Allow empty labels array to be pushed to set-labels to remove all of them

### DIFF
--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -442,7 +442,7 @@ export class CreatePullRequestViewProvider extends WebviewViewBase implements vs
 			{ canPickMany: true },
 		);
 
-		if (labelsToAdd && labelsToAdd.length) {
+		if (labelsToAdd) {
 			const addedLabels: ILabel[] = labelsToAdd.map(label => newLabels.find(l => l.name === label.label)!);
 			this.labels = addedLabels;
 			this._postMessage({


### PR DESCRIPTION
This PR fixes #4634

If there are no checked labels from the quick pick menu, the command `set-labels`is not posted, preventing the possibility to remove all (the last one) selected labels.
I didn’t remove the if because `labelsToAdd` can be undefined if the menu is closed with esc, but the length control is causing the bug hence should be removed.