### PR TITLE
Add org projects to list of projects in repository view

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -365,7 +365,7 @@ export class CredentialStore implements vscode.Disposable {
 	}
 
 	private async findExistingScopes(authProviderId: AuthProvider): Promise<{ session: vscode.AuthenticationSession, scopes: string[] } | undefined> {
-		const scopesInPreferenceOrder = [SCOPES_WITH_ADDITIONAL, SCOPES, SCOPES_OLD, SCOPES_OLDEST];
+		const scopesInPreferenceOrder = [SCOPES_WITH_ADDITIONAL, SCOPES_OLD, SCOPES_OLDEST];
 		for (const scopes of scopesInPreferenceOrder) {
 			const session = await vscode.authentication.getSession(authProviderId, scopes, { silent: true });
 			if (session) {

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -29,7 +29,6 @@ const PROMPT_FOR_SIGN_IN_STORAGE_KEY = 'login';
 // If the scopes are changed, make sure to notify all interested parties to make sure this won't cause problems.
 const SCOPES_OLDEST = ['read:user', 'user:email', 'repo'];
 const SCOPES_OLD = ['read:user', 'user:email', 'repo', 'workflow'];
-const SCOPES = ['read:user', 'user:email', 'repo', 'workflow', 'project'];
 const SCOPES_WITH_ADDITIONAL = ['read:user', 'user:email', 'repo', 'workflow', 'project', 'read:org'];
 
 const LAST_USED_SCOPES_GITHUB_KEY = 'githubPullRequest.lastUsedScopes';
@@ -238,9 +237,9 @@ export class CredentialStore implements vscode.Disposable {
 
 	public areScopesOld(authProviderId: AuthProvider): boolean {
 		if (!isEnterprise(authProviderId)) {
-			return !this.allScopesIncluded(this._scopes, SCOPES);
+			return !this.allScopesIncluded(this._scopes, SCOPES_OLD);
 		}
-		return !this.allScopesIncluded(this._scopesEnterprise, SCOPES);
+		return !this.allScopesIncluded(this._scopesEnterprise, SCOPES_OLD);
 	}
 
 	public async getHubEnsureAdditionalScopes(authProviderId: AuthProvider): Promise<GitHub | undefined> {

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -619,6 +619,18 @@ export interface RepoProjectsResponse {
 	}
 }
 
+export interface OrgProjectsResponse {
+	organization: {
+		projectsV2: {
+			nodes: {
+				title: string;
+				id: string;
+			}[];
+			pageInfo: PageInfo;
+		}
+	}
+}
+
 export interface MilestoneIssuesResponse {
 	repository: {
 		milestones: {

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -156,6 +156,21 @@ query GetRepoProjects($owner: String!, $name: String!) {
 	}
 }
 
+query GetOrgProjects($owner: String!, $after: String) {
+	organization(login: $owner) {
+		projectsV2(first: 100, after: $after, query: "state:OPEN", orderBy: { field: UPDATED_AT, direction: DESC }) {
+			nodes {
+				title
+				id
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}
+}
+
 mutation AddPullRequestToProject($input: AddProjectV2ItemByIdInput!) {
 	addProjectV2ItemById(input: $input) {
 		item {


### PR DESCRIPTION
This pull request adds the ability to view organization projects in addition to repository projects in the project list view. The `getOrgProjects` method was added to fetch the organization projects and the `getProjects` method was updated to include the organization projects in the returned list. 
Fixes #5393.