### PR TITLE
Disable scheduled pre-release out of main

### DIFF
--- a/azure-pipeline.nightly.yml
+++ b/azure-pipeline.nightly.yml
@@ -2,13 +2,13 @@
 trigger: none
 pr: none
 
-schedules:
-  - cron: '0 9 * * Mon-Thu'
-    displayName: Nightly Release Schedule
-    always: true
-    branches:
-      include:
-        - main
+# schedules:
+#   - cron: '0 9 * * Mon-Thu'
+#     displayName: Nightly Release Schedule
+#     always: true
+#     branches:
+#       include:
+#         - main
 
 resources:
   repositories:

--- a/documentation/releasing.md
+++ b/documentation/releasing.md
@@ -28,3 +28,5 @@
     - Upload .vsix, which can be downloaded from the release pipeline
     - Preview release
     - **Publish** release
+
+9. If the nightly pre-release build was disable, re-enable in in https://github.com/microsoft/vscode-pull-request-github/blob/c6f00d59fb99c7807bfb963f55926505bdb723ef/azure-pipeline.nightly.yml


### PR DESCRIPTION
We now have more people working in this repo, so it's easier to branch for release during endgame rather ask everyone to hold off on changes while we stabilize.
To that end, I've branched for release (`release/0.68`) and with this PR the nightly pre-release build out of `main` will be disabled. This will need to be re-enabled after release.