### PR TITLE
Fix scopes error and cursor on sign in prompt

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -237,9 +237,9 @@ export class CredentialStore implements vscode.Disposable {
 
 	public areScopesOld(authProviderId: AuthProvider): boolean {
 		if (!isEnterprise(authProviderId)) {
-			return !this.allScopesIncluded(this._scopes, SCOPES_OLD);
+			return !this.allScopesIncluded(this._scopes, SCOPES_WITH_ADDITIONAL);
 		}
-		return !this.allScopesIncluded(this._scopesEnterprise, SCOPES_OLD);
+		return !this.allScopesIncluded(this._scopesEnterprise, SCOPES_WITH_ADDITIONAL);
 	}
 
 	public async getHubEnsureAdditionalScopes(authProviderId: AuthProvider): Promise<GitHub | undefined> {

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -228,7 +228,7 @@ export class GitHubRepository implements vscode.Disposable {
 				return this.query(query, ignoreSamlErrors);
 			}
 
-			if (e.graphQLErrors && e.graphQLErrors.length && e.graphQLErrors[0].extensions.code === 'undefinedField' && !this._areQueriesLimited) {
+			if (e.graphQLErrors && e.graphQLErrors.length && (e.graphQLErrors[0].extensions && e.graphQLErrors[0].extensions.code === 'undefinedField') && !this._areQueriesLimited) {
 				// We're running against a GitHub server that doesn't support the query we're trying to run.
 				// Switch to the limited schema and try again.
 				this._areQueriesLimited = true;

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -1079,6 +1079,10 @@ code {
 		padding-bottom: 24px;
 	}
 
+	#project a {
+		cursor: pointer;
+	}
+
 	.section-content {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
This pull request fixes an issue where scopes were not being properly checked for old values, causing errors when making some queries. Additionally, the cursor on the sign in prompt has been styled correctly

Fixes #5392