### PR TITLE
Only show error on internal API limit on enterprise

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -416,7 +416,7 @@ export class CredentialStore implements vscode.Disposable {
 			},
 		});
 
-		const rateLogger = new RateLogger(this._telemetry);
+		const rateLogger = new RateLogger(this._telemetry, isEnterprise(authProviderId));
 		const github: GitHub = {
 			octokit: new LoggingOctokit(octokit, rateLogger),
 			graphql: new LoggingApolloClient(graphql, rateLogger),

--- a/src/test/mocks/mockGitHubRepository.ts
+++ b/src/test/mocks/mockGitHubRepository.ts
@@ -31,7 +31,7 @@ export class MockGitHubRepository extends GitHubRepository {
 		this.queryProvider = new QueryProvider(sinon);
 
 		this._hub = {
-			octokit: new LoggingOctokit(this.queryProvider.octokit, new RateLogger(new MockTelemetry())),
+			octokit: new LoggingOctokit(this.queryProvider.octokit, new RateLogger(new MockTelemetry(), true)),
 			graphql: null,
 		};
 

--- a/src/test/view/prsTree.test.ts
+++ b/src/test/view/prsTree.test.ts
@@ -56,7 +56,7 @@ describe('GitHub Pull Requests view', function () {
 					baseUrl: 'https://github.com',
 					userAgent: 'GitHub VSCode Pull Requests',
 					previews: ['shadow-cat-preview'],
-				}), new RateLogger(telemetry)),
+				}), new RateLogger(telemetry, true)),
 				graphql: null,
 			};
 


### PR DESCRIPTION
We've had too many false positives. We'll still get the telemetry for floods, but we shouldn't keep erroring when it happens when it's not actually a problem
Fixes #4813