### PR TITLE
Don't use octokit.paginate

### DIFF
--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -978,7 +978,7 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 		try {
 			Logger.debug(`Fetch commits of PR #${this.number} - enter`, PullRequestModel.ID);
 			const { remote, octokit } = await this.githubRepository.ensure();
-			const commitData = await octokit.api.paginate(octokit.api.pulls.listCommits, {
+			const commitData = await restPaginate<typeof octokit.api.pulls.listCommits, OctokitCommon.PullsListCommitsResponseData[0]>(octokit.api.pulls.listCommits, {
 				pull_number: this.number,
 				owner: remote.owner,
 				repo: remote.repositoryName,


### PR DESCRIPTION
`octokit.paginate` + providing a `fetch` method when creating the octokit causes the `accept` header contents to be duplicated. It's unclear why this happens, but the safest fix is just to avoid `octokit.paginate`. This was causing the "Commits" tree node to error out on web.