### PR TITLE
Fix deprecation messages for createDraft and setAutoMerge

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 				"githubPullRequests.createDraft": {
 					"type": "boolean",
 					"default": false,
-					"deprecationMessage": "Use the setting 'githubPullRequests.defaultCreateMethod' instead.",
+					"deprecationMessage": "Use the setting 'githubPullRequests.defaultCreateOption' instead.",
 					"description": "%githubPullRequests.createDraft%"
 				},
 				"githubPullRequests.logLevel": {
@@ -373,7 +373,7 @@
 				"githubPullRequests.setAutoMerge": {
 					"type": "boolean",
 					"description": "%githubPullRequests.setAutoMerge.description%",
-					"deprecationMessage": "Use the setting 'githubPullRequests.defaultCreateMethod' instead.",
+					"deprecationMessage": "Use the setting 'githubPullRequests.defaultCreateOption' instead.",
 					"default": false
 				},
 				"githubPullRequests.pullPullRequestBranchBeforeCheckout": {


### PR DESCRIPTION
The suggestion in the deprecation messages is to use `githubPullRequests.defaultCreateMethod`, but it should be `githubPullRequests.defaultCreateOption` instead.