### PR TITLE
Allow empty array to be pushed to remove the last label

### DIFF
--- a/src/github/issueOverview.ts
+++ b/src/github/issueOverview.ts
@@ -250,7 +250,7 @@ export class IssueOverviewPanel<TItem extends IssueModel = IssueModel> extends W
 			const labelsToAdd = await Promise.race<readonly vscode.QuickPickItem[] | void>([acceptPromise, hidePromise]);
 			quickPick.busy = true;
 
-			if (labelsToAdd && labelsToAdd.length) {
+			if (labelsToAdd) {
 				await this._item.setLabels(labelsToAdd.map(r => r.label));
 				const addedLabels: ILabel[] = labelsToAdd.map(label => newLabels.find(l => l.name === label.label)!);
 


### PR DESCRIPTION
Pretty much the same as #4637 but in the PR description view.

Here is less debilitating though, because labels have the X button anyway (which already works fine)

![image](https://user-images.githubusercontent.com/7253929/226472012-e7c410a2-3490-4dc2-af54-4f27bc517f2d.png)
