### PR TITLE
create: Fix bottom spacing

### DIFF
--- a/webviews/createPullRequestViewNew/index.css
+++ b/webviews/createPullRequestViewNew/index.css
@@ -221,8 +221,8 @@ textarea {
 .group-actions {
 	display: flex;
 	gap: 8px;
-	margin-top: 10px;
-	margin-bottom: 20px;
+	padding-top: 10px;
+	padding-bottom: 20px;
 	width: 100%;
 }
 


### PR DESCRIPTION
The bottom spacing below the Cancel/Create buttons was collapsing when the viewport height got small. Using padding instead of margin fixes this.

Fixes #5239