### PR TITLE
Re-request review from one reviewer will remove other reviewers.

### DIFF
--- a/src/common/timelineEvent.ts
+++ b/src/common/timelineEvent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAccount } from '../github/interface';
+import { IAccount, IActor } from '../github/interface';
 import { IComment } from './comment';
 
 export enum EventType {
@@ -80,7 +80,7 @@ export interface NewCommitsSinceReviewEvent {
 export interface MergedEvent {
 	id: string;
 	graphNodeId: string;
-	user: IAccount;
+	user: IActor;
 	createdAt: string;
 	mergeRef: string;
 	sha: string;
@@ -93,13 +93,13 @@ export interface AssignEvent {
 	id: number;
 	event: EventType.Assigned;
 	user: IAccount;
-	actor: IAccount;
+	actor: IActor;
 }
 
 export interface HeadRefDeleteEvent {
 	id: string;
 	event: EventType.HeadRefDeleted;
-	actor: IAccount;
+	actor: IActor;
 	createdAt: string;
 	headRef: string;
 }

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -117,13 +117,13 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 	}
 
 	private reRequestReview(message: IRequestMessage<string>): void {
-		const reviewer = this._existingReviewers.find(reviewer => reviewerId(reviewer.reviewer) === message.args);
+		const reviewer = this._existingReviewers.find(reviewer => reviewer.reviewer.id === message.args);
 		const userReviewers: string[] = [];
 		const teamReviewers: string[] = [];
 		if (reviewer && isTeam(reviewer.reviewer)) {
 			teamReviewers.push(reviewer.reviewer.id);
 		} else if (reviewer && !isTeam(reviewer.reviewer)) {
-			userReviewers.push(reviewer.reviewer.login);
+			userReviewers.push(reviewer.reviewer.id);
 		}
 		this._item.requestReview(userReviewers, teamReviewers).then(() => {
 			if (reviewer) {
@@ -217,6 +217,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 						avatarUrl: pullRequest.userAvatar,
 						url: pullRequest.author.url,
 						email: pullRequest.author.email,
+						id: pullRequest.author.id
 					},
 					state: pullRequest.state,
 					isCurrentlyCheckedOut: isCurrentlyCheckedOut,

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -935,7 +935,10 @@ export class FolderRepositoryManager implements vscode.Disposable {
 	}
 
 	async getOrgTeamsCount(repository: GitHubRepository): Promise<number> {
-		return repository.getOrgTeamsCount();
+		if ((await repository.getMetadata()).organization) {
+			return repository.getOrgTeamsCount();
+		}
+		return 0;
 	}
 
 	async getPullRequestParticipants(githubRepository: GitHubRepository, pullRequestNumber: number): Promise<{ participants: IAccount[], viewer: IAccount }> {

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -971,6 +971,7 @@ export class GitHubRepository implements vscode.Disposable {
 							name: node.name,
 							url: node.url,
 							email: node.email,
+							id: node.id
 						};
 					}),
 				);
@@ -1014,6 +1015,7 @@ export class GitHubRepository implements vscode.Disposable {
 							name: node.name,
 							url: node.url,
 							email: node.email,
+							id: node.id
 						};
 					}),
 				);
@@ -1151,6 +1153,7 @@ export class GitHubRepository implements vscode.Disposable {
 						name: node.name,
 						url: node.url,
 						email: node.email,
+						id: node.id
 					};
 				}),
 			);

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -42,7 +42,8 @@ export interface AbbreviatedIssueComment {
 		login: string;
 		avatarUrl: string;
 		url: string;
-		email?: string
+		email?: string;
+		id: string;
 	};
 	body: string;
 	databaseId: number;
@@ -75,6 +76,7 @@ export interface Account {
 	name: string;
 	url: string;
 	email: string;
+	id: string;
 }
 
 interface Team {
@@ -99,6 +101,7 @@ export interface ReviewComment {
 		login: string;
 		avatarUrl: string;
 		url: string;
+		id: string;
 	};
 	path: string;
 	originalPosition: number;
@@ -134,6 +137,7 @@ export interface Commit {
 				login: string;
 				avatarUrl: string;
 				url: string;
+				id: string;
 			};
 		};
 		committer: {
@@ -160,6 +164,7 @@ export interface AssignedEvent {
 		login: string;
 		avatarUrl: string;
 		url: string;
+		id: string;
 	};
 }
 
@@ -173,6 +178,7 @@ export interface Review {
 		login: string;
 		avatarUrl: string;
 		url: string;
+		id: string;
 	};
 	state: 'COMMENTED' | 'APPROVED' | 'CHANGES_REQUESTED' | 'PENDING';
 	body: string;
@@ -254,7 +260,7 @@ export interface GetReviewRequestsResponse {
 						email?: string;
 						// Team properties
 						slug?: string;
-						id?: string;
+						id: string;
 					} | null;
 				}[];
 			};
