### PR TITLE
Improve multi-repo logging and add more error handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,8 +148,9 @@ async function init(
 	context.subscriptions.push(activePrViewCoordinator);
 	const createPrHelper = new CreatePullRequestHelper();
 	context.subscriptions.push(createPrHelper);
+	let reviewManagerIndex = 0;
 	const reviewManagers = reposManager.folderManagers.map(
-		folderManager => new ReviewManager(context, folderManager.repository, folderManager, telemetry, changesTree, tree, showPRController, activePrViewCoordinator, createPrHelper, git),
+		folderManager => new ReviewManager(reviewManagerIndex++, context, folderManager.repository, folderManager, telemetry, changesTree, tree, showPRController, activePrViewCoordinator, createPrHelper, git),
 	);
 	context.subscriptions.push(new FileTypeDecorationProvider(reposManager));
 
@@ -169,9 +170,10 @@ async function init(
 				Logger.appendLine(`Repo ${repo.rootUri} has already been setup.`);
 				return;
 			}
-			const newFolderManager = new FolderRepositoryManager(context, repo, telemetry, git, credentialStore);
+			const newFolderManager = new FolderRepositoryManager(reposManager.folderManagers.length, context, repo, telemetry, git, credentialStore);
 			reposManager.insertFolderManager(newFolderManager);
 			const newReviewManager = new ReviewManager(
+				reviewManagerIndex++,
 				context,
 				newFolderManager.repository,
 				newFolderManager,
@@ -362,8 +364,9 @@ async function deferredActivate(context: vscode.ExtensionContext, apiImpl: GitAp
 	const repositories = apiImpl.repositories;
 	Logger.appendLine(`Found ${repositories.length} repositories during activation`);
 
+	let folderManagerIndex = 0;
 	const folderManagers = repositories.map(
-		repository => new FolderRepositoryManager(context, repository, telemetry, apiImpl, credentialStore),
+		repository => new FolderRepositoryManager(folderManagerIndex++, context, repository, telemetry, apiImpl, credentialStore),
 	);
 	context.subscriptions.push(...folderManagers);
 

--- a/src/test/github/folderRepositoryManager.test.ts
+++ b/src/test/github/folderRepositoryManager.test.ts
@@ -35,7 +35,7 @@ describe('PullRequestManager', function () {
 		const repository = new MockRepository();
 		const context = new MockExtensionContext();
 		const credentialStore = new CredentialStore(telemetry, context);
-		manager = new FolderRepositoryManager(context, repository, telemetry, new GitApiImpl(), credentialStore);
+		manager = new FolderRepositoryManager(0, context, repository, telemetry, new GitApiImpl(), credentialStore);
 	});
 
 	afterEach(function () {

--- a/src/test/github/pullRequestOverview.test.ts
+++ b/src/test/github/pullRequestOverview.test.ts
@@ -43,7 +43,7 @@ describe('PullRequestOverview', function () {
 		const repository = new MockRepository();
 		telemetry = new MockTelemetry();
 		credentialStore = new CredentialStore(telemetry, context);
-		pullRequestManager = new FolderRepositoryManager(context, repository, telemetry, new GitApiImpl(), credentialStore);
+		pullRequestManager = new FolderRepositoryManager(0, context, repository, telemetry, new GitApiImpl(), credentialStore);
 
 		const url = 'https://github.com/aaa/bbb';
 		remote = new GitHubRemote('origin', url, new Protocol(url), GitHubServerType.GitHubDotCom);

--- a/src/test/view/prsTree.test.ts
+++ b/src/test/view/prsTree.test.ts
@@ -92,7 +92,7 @@ describe('GitHub Pull Requests view', function () {
 		const repository = new MockRepository();
 		repository.addRemote('origin', 'git@github.com:aaa/bbb');
 		const manager = new RepositoriesManager(
-			[new FolderRepositoryManager(context, repository, telemetry, new GitApiImpl(), credentialStore)],
+			[new FolderRepositoryManager(0, context, repository, telemetry, new GitApiImpl(), credentialStore)],
 			credentialStore,
 			telemetry,
 		);
@@ -107,7 +107,7 @@ describe('GitHub Pull Requests view', function () {
 		repository.addRemote('origin', 'git@github.com:aaa/bbb');
 
 		const manager = new RepositoriesManager(
-			[new FolderRepositoryManager(context, repository, telemetry, new GitApiImpl(), credentialStore)],
+			[new FolderRepositoryManager(0, context, repository, telemetry, new GitApiImpl(), credentialStore)],
 			credentialStore,
 			telemetry,
 		);
@@ -179,7 +179,7 @@ describe('GitHub Pull Requests view', function () {
 
 			await repository.createBranch('non-pr-branch', false);
 
-			const manager = new FolderRepositoryManager(context, repository, telemetry, new GitApiImpl(), credentialStore);
+			const manager = new FolderRepositoryManager(0, context, repository, telemetry, new GitApiImpl(), credentialStore);
 			const reposManager = new RepositoriesManager([manager], credentialStore, telemetry);
 			sinon.stub(manager, 'createGitHubRepository').callsFake((r, cs) => {
 				assert.deepStrictEqual(r, remote);

--- a/src/test/view/reviewCommentController.test.ts
+++ b/src/test/view/reviewCommentController.test.ts
@@ -75,9 +75,9 @@ describe('ReviewCommentController', function () {
 		const createPrHelper = new CreatePullRequestHelper();
 		Resource.initialize(context);
 		const gitApiImpl = new GitApiImpl();
-		manager = new FolderRepositoryManager(context, repository, telemetry, gitApiImpl, credentialStore);
+		manager = new FolderRepositoryManager(0, context, repository, telemetry, gitApiImpl, credentialStore);
 		const tree = new PullRequestChangesTreeDataProvider(context, gitApiImpl, new RepositoriesManager([manager], credentialStore, telemetry));
-		reviewManager = new ReviewManager(context, repository, manager, telemetry, tree, provider, new ShowPullRequest(), activePrViewCoordinator, createPrHelper, gitApiImpl);
+		reviewManager = new ReviewManager(0, context, repository, manager, telemetry, tree, provider, new ShowPullRequest(), activePrViewCoordinator, createPrHelper, gitApiImpl);
 		sinon.stub(manager, 'createGitHubRepository').callsFake((r, cStore) => {
 			return Promise.resolve(new MockGitHubRepository(GitHubRemote.remoteAsGitHub(r, GitHubServerType.GitHubDotCom), cStore, telemetry, sinon));
 		});

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -91,6 +91,7 @@ export class ReviewManager {
 	private _isFirstLoad = true;
 
 	constructor(
+		private _id: number,
 		private _context: vscode.ExtensionContext,
 		private readonly _repository: Repository,
 		private _folderRepoManager: FolderRepositoryManager,
@@ -262,16 +263,20 @@ export class ReviewManager {
 		}, 1000 * 60 * 5);
 	}
 
+	private get id(): string {
+		return `${ReviewManager.ID}+${this._id}`;
+	}
+
 	public async updateState(silent: boolean = false, updateLayout: boolean = true) {
 		if (this.switchingToReviewMode) {
 			return;
 		}
 		if (!this._validateStatusInProgress) {
-			Logger.appendLine('Validate state in progress', ReviewManager.ID);
+			Logger.appendLine('Validate state in progress', this.id);
 			this._validateStatusInProgress = this.validateStatueAndSetContext(silent, updateLayout);
 			return this._validateStatusInProgress;
 		} else {
-			Logger.appendLine('Queuing additional validate state', ReviewManager.ID);
+			Logger.appendLine('Queuing additional validate state', this.id);
 			this._validateStatusInProgress = this._validateStatusInProgress.then(async _ => {
 				return await this.validateStatueAndSetContext(silent, updateLayout);
 			});
@@ -291,7 +296,7 @@ export class ReviewManager {
 				if (timeout) {
 					clearTimeout(timeout);
 					timeout = undefined;
-					Logger.error('Timeout occurred while validating state.', ReviewManager.ID);
+					Logger.error('Timeout occurred while validating state.', this.id);
 					if (!this.hasShownLogRequest && isPreRelease(this._context)) {
 						this.hasShownLogRequest = true;
 						vscode.window.showErrorMessage(vscode.l10n.t('A known error has occurred refreshing the repository state. Please share logs from "GitHub Pull Request" in the [tracking issue]({0}).', 'https://github.com/microsoft/vscode-pull-request-github/issues/5277'));
@@ -341,7 +346,7 @@ export class ReviewManager {
 			ignore,
 			dontShow);
 		if (offerResult === ignore) {
-			Logger.appendLine(`Branch ${currentBranchName} will now be ignored in ${IGNORE_PR_BRANCHES}.`, ReviewManager.ID);
+			Logger.appendLine(`Branch ${currentBranchName} will now be ignored in ${IGNORE_PR_BRANCHES}.`, this.id);
 			const settingNamespace = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE);
 			const setting = settingNamespace.get<string[]>(IGNORE_PR_BRANCHES, []);
 			setting.push(currentBranchName);
@@ -367,7 +372,7 @@ export class ReviewManager {
 				}
 				return { url, branchName, remoteName: undefined };
 			} catch (e) {
-				Logger.appendLine(`Failed to get upstream for branch ${branch.name} from git config.`, ReviewManager.ID);
+				Logger.appendLine(`Failed to get upstream for branch ${branch.name} from git config.`, this.id);
 				return { url: undefined, branchName: undefined, remoteName: undefined };
 			}
 		}
@@ -404,7 +409,7 @@ export class ReviewManager {
 	}
 
 	private async validateState(silent: boolean, updateLayout: boolean) {
-		Logger.appendLine('Validating state...', ReviewManager.ID);
+		Logger.appendLine('Validating state...', this.id);
 		const oldLastCommitSha = this._lastCommitSha;
 		this._lastCommitSha = undefined;
 		await this._folderRepoManager.updateRepositories(false);
@@ -417,7 +422,7 @@ export class ReviewManager {
 		const branch = this._repository.state.HEAD;
 		const ignoreBranches = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<string[]>(IGNORE_PR_BRANCHES);
 		if (ignoreBranches?.find(value => value === branch.name)) {
-			Logger.appendLine(`Branch ${branch.name} is ignored in ${IGNORE_PR_BRANCHES}.`, ReviewManager.ID);
+			Logger.appendLine(`Branch ${branch.name} is ignored in ${IGNORE_PR_BRANCHES}.`, this.id);
 			await this.clear(true);
 			return;
 		}
@@ -425,37 +430,37 @@ export class ReviewManager {
 		let matchingPullRequestMetadata = await this._folderRepoManager.getMatchingPullRequestMetadataForBranch();
 
 		if (!matchingPullRequestMetadata) {
-			Logger.appendLine(`No matching pull request metadata found locally for current branch ${branch.name}`, ReviewManager.ID);
+			Logger.appendLine(`No matching pull request metadata found locally for current branch ${branch.name}`, this.id);
 			matchingPullRequestMetadata = await this.checkGitHubForPrBranch(branch);
 		}
 
 		if (!matchingPullRequestMetadata) {
 			Logger.appendLine(
-				`No matching pull request metadata found on GitHub for current branch ${branch.name}`, ReviewManager.ID
+				`No matching pull request metadata found on GitHub for current branch ${branch.name}`, this.id
 			);
 			await this.clear(true);
 			return;
 		}
-		Logger.appendLine(`Found matching pull request metadata for current branch ${branch.name}. Repo: ${matchingPullRequestMetadata.owner}/${matchingPullRequestMetadata.repositoryName} PR: ${matchingPullRequestMetadata.prNumber}`, ReviewManager.ID);
+		Logger.appendLine(`Found matching pull request metadata for current branch ${branch.name}. Repo: ${matchingPullRequestMetadata.owner}/${matchingPullRequestMetadata.repositoryName} PR: ${matchingPullRequestMetadata.prNumber}`, this.id);
 
 		const remote = branch.upstream ? branch.upstream.remote : null;
 		if (!remote) {
-			Logger.appendLine(`Current branch ${this._repository.state.HEAD.name} hasn't setup remote yet`, ReviewManager.ID);
+			Logger.appendLine(`Current branch ${this._repository.state.HEAD.name} hasn't setup remote yet`, this.id);
 			await this.clear(true);
 			return;
 		}
 
 		// we switch to another PR, let's clean up first.
 		Logger.appendLine(
-			`current branch ${this._repository.state.HEAD.name} is associated with pull request #${matchingPullRequestMetadata.prNumber}`, ReviewManager.ID
+			`current branch ${this._repository.state.HEAD.name} is associated with pull request #${matchingPullRequestMetadata.prNumber}`, this.id
 		);
 		const previousPrNumber = this._prNumber;
 		let pr = await this.resolvePullRequest(matchingPullRequestMetadata);
 		if (!pr) {
-			Logger.appendLine(`Unable to resolve PR #${matchingPullRequestMetadata.prNumber}`, ReviewManager.ID);
+			Logger.appendLine(`Unable to resolve PR #${matchingPullRequestMetadata.prNumber}`, this.id);
 			return;
 		}
-		Logger.appendLine(`Resolved PR #${matchingPullRequestMetadata.prNumber}, state is ${pr.state}`, ReviewManager.ID);
+		Logger.appendLine(`Resolved PR #${matchingPullRequestMetadata.prNumber}, state is ${pr.state}`, this.id);
 
 		// Check if the PR is open, if not, check if there's another PR from the same branch on GitHub
 		if (pr.state !== GithubItemStateEnum.Open) {
@@ -482,13 +487,13 @@ export class ReviewManager {
 			.get<{ merged: boolean, closed: boolean }>(USE_REVIEW_MODE, { merged: true, closed: false });
 
 		if (pr.isClosed && !useReviewConfiguration.closed) {
-			Logger.appendLine('This PR is closed', ReviewManager.ID);
+			Logger.appendLine('This PR is closed', this.id);
 			await this.clear(true);
 			return;
 		}
 
 		if (pr.isMerged && !useReviewConfiguration.merged) {
-			Logger.appendLine('This PR is merged', ReviewManager.ID);
+			Logger.appendLine('This PR is merged', this.id);
 			await this.clear(true);
 			return;
 		}
@@ -505,7 +510,7 @@ export class ReviewManager {
 			this._folderRepoManager.checkBranchUpToDate(pr, true);
 		}
 
-		Logger.appendLine('Fetching pull request data', ReviewManager.ID);
+		Logger.appendLine('Fetching pull request data', this.id);
 		if (!silent) {
 			onceEvent(this._reviewModel.onDidChangeLocalFileChanges)(() => {
 				if (pr) {
@@ -524,7 +529,7 @@ export class ReviewManager {
 		);
 		this.justSwitchedToReviewMode = false;
 
-		Logger.appendLine(`Register comments provider`, ReviewManager.ID);
+		Logger.appendLine(`Register comments provider`, this.id);
 		await this.registerCommentController();
 
 		this._activePrViewCoordinator.setPullRequest(pr, this._folderRepoManager, this, previousActive);
@@ -537,7 +542,7 @@ export class ReviewManager {
 				this._changesSinceLastReviewProgress.endProgress();
 			})
 		);
-		Logger.appendLine(`Register in memory content provider`, ReviewManager.ID);
+		Logger.appendLine(`Register in memory content provider`, this.id);
 		await this.registerGitHubInMemContentProvider();
 
 		this.statusBarItem.text = '$(git-pull-request) ' + vscode.l10n.t('Pull Request #{0}', pr.number);
@@ -546,7 +551,7 @@ export class ReviewManager {
 			title: vscode.l10n.t('View Pull Request Description'),
 			arguments: [pr],
 		};
-		Logger.appendLine(`Display pull request status bar indicator.`, ReviewManager.ID);
+		Logger.appendLine(`Display pull request status bar indicator.`, this.id);
 		this.statusBarItem.show();
 
 		this.layout(pr, updateLayout, silent);
@@ -557,15 +562,15 @@ export class ReviewManager {
 	private layout(pr: PullRequestModel, updateLayout: boolean, silent: boolean) {
 		const isFocusMode = this._context.workspaceState.get(FOCUS_REVIEW_MODE);
 
-		Logger.appendLine(`Using focus mode = ${isFocusMode}.`, ReviewManager.ID);
-		Logger.appendLine(`State validation silent = ${silent}.`, ReviewManager.ID);
-		Logger.appendLine(`PR show should show = ${this._showPullRequest.shouldShow}.`, ReviewManager.ID);
+		Logger.appendLine(`Using focus mode = ${isFocusMode}.`, this.id);
+		Logger.appendLine(`State validation silent = ${silent}.`, this.id);
+		Logger.appendLine(`PR show should show = ${this._showPullRequest.shouldShow}.`, this.id);
 
 		if ((!silent || this._showPullRequest.shouldShow) && isFocusMode) {
 			this._doFocusShow(pr, updateLayout);
 		} else if (!this._showPullRequest.shouldShow && isFocusMode) {
 			const showPRChangedDisposable = this._showPullRequest.onChangedShowValue(shouldShow => {
-				Logger.appendLine(`PR show value changed = ${shouldShow}.`, ReviewManager.ID);
+				Logger.appendLine(`PR show value changed = ${shouldShow}.`, this.id);
 				if (shouldShow) {
 					this._doFocusShow(pr, updateLayout);
 				}
@@ -709,7 +714,7 @@ export class ReviewManager {
 		);
 
 		if (!pr || !pr.isResolved()) {
-			Logger.warn('This PR is no longer valid', ReviewManager.ID);
+			Logger.warn('This PR is no longer valid', this.id);
 			return;
 		}
 
@@ -822,52 +827,56 @@ export class ReviewManager {
 
 			return Promise.resolve(void 0);
 		} catch (e) {
-			Logger.error(`${e}`, ReviewManager.ID);
+			Logger.error(`Failed to initialize PR data ${e}`, this.id);
 		}
 	}
 
 	private async registerGitHubInMemContentProvider() {
-		this._inMemGitHubContentProvider?.dispose();
-		this._inMemGitHubContentProvider = undefined;
+		try {
+			this._inMemGitHubContentProvider?.dispose();
+			this._inMemGitHubContentProvider = undefined;
 
-		const pr = this._folderRepoManager.activePullRequest;
-		if (!pr) {
-			return;
-		}
-		const rawChanges = await pr.getFileChangesInfo();
-		const mergeBase = pr.mergeBase;
-		if (!mergeBase) {
-			return;
-		}
-		const changes = rawChanges.map(change => {
-			if (change instanceof SlimFileChange) {
-				return new RemoteFileChangeModel(this._folderRepoManager, change, pr);
+			const pr = this._folderRepoManager.activePullRequest;
+			if (!pr) {
+				return;
 			}
-			return new InMemFileChangeModel(this._folderRepoManager,
-				pr as (PullRequestModel & IResolvedPullRequestModel),
-				change, true, mergeBase);
-		});
-
-		this._inMemGitHubContentProvider = getInMemPRFileSystemProvider()?.registerTextDocumentContentProvider(
-			pr.number,
-			async (uri: vscode.Uri): Promise<string> => {
-				const params = fromPRUri(uri);
-				if (!params) {
-					return '';
+			const rawChanges = await pr.getFileChangesInfo();
+			const mergeBase = pr.mergeBase;
+			if (!mergeBase) {
+				return;
+			}
+			const changes = rawChanges.map(change => {
+				if (change instanceof SlimFileChange) {
+					return new RemoteFileChangeModel(this._folderRepoManager, change, pr);
 				}
-				const fileChange = changes.find(
-					contentChange => contentChange.fileName === params.fileName,
-				);
+				return new InMemFileChangeModel(this._folderRepoManager,
+					pr as (PullRequestModel & IResolvedPullRequestModel),
+					change, true, mergeBase);
+			});
 
-				if (!fileChange) {
-					Logger.error(`Cannot find content for document ${uri.toString()}`, 'PR');
-					return '';
-				}
+			this._inMemGitHubContentProvider = getInMemPRFileSystemProvider()?.registerTextDocumentContentProvider(
+				pr.number,
+				async (uri: vscode.Uri): Promise<string> => {
+					const params = fromPRUri(uri);
+					if (!params) {
+						return '';
+					}
+					const fileChange = changes.find(
+						contentChange => contentChange.fileName === params.fileName,
+					);
 
-				return provideDocumentContentForChangeModel(this._folderRepoManager, pr, params, fileChange);
+					if (!fileChange) {
+						Logger.error(`Cannot find content for document ${uri.toString()}`, 'PR');
+						return '';
+					}
 
-			},
-		);
+					return provideDocumentContentForChangeModel(this._folderRepoManager, pr, params, fileChange);
+
+				},
+			);
+		} catch (e) {
+			Logger.error(`Failed to register in mem content provider: ${e}`, this.id);
+		}
 	}
 
 	private async registerCommentController() {
@@ -900,7 +909,7 @@ export class ReviewManager {
 	}
 
 	public async switch(pr: PullRequestModel): Promise<void> {
-		Logger.appendLine(`Switch to Pull Request #${pr.number} - start`, ReviewManager.ID);
+		Logger.appendLine(`Switch to Pull Request #${pr.number} - start`, this.id);
 		this.statusBarItem.text = vscode.l10n.t('{0} Switching to Review Mode', '$(sync~spin)');
 		this.statusBarItem.command = undefined;
 		this.statusBarItem.show();
@@ -915,7 +924,7 @@ export class ReviewManager {
 				}
 			});
 		} catch (e) {
-			Logger.error(`Checkout failed #${JSON.stringify(e)}`, ReviewManager.ID);
+			Logger.error(`Checkout failed #${JSON.stringify(e)}`, this.id);
 			this.switchingToReviewMode = false;
 
 			if (e.message === 'User aborted') {
@@ -955,7 +964,7 @@ export class ReviewManager {
 				"pr.checkout" : {}
 			*/
 			this._telemetry.sendTelemetryEvent('pr.checkout');
-			Logger.appendLine(`Switch to Pull Request #${pr.number} - done`, ReviewManager.ID);
+			Logger.appendLine(`Switch to Pull Request #${pr.number} - done`, this.id);
 		} finally {
 			this.setStatusForPr(pr);
 			await this._repository.status();


### PR DESCRIPTION
This pull request updates pre-repo objects to include an id, which is used to improve logging for multi-repo scenarios. It also adds error handling for the `registerGitHubInMemContentProvider` function.

Part of #5277