### PR TITLE
Add naive undo of sparkle action

### DIFF
--- a/webviews/common/createContextNew.ts
+++ b/webviews/common/createContextNew.ts
@@ -30,6 +30,8 @@ const defaultCreateParams: CreateParamsNew = {
 
 export class CreatePRContextNew {
 	public createParams: CreateParamsNew;
+	private _titleStack: string[] = [];
+	private _descriptionStack: string[] = [];
 
 	constructor(
 		public onchange: ((ctx: CreateParamsNew) => void) | null = null,
@@ -138,6 +140,12 @@ export class CreatePRContextNew {
 		if (response.description) {
 			updateValues.pendingDescription = response.description;
 		}
+		if (updateValues.pendingTitle && this.createParams.pendingTitle && this.createParams.pendingTitle !== updateValues.pendingTitle) {
+			this._titleStack.push(this.createParams.pendingTitle);
+		}
+		if (updateValues.pendingDescription && this.createParams.pendingDescription && this.createParams.pendingDescription !== updateValues.pendingDescription) {
+			this._descriptionStack.push(this.createParams.pendingDescription);
+		}
 		this.updateState(updateValues);
 	};
 
@@ -146,6 +154,18 @@ export class CreatePRContextNew {
 			command: 'pr.cancelGenerateTitleAndDescription'
 		});
 	};
+
+	public popTitle = (): void => {
+		if (this._titleStack.length > 0) {
+			this.updateState({ pendingTitle: this._titleStack.pop() });
+		}
+	};
+
+	public popDescription = (): void => {
+		if (this._descriptionStack.length > 0) {
+			this.updateState({ pendingDescription: this._descriptionStack.pop() });
+		}
+	}
 
 	public validate = (): boolean => {
 		let isValid = true;

--- a/webviews/createPullRequestViewNew/app.tsx
+++ b/webviews/createPullRequestViewNew/app.tsx
@@ -89,11 +89,16 @@ export function main() {
 					isCreateable = false;
 				}
 
-				const onKeyDown = useCallback(
-					e => {
+				const onKeyDown = useCallback((isTitle: boolean, e) => {
 						if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
 							e.preventDefault();
 							create();
+						} else if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
+							if (isTitle) {
+								ctx.popTitle();
+							} else {
+								ctx.popDescription();
+							}
 						}
 					},
 					[create],
@@ -217,7 +222,7 @@ export function main() {
 							title='Required'
 							required
 							onChange={(e) => updateTitle(e.currentTarget.value)}
-							onKeyDown={onKeyDown}
+							onKeyDown={(e) => onKeyDown(true, e)}
 							data-vscode-context='{"preventDefaultContextMenuItems": false}'
 							disabled={!ctx.initialized || isBusy}>
 						</input>
@@ -300,7 +305,7 @@ export function main() {
 							aria-label='Description'
 							value={params.pendingDescription}
 							onChange={(e) => ctx.updateState({ pendingDescription: e.currentTarget.value })}
-							onKeyDown={onKeyDown}
+							onKeyDown={(e) => onKeyDown(false, e)}
 							data-vscode-context='{"preventDefaultContextMenuItems": false}'
 							disabled={!ctx.initialized || isBusy}></textarea>
 					</div>


### PR DESCRIPTION
This pull request adds a naive undo feature for the sparkle action. The `CreatePRContextNew` class now has two new methods, `popTitle` and `popDescription`, which allow the user to undo changes made to the title and description fields respectively. 