### PR TITLE
Fix error notification when signing in with more permissions

### DIFF
--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -268,6 +268,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 					reviewers: this._existingReviewers,
 					continueOnGitHub,
 					isDarkTheme: vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark,
+					isEnterprise: pullRequest.githubRepository.remote.isEnterprise,
 					hasReviewDraft
 				};
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -266,7 +266,8 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 					continueOnGitHub,
 					isAuthor: currentUser.login === pullRequest.author.login,
 					currentUserReviewState: reviewState,
-					isDarkTheme: vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
+					isDarkTheme: vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark,
+					isEnterprise: pullRequest.githubRepository.remote.isEnterprise
 				};
 				this._postMessage({
 					command: 'pr.initialize',

--- a/src/github/views.ts
+++ b/src/github/views.ts
@@ -74,6 +74,7 @@ export interface PullRequest {
 	continueOnGitHub: boolean;
 	currentUserReviewState: string;
 	isDarkTheme: boolean;
+	isEnterprise: boolean;
 	hasReviewDraft: boolean;
 
 	lastReviewType?: ReviewType;

--- a/webviews/components/sidebar.tsx
+++ b/webviews/components/sidebar.tsx
@@ -135,26 +135,28 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 					<div className="section-placeholder">None yet</div>
 				)}
 			</div>
-			<div id="project" className="section">
-				<div className="section-header" onClick={updateProjects}>
-					<div className="section-title">Project</div>
-					{hasWritePermission ? (
-						<button
-							className="icon-button"
-							title="Add Project">
-							{settingsIcon}
-						</button>
-					) : null}
+			{pr.isEnterprise ? null :
+				<div id="project" className="section">
+					<div className="section-header" onClick={updateProjects}>
+						<div className="section-title">Project</div>
+						{hasWritePermission ? (
+							<button
+								className="icon-button"
+								title="Add Project">
+								{settingsIcon}
+							</button>
+						) : null}
+					</div>
+					{!projects ?
+						<a onClick={updateProjects}>Sign in with more permissions to see projects</a>
+						: (projects.length > 0)
+							? projects.map(project => (
+								<Project key={project.project.title} {...project} canDelete={hasWritePermission} />
+							)) :
+							<div className="section-placeholder">None Yet</div>
+					}
 				</div>
-				{!projects ?
-					<a onClick={updateProjects}>Sign in with more permissions to see projects</a>
-					: (projects.length > 0)
-						? projects.map(project => (
-							<Project key={project.project.title} {...project} canDelete={hasWritePermission} />
-						)) :
-						<div className="section-placeholder">None Yet</div>
-				}
-			</div>
+			}
 			<div id="milestone" className="section">
 				<div className="section-header" onClick={async () => {
 					const newMilestone = await addMilestone();

--- a/webviews/editorWebview/test/builder/pullRequest.ts
+++ b/webviews/editorWebview/test/builder/pullRequest.ts
@@ -49,6 +49,7 @@ export const PullRequestBuilder = createBuilderClass<PullRequest>()({
 	continueOnGitHub: { default: false },
 	currentUserReviewState: { default: 'REQUESTED' },
 	isDarkTheme: { default: true },
+	isEnterprise: { default: false },
 	hasReviewDraft: { default: false },
 	busy: { default: undefined },
 	lastReviewType: { default: undefined },


### PR DESCRIPTION
Previously, when attempting to sign in with more permissions to see projects, the extension would show an error notification. This PR fixes that issue by adding a check for enterprise accounts and only showing the "Add Project" button for non-enterprise accounts.

Fixes #5389