### PR TITLE
Sanitize slashes from title

### DIFF
--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -1166,7 +1166,7 @@ export function getIssuesUrl(repo: GitHubRepository) {
 }
 
 export function sanitizeIssueTitle(title: string): string {
-	const regex = /[~^:;'".,~#?%*[\]@\\{}()]|\/\//g;
+	const regex = /[~^:;'".,~#?%*[\]@\\{}()/]|\/\//g;
 
 	return title.replace(regex, '').trim().substring(0, 150).replace(/\s+/g, '-');
 }


### PR DESCRIPTION
Remove slashes from title. A slash will cause many git UIs to nest the branch, which probably isnt wanted?

Fixes #5154