### PR TITLE
Fix padding in editorWebview

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -1076,6 +1076,7 @@ code {
 		column-gap: 20px;
 		grid-template-columns: 50% 50%;
 		padding: 0;
+		padding-bottom: 24px;
 	}
 
 	.section-content {


### PR DESCRIPTION
This pull request fixes the padding issue in the editorWebview by adding a bottom padding of 24px. The changes are contained in the file index.css. 
Fixes #5360.