### PR TITLE
Remove repo commit message props from limited queries

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -483,10 +483,10 @@ export interface RefRepository {
 }
 
 export interface BaseRefRepository extends RefRepository {
-	squashMergeCommitTitle: DefaultCommitTitle;
-	squashMergeCommitMessage: DefaultCommitMessage;
-	mergeCommitMessage: DefaultCommitMessage;
-	mergeCommitTitle: DefaultCommitTitle;
+	squashMergeCommitTitle?: DefaultCommitTitle;
+	squashMergeCommitMessage?: DefaultCommitMessage;
+	mergeCommitMessage?: DefaultCommitMessage;
+	mergeCommitTitle?: DefaultCommitTitle;
 }
 
 export interface Ref {

--- a/src/github/queriesLimited.gql
+++ b/src/github/queriesLimited.gql
@@ -58,10 +58,6 @@ fragment PullRequestFragment on PullRequest {
 			login
 		}
 		url
-		squashMergeCommitTitle
-		squashMergeCommitMessage
-		mergeCommitMessage
-		mergeCommitTitle
 	}
 	labels(first: 50) {
 		nodes {

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -681,7 +681,11 @@ export function parseGraphQLPullRequest(
 	return pr;
 }
 
-function parseCommitMeta(titleSource: GraphQL.DefaultCommitTitle, descriptionSource: GraphQL.DefaultCommitMessage, pullRequest: PullRequest): { title: string, description: string } {
+function parseCommitMeta(titleSource: GraphQL.DefaultCommitTitle | undefined, descriptionSource: GraphQL.DefaultCommitMessage | undefined, pullRequest: PullRequest): { title: string, description: string } | undefined {
+	if (titleSource === undefined || descriptionSource === undefined) {
+		return undefined;
+	}
+
 	let title = '';
 	let description = '';
 


### PR DESCRIPTION
GHE 3.6 was only recently deprecated, so let's support them a little longer.