@@ -489,6 +495,7 @@ export interface SuggestedReviewerResponse {
 		avatarUrl: string;
 		name: string;
 		url: string;
+		id: string;
 	};
 }
 
@@ -508,12 +515,14 @@ export interface PullRequest {
 			url: string;
 			email: string;
 			avatarUrl: string;
+			id: string;
 		}[];
 	};
 	author: {
 		login: string;
 		url: string;
 		avatarUrl: string;
+		id: string;
 	};
 	comments?: {
 		nodes: AbbreviatedIssueComment[];
@@ -689,6 +698,7 @@ export interface UserResponse {
 		name: string;
 		contributionsCollection: ContributionsCollection;
 		url: string;
+		id: string;
 	};
 }
 

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -34,8 +34,15 @@ export interface ReviewState {
 	state: string;
 }
 
-export interface IAccount {
+export interface IActor {
 	login: string;
+	avatarUrl?: string;
+	url: string;
+}
+
+export interface IAccount extends IActor {
+	login: string;
+	id: string;
 	name?: string;
 	avatarUrl?: string;
 	url: string;
@@ -55,12 +62,12 @@ export function reviewerId(reviewer: ITeam | IAccount): string {
 	return isTeam(reviewer) ? reviewer.id : reviewer.login;
 }
 
-export function reviewerLabel(reviewer: ITeam | IAccount): string {
+export function reviewerLabel(reviewer: ITeam | IAccount | IActor): string {
 	return isTeam(reviewer) ? (reviewer.name ?? reviewer.slug) : reviewer.login;
 }
 
-export function isTeam(reviewer: ITeam | IAccount): reviewer is ITeam {
-	return 'id' in reviewer;
+export function isTeam(reviewer: ITeam | IAccount | IActor): reviewer is ITeam {
+	return 'org' in reviewer;
 }
 
 export interface ISuggestedReviewer extends IAccount {

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -788,7 +788,8 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 					url: reviewer.requestedReviewer.url,
 					avatarUrl: getAvatarWithEnterpriseFallback(reviewer.requestedReviewer.avatarUrl, undefined, remote.isEnterprise),
 					email: reviewer.requestedReviewer.email,
-					name: reviewer.requestedReviewer.name
+					name: reviewer.requestedReviewer.name,
+					id: reviewer.requestedReviewer.id
 				};
 				reviewers.push(account);
 			} else if (reviewer.requestedReviewer) {
@@ -811,22 +812,17 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 	 * @param reviewers A list of GitHub logins
 	 */
 	async requestReview(reviewers: string[], teamReviewers: string[]): Promise<void> {
-		const { octokit, mutate, schema, remote } = await this.githubRepository.ensure();
-		await Promise.all([mutate({
+		const { mutate, schema } = await this.githubRepository.ensure();
+		await mutate({
 			mutation: schema.AddReviewers,
 			variables: {
 				input: {
 					pullRequestId: this.graphNodeId,
 					teamIds: teamReviewers,
+					userIds: reviewers
 				},
 			},
-		}),
-		octokit.call(octokit.api.pulls.requestReviewers, {
-			owner: remote.owner,
-			repo: remote.repositoryName,
-			pull_number: this.number,
-			reviewers,
-		})]);
+		});
 	}
 
 	/**

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -593,7 +593,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				const newTeamReviewers: string[] = [];
 				allReviewers.forEach(reviewer => {
 					const newReviewers = isTeam(reviewer.reviewer) ? newTeamReviewers : newUserReviewers;
-					newReviewers.push(reviewerId(reviewer.reviewer));
+					newReviewers.push(reviewer.reviewer.id);
 				});
 
 				const removedUserReviewers: string[] = [];
@@ -601,8 +601,8 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				this._existingReviewers.forEach(existing => {
 					let newReviewers: string[] = isTeam(existing.reviewer) ? newTeamReviewers : newUserReviewers;
 					let removedReviewers: string[] = isTeam(existing.reviewer) ? removedTeamReviewers : removedUserReviewers;
-					if (!newReviewers.find(newTeamReviewer => newTeamReviewer === reviewerId(existing.reviewer))) {
-						removedReviewers.push(reviewerId(existing.reviewer));
+					if (!newReviewers.find(newTeamReviewer => newTeamReviewer === existing.reviewer.id)) {
+						removedReviewers.push(existing.reviewer.id);
 					}
 				});
 
@@ -992,7 +992,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 				id = reviewer.reviewer.id;
 				reviewerArray = teamReviewers;
 			} else if (reviewer && !isTeam(reviewer.reviewer)) {
-				id = reviewer.reviewer.login;
+				id = reviewer.reviewer.id;
 				reviewerArray = userReviewers;
 			}
 			if (reviewerArray && id && ((reviewer.state === 'REQUESTED') || (id === message.args))) {

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -55,9 +55,11 @@ fragment Comment on IssueComment {
 		url
 		... on User {
 			email
+			id
 		}
 		... on Organization {
 			email
+			id
 		}
 	}
 	url
@@ -77,6 +79,7 @@ fragment Commit on PullRequestCommit {
 			user {
 				login
 				avatarUrl
+				id
 				url
 				email
 			}
@@ -102,6 +105,7 @@ fragment AssignedEvent on AssignedEvent {
 	user {
 		login
 		avatarUrl
+		id
 		url
 	}
 }
@@ -117,9 +121,11 @@ fragment Review on PullRequestReview {
 		url
 		... on User {
 			email
+			id
 		}
 		... on Organization {
 			email
+			id
 		}
 	}
 	state
@@ -193,9 +199,11 @@ fragment PullRequestFragment on PullRequest {
 		avatarUrl
 		... on User {
 			email
+			id
 		}
 		... on Organization {
 			email
+			id
 		}
 	}
 	createdAt
@@ -252,6 +260,7 @@ fragment PullRequestFragment on PullRequest {
 			login
 			name
 			avatarUrl
+			id
 			url
 			email
 		}
@@ -262,6 +271,7 @@ fragment PullRequestFragment on PullRequest {
 		reviewer {
 			login
 			avatarUrl
+			id
 			name
 			url
 		}
@@ -395,6 +405,7 @@ query GetReviewRequestsAdditionalScopes($owner: String!, $name: String!, $number
 						... on User {
 							login
 							avatarUrl
+							id
 							url
 							email
 							name
@@ -422,6 +433,7 @@ query GetReviewRequests($owner: String!, $name: String!, $number: Int!) {
 						... on User {
 							login
 							avatarUrl
+							id
 							url
 							email
 							name
@@ -443,9 +455,11 @@ fragment ReviewComment on PullRequestReviewComment {
 		url
 		... on User {
 			email
+			id
 		}
 		... on Organization {
 			email
+			id
 		}
 	}
 	path
@@ -486,6 +500,7 @@ query GetParticipants($owner: String!, $name: String!, $number: Int!, $first: In
 				nodes {
 					login
 					avatarUrl
+					id
 					name
 					url
 					email
@@ -604,6 +619,7 @@ query Viewer {
 	viewer {
 		login
 		avatarUrl
+		id
 		name
 		url
 		email
@@ -668,9 +684,11 @@ query Issue($owner: String!, $name: String!, $number: Int!) {
 				avatarUrl
 				... on User {
 					email
+					id
 				}
 				... on Organization {
 					email
+					id
 				}
 			}
 			createdAt
@@ -708,9 +726,11 @@ query IssueWithComments($owner: String!, $name: String!, $number: Int!) {
 				avatarUrl
 				... on User {
 					email
+					id
 				}
 				... on Organization {
 					email
+					id
 				}
 			}
 			createdAt
@@ -731,9 +751,11 @@ query IssueWithComments($owner: String!, $name: String!, $number: Int!) {
 						avatarUrl
 						... on User {
 							email
+							id
 						}
 						... on Organization {
 							email
+							id
 						}
 					}
 					body
@@ -754,6 +776,7 @@ query GetUser($login: String!) {
 	user(login: $login) {
 		login
 		avatarUrl(size: 50)
+		id
 		bio
 		name
 		company
@@ -977,6 +1000,7 @@ query GetMentionableUsers($owner: String!, $name: String!, $first: Int!, $after:
 				name
 				url
 				email
+				id
 			}
 			pageInfo {
 				hasNextPage
@@ -1001,6 +1025,7 @@ query GetAssignableUsers($owner: String!, $name: String!, $first: Int!, $after: 
 				name
 				url
 				email
+				id
 			}
 			pageInfo {
 				hasNextPage
@@ -1180,6 +1205,7 @@ query GetMilestonesWithIssues($owner: String!, $name: String!, $assignee: String
 										email
 										login
 										url
+										id
 									}
 								}
 								author {
@@ -1188,9 +1214,11 @@ query GetMilestonesWithIssues($owner: String!, $name: String!, $assignee: String
 									avatarUrl(size: 50)
 									... on User {
 										email
+										id
 									}
 									... on Organization {
 										email
+										id
 									}
 								}
 								createdAt
@@ -1248,6 +1276,7 @@ query Issues($query: String!) {
 							email
 							login
 							url
+							id
 						}
 					}
 					author {
@@ -1256,9 +1285,11 @@ query Issues($query: String!) {
 						avatarUrl(size: 50)
 						... on User {
 							email
+							id
 						}
 						... on Organization {
 							email
+							id
 						}
 					}
 					createdAt

--- a/src/test/builders/graphql/pullRequestBuilder.ts
+++ b/src/test/builders/graphql/pullRequestBuilder.ts
@@ -50,6 +50,7 @@ export const PullRequestBuilder = createBuilderClass<PullRequestResponse>()({
 							email: undefined,
 							login: 'me',
 							url: 'https://github.com/me',
+							id: '123'
 						},
 					],
 				},
@@ -58,6 +59,7 @@ export const PullRequestBuilder = createBuilderClass<PullRequestResponse>()({
 				login: { default: 'me' },
 				url: { default: 'https://github.com/me' },
 				avatarUrl: { default: 'https://avatars3.githubusercontent.com/u/17565?v=4' },
+				id: { default: '123' },
 			}),
 			createdAt: { default: '2019-01-01T10:00:00Z' },
 			updatedAt: { default: '2019-01-01T11:00:00Z' },

--- a/src/test/view/reviewCommentController.test.ts
+++ b/src/test/view/reviewCommentController.test.ts
@@ -202,6 +202,7 @@ describe('ReviewCommentController', function () {
 		sinon.stub(manager, 'getCurrentUser').returns(Promise.resolve({
 			login: 'rmacfarlane',
 			url: 'https://github.com/rmacfarlane',
+			id: '123'
 		}));
 
 		sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns({
@@ -240,6 +241,7 @@ describe('ReviewCommentController', function () {
 			sinon.stub(manager, 'getCurrentUser').returns(Promise.resolve({
 				login: 'rmacfarlane',
 				url: 'https://github.com/rmacfarlane',
+				id: '123'
 			}));
 
 			sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns({

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -160,8 +160,8 @@ export class PRContext {
 		this.updatePR(state);
 	}
 
-	public reRequestReview = async (reviewerLogin: string) => {
-		const { reviewers } = await this.postMessage({ command: 'pr.re-request-review', args: reviewerLogin });
+	public reRequestReview = async (reviewerId: string) => {
+		const { reviewers } = await this.postMessage({ command: 'pr.re-request-review', args: reviewerId });
 		const state = this.pr;
 		state.reviewers = reviewers;
 		this.updatePR(state);

--- a/webviews/components/reviewer.tsx
+++ b/webviews/components/reviewer.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import React, { cloneElement, useContext } from 'react';
-import { reviewerId, ReviewState } from '../../src/github/interface';
+import {  ReviewState } from '../../src/github/interface';
 import PullRequestContext from '../common/context';
 import { checkIcon, commentIcon, pendingIcon, requestChanges, syncIcon } from './icon';
 import { AuthorLink, Avatar } from './user';
@@ -21,7 +21,7 @@ export function Reviewer(reviewState: ReviewState) {
 			<div className="reviewer-icons">
 				{
 					state !== 'REQUESTED' ?
-						(<button className="icon-button" title="Re-request review" onClick={() => reRequestReview(reviewerId(reviewState.reviewer))}>
+						(<button className="icon-button" title="Re-request review" onClick={() => reRequestReview(reviewState.reviewer.id)}>
 							{syncIcon}️
 						</button>) : null
 				}

--- a/webviews/components/user.tsx
+++ b/webviews/components/user.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react';
-import { IAccount, ITeam, reviewerLabel } from '../../src/github/interface';
+import { IAccount, IActor, ITeam, reviewerLabel } from '../../src/github/interface';
 import { Icon } from './icon';
 
 export const Avatar = ({ for: author }: { for: Partial<IAccount> }) => (
@@ -17,7 +17,7 @@ export const Avatar = ({ for: author }: { for: Partial<IAccount> }) => (
 	</a>
 );
 
-export const AuthorLink = ({ for: author, text = reviewerLabel(author) }: { for: IAccount | ITeam; text?: string }) => (
+export const AuthorLink = ({ for: author, text = reviewerLabel(author) }: { for: IActor | ITeam; text?: string }) => (
 	<a className="author-link" href={author.url} title={author.url}>
 		{text}
 	</a>

--- a/webviews/editorWebview/test/builder/account.ts
+++ b/webviews/editorWebview/test/builder/account.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { IAccount } from '../../../../src/github/interface';
 import { createBuilderClass } from '../../../../src/test/builders/base';
 
@@ -6,4 +11,5 @@ export const AccountBuilder = createBuilderClass<IAccount>()({
 	name: { default: 'Myself' },
 	avatarUrl: { default: 'https://avatars3.githubusercontent.com/u/17565?v=4' },
 	url: { default: 'https://github.com/me' },
+	id: { default: '123' }
 });


### PR DESCRIPTION
Not sure why the REST API has this unexpected behavior. I didn't want to change to the GraphQL API initially because the `id` property needed to be added, but it works great for setting reviewers.
Fixes #4830, #4836