### PR TITLE
a11y: Shorten separator label

### DIFF
--- a/webviews/createPullRequestViewNew/app.tsx
+++ b/webviews/createPullRequestViewNew/app.tsx
@@ -265,7 +265,7 @@ export function main() {
 									onChange={onCreateButton}>
 									{createMethodOption()}
 									{createMethodOption(true)}
-									{params.allowAutoMerge ? <option disabled>&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</option> : null}
+									{params.allowAutoMerge ? <option disabled aria-hidden='true'>&mdash;</option> : null}
 									{params.allowAutoMerge && params.mergeMethodsAvailability && params.mergeMethodsAvailability['merge'] ? createMethodOption(false, true, 'merge') : null}
 									{params.allowAutoMerge && params.mergeMethodsAvailability && params.mergeMethodsAvailability['squash'] ? createMethodOption(false, true, 'squash') : null}
 									{params.allowAutoMerge && params.mergeMethodsAvailability && params.mergeMethodsAvailability['rebase'] ? createMethodOption(false, true, 'rebase') : null}


### PR DESCRIPTION
VoiceOver was reading out all the dashes. This looks ok until we investigate using a real menu.

<img width="415" alt="image" src="https://github.com/microsoft/vscode-pull-request-github/assets/103326/eec79366-f9f3-441e-a149-dbac453fb686">
