### PR TITLE
Add caching for pull request template location

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,11 +78,13 @@
 					"type": "string",
 					"enum": [
 						"template",
-						"commit"
+						"commit",
+						"none"
 					],
 					"enumDescriptions": [
 						"%githubPullRequests.pullRequestDescription.template%",
-						"%githubPullRequests.pullRequestDescription.commit%"
+						"%githubPullRequests.pullRequestDescription.commit%",
+						"%githubPullRequests.pullRequestDescription.none%"
 					],
 					"default": "template",
 					"description": "%githubPullRequests.pullRequestDescription.description%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
 	"githubPullRequests.pullRequestDescription.description": "The description used when creating pull requests.",
 	"githubPullRequests.pullRequestDescription.template": "Use a pull request template and commit description, or just use the commit description if no templates were found",
 	"githubPullRequests.pullRequestDescription.commit": "Use the latest commit message only",
+	"githubPullRequests.pullRequestDescription.none": "Do not have a default description",
 	"githubPullRequests.defaultCreateOption.description": "The create option that the \"Create\" button will default to when creating a pull request.",
 	"githubPullRequests.defaultCreateOption.lastUsed": "The most recently used create option.",
 	"githubPullRequests.defaultCreateOption.create": "The pull request will be created.",

--- a/src/github/createPRViewProviderNew.ts
+++ b/src/github/createPRViewProviderNew.ts
@@ -225,7 +225,7 @@ export class CreatePullRequestViewProviderNew extends WebviewViewBase implements
 
 	private async getPullRequestTemplate(): Promise<string | undefined> {
 		Logger.debug(`Pull request template - enter`, CreatePullRequestViewProviderNew.ID);
-		const templateUris = await this._folderRepositoryManager.getPullRequestTemplates();
+		const templateUris = await this._folderRepositoryManager.getPullRequestTemplatesWithCache();
 		let template: string | undefined;
 		if (templateUris[0]) {
 			try {

--- a/src/github/createPRViewProviderNew.ts
+++ b/src/github/createPRViewProviderNew.ts
@@ -158,14 +158,15 @@ export class CreatePullRequestViewProviderNew extends WebviewViewBase implements
 	private async getTitleAndDescription(compareBranch: Branch, baseBranch: string): Promise<{ title: string, description: string }> {
 		let title: string = '';
 		let description: string = '';
+		const descrptionSource = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<'commit' | 'template' | 'none'>(PULL_REQUEST_DESCRIPTION);
+		if (descrptionSource === 'none') {
+			return { title, description };
+		}
 
 		// Use same default as GitHub, if there is only one commit, use the commit, otherwise use the branch name, as long as it is not the default branch.
 		// By default, the base branch we use for comparison is the base branch of origin. Compare this to the
 		// compare branch if it has a GitHub remote.
 		const origin = await this._folderRepositoryManager.getOrigin(compareBranch);
-		const useTemplate =
-			vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<string>(PULL_REQUEST_DESCRIPTION) ===
-			'template';
 
 		let useBranchName = this._pullRequestDefaults.base === compareBranch.name;
 		Logger.debug(`Compare branch name: ${compareBranch.name}, Base branch name: ${this._pullRequestDefaults.base}`, CreatePullRequestViewProviderNew.ID);
@@ -174,7 +175,7 @@ export class CreatePullRequestViewProviderNew extends WebviewViewBase implements
 			const [totalCommits, lastCommit, pullRequestTemplate] = await Promise.all([
 				this.getTotalGitHubCommits(compareBranch, baseBranch),
 				name ? titleAndBodyFrom(promiseWithTimeout(this._folderRepositoryManager.getTipCommitMessage(name), 5000)) : undefined,
-				useTemplate ? await this.getPullRequestTemplate() : undefined
+				descrptionSource === 'template' ? await this.getPullRequestTemplate() : undefined
 			]);
 
 			Logger.debug(`Total commits: ${totalCommits}`, CreatePullRequestViewProviderNew.ID);


### PR DESCRIPTION
This pull request adds caching for the location of the pull request template to improve performance. Instead of searching for the template location every time, the cached location is used if available. Fixes #5399.