### PR TITLE
Fix wrong repo URL for nested repos in workspace (fix copy permalink)

### DIFF
--- a/src/github/repositoriesManager.ts
+++ b/src/github/repositoriesManager.ts
@@ -151,7 +151,12 @@ export class RepositoriesManager implements vscode.Disposable {
 			return this._folderManagers[0];
 		}
 
-		for (const folderManager of this._folderManagers) {
+		// Prioritize longest path first to handle nested workspaces
+		const folderManagers = this._folderManagers
+			.slice()
+			.sort((a, b) => b.repository.rootUri.path.length - a.repository.rootUri.path.length);
+
+		for (const folderManager of folderManagers) {
 			const managerPath = folderManager.repository.rootUri.path;
 			const testUriRelativePath = uri.path.substring(
 				managerPath.length > 1 ? managerPath.length + 1 : managerPath.length,


### PR DESCRIPTION
For example I have workspace which contains git repos in below locations:

- /foo
- /foo/bar
- /foo/bar/baz
- /foo/qux

When I'm editing `/foo/bar/abc.tsx`, `getManagerForFile()` returns the Manager of `/foo`, not `/foo/bar`.
So I get wrong repo URL in "Copy GitHub permalink":

- Expected: `https://github.com/test-user/foo-bar/blob/...`
- Actual: `https://github.com/test-user/foo/blob/...`

With this PR, `getManagerForFile()` returns `/foo/bar` for above case.

Note this PR affects other features like issue number completion:

- Before this PR, it shows issues in root repo (`/foo`)
- After this PR it, shows issues in nested repo (`/foo/bar`)