### PR TITLE
Fix issue with selecting repository when submodules are present

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,7 +165,7 @@ async function init(
 	git.onDidOpenRepository(repo => {
 		function addRepo() {
 			// Make sure we don't already have a folder manager for this repo.
-			const existing = reposManager.getManagerForFile(repo.rootUri);
+			const existing = reposManager.folderManagers.find(manager => manager.repository.rootUri.toString() === repo.rootUri.toString());
 			if (existing) {
 				Logger.appendLine(`Repo ${repo.rootUri} has already been setup.`);
 				return;


### PR DESCRIPTION
This pull request fixes an issue where the Pull Requests and Issues tabs only display the PRs and issues from the submodule repository instead of the root repository. The problem was caused by not properly checking for existing folder managers for the root repository. This PR updates the code to correctly find the existing folder manager for the root repository. Fixes #3950