### PR TITLE
Use unique ID and title for PR comments controllers

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -158,7 +158,7 @@ export class GitHubRepository implements vscode.Disposable {
 
 			await this.ensure();
 			this.commentsController = vscode.comments.createCommentController(
-				`github-browse-${this.remote.normalizedHost}`,
+				`github-browse-${this.remote.normalizedHost}-${this.remote.owner}-${this.remote.repositoryName}`,
 				`GitHub Pull Request for ${this.remote.normalizedHost}`,
 			);
 			this.commentsHandler = new PRCommentControllerRegistry(this.commentsController);

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -159,7 +159,7 @@ export class GitHubRepository implements vscode.Disposable {
 			await this.ensure();
 			this.commentsController = vscode.comments.createCommentController(
 				`github-browse-${this.remote.normalizedHost}-${this.remote.owner}-${this.remote.repositoryName}`,
-				`GitHub Pull Request for ${this.remote.normalizedHost}`,
+				`GitHub Pull Request for ${this.remote.normalizedHost} (${this.remote.owner}/${this.remote.repositoryName})`,
 			);
 			this.commentsHandler = new PRCommentControllerRegistry(this.commentsController);
 			this._toDispose.push(this.commentsHandler);


### PR DESCRIPTION
This pull request fixes issue #5317 by updating the comments controller in `githubRepository.ts` to use a unique ID and title. The ID now includes the repository owner and name, and the title includes the normalized host, owner, and repository name. This ensures that the comments controller is unique.