### PR TITLE
Fix visibility issue with Windows high contrast "Desert" theme

### DIFF
--- a/resources/icons/chevron_down.svg
+++ b/resources/icons/chevron_down.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M7.97612 10.0719L12.3334 5.7146L12.9521 6.33332L8.28548 11L7.66676 11L3.0001 6.33332L3.61882 5.7146L7.97612 10.0719Z" fill="#C5C5C5"/>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.97612 10.0719L12.3334 5.7146L12.9521 6.33332L8.28548 11L7.66676 11L3.0001 6.33332L3.61882 5.7146L7.97612 10.0719Z"/>
 </svg>

--- a/webviews/activityBarView/index.css
+++ b/webviews/activityBarView/index.css
@@ -211,7 +211,3 @@ button.split-right .icon {
 	position: absolute;
 	top: 6px; right: 4px;
 }
-
-button.split-right .icon svg path {
-	fill: var(--vscode-button-foreground);
-}

--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -363,7 +363,3 @@ button.split-right .icon {
 	top: 6px;
 	right: 4px;
 }
-
-button.split-right .icon svg path {
-	fill: var(--vscode-button-foreground);
-}


### PR DESCRIPTION
This pull request fixes an issue where the arrow button for the "Create with option" feature is not visible when using the Windows high contrast "Desert" theme. The problem is caused by the incorrect fill color of the chevron_down.svg icon. This PR updates the fill color to ensure the arrow button is visible in all high contrast themes.

Fixes #5480