### PR TITLE
Fix error fetching merge queue when no merge queue

### DIFF
--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -456,7 +456,7 @@ export class GitHubRepository implements vscode.Disposable {
 			});
 
 			Logger.debug('Fetch branch has merge queue - done', GitHubRepository.ID);
-			const mergeMethod = parseMergeMethod(result.data.repository.mergeQueue.configuration?.mergeMethod);
+			const mergeMethod = parseMergeMethod(result.data.repository.mergeQueue?.configuration?.mergeMethod);
 			if (mergeMethod) {
 				this._branchHasMergeQueue.set(branch, mergeMethod);
 			}

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -399,8 +399,8 @@ export interface MarkPullRequestReadyForReviewResponse {
 
 export interface MergeQueueForBranchResponse {
 	repository: {
-		mergeQueue: {
-			configuration: {
+		mergeQueue?: {
+			configuration?: {
 				mergeMethod: MergeMethod;
 			}
 		}


### PR DESCRIPTION
This PR fixes an error that occurs when attempting to fetch the merge queue for a branch that does not have a merge queue. The error was caused by a null check that was not properly handling the absence of a merge queue. This PR updates the null check to properly handle the absence of a merge queue.

Fixes #1234