### PR TITLE
add setting to never offer ignoring default branch pr

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,6 +329,10 @@
 					},
 					"description": "%githubPullRequests.ignoredPullRequestBranches.description%"
 				},
+				"githubPullRequests.neverIgnoreDefaultBranch": {
+					"type": "boolean",
+					"description": "%githubPullRequests.neverIgnoreDefaultBranch.description%"
+				},
 				"githubPullRequests.overrideDefaultBranch": {
 					"type": "string",
 					"description": "%githubPullRequests.overrideDefaultBranch.description%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -61,6 +61,7 @@
 	"githubPullRequests.pullBranch.always": "Always pull a PR branch when changes are detected in the PR. When `\"git.autoStash\": true` this will instead `prompt` to prevent unexpected file changes.",
 	"githubPullRequests.ignoredPullRequestBranches.description": "Prevents branches that are associated with a pull request from being automatically detected. This will prevent review mode from being entered on these branches.",
 	"githubPullRequests.ignoredPullRequestBranches.items": "Branch name",
+	"githubPullRequests.neverIgnoreDefaultBranch.description": "Never offer to ignore a pull request associated with the default branch of a repository.",
 	"githubPullRequests.overrideDefaultBranch.description": "The default branch for a repository is set on github.com. With this setting, you can override that default with another branch.",
 	"githubPullRequests.postCreate.description": "The action to take after creating a pull request.",
 	"githubPullRequests.postCreate.none": "No action",

--- a/src/common/settingKeys.ts
+++ b/src/common/settingKeys.ts
@@ -11,6 +11,7 @@ export const FILE_LIST_LAYOUT = 'fileListLayout';
 export const ASSIGN_TO = 'assignCreated';
 export const PUSH_BRANCH = 'pushBranch';
 export const IGNORE_PR_BRANCHES = 'ignoredPullRequestBranches';
+export const NEVER_IGNORE_DEFAULT_BRANCH = 'neverIgnoreDefaultBranch';
 export const OVERRIDE_DEFAULT_BRANCH = 'overrideDefaultBranch';
 export const PULL_BRANCH = 'pullBranch';
 export const PULL_REQUEST_DESCRIPTION = 'pullRequestDescription';

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -17,6 +17,7 @@ import {
 	COMMENTS,
 	FOCUSED_MODE,
 	IGNORE_PR_BRANCHES,
+	NEVER_IGNORE_DEFAULT_BRANCH,
 	OPEN_VIEW,
 	POST_CREATE,
 	PR_SETTINGS_NAMESPACE,
@@ -498,8 +499,11 @@ export class ReviewManager {
 			return;
 		}
 
-		// Do not await the result of offering to ignore the branch.
-		this.offerIgnoreBranch(branch.name);
+		const neverIgnoreDefaultBranch = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<boolean>(NEVER_IGNORE_DEFAULT_BRANCH, false);
+		if (!neverIgnoreDefaultBranch) {
+			// Do not await the result of offering to ignore the branch.
+			this.offerIgnoreBranch(branch.name);
+		}
 
 		const previousActive = this._folderRepoManager.activePullRequest;
 		this._folderRepoManager.activePullRequest = pr;


### PR DESCRIPTION
In my organization's workflow, we _always_ have a PR associated with the default branch. And because we're heavy users of Dev Containers and Codespaces, our vscode workspaces are fairly ephemeral so we're always creating new ones.

Which means that in new workspaces we always see "there's a pull request associated with the default branch, do you want to ignore" notification and have to click the "Don't show" button. And since we create new environments frequently we see this notification frequently.

This pull request adds a setting to disable the offer to ignore PRs on the default branch, which improves our team's developer experience.