### PR TITLE
Editor not opening when selecting file in commits view

### DIFF
--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -446,7 +446,7 @@ export class GitHubFileChangeNode extends TreeNode implements vscode.TreeItem {
 		});
 
 		let parentURI = vscode.Uri.file(fileName).with({
-			scheme: Schemes.GithubPr,
+			scheme,
 			query: JSON.stringify({ fileName, branch: baseBranch }),
 		});
 		let headURI = vscode.Uri.file(fileName).with({
@@ -456,14 +456,14 @@ export class GitHubFileChangeNode extends TreeNode implements vscode.TreeItem {
 		switch (status) {
 			case GitChangeType.ADD:
 				parentURI = vscode.Uri.file(fileName).with({
-					scheme: Schemes.GithubPr,
+					scheme,
 					query: JSON.stringify({ fileName, branch: baseBranch, isEmpty: true }),
 				});
 				break;
 
 			case GitChangeType.RENAME:
 				parentURI = vscode.Uri.file(previousFileName!).with({
-					scheme: Schemes.GithubPr,
+					scheme,
 					query: JSON.stringify({ fileName: previousFileName, branch: baseBranch, isEmpty: true }),
 				});
 				break;


### PR DESCRIPTION
The content of parent URI of each file was comming from github, not git.  This worked for the file view, but not the commits view as there will be commits in the commits view that aren't available on github.
Fixes #5288