### PR TITLE
Fix copy permalink for submodules

### DIFF
--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -1128,10 +1128,15 @@ export function isFileInRepo(repository: Repository, file: vscode.Uri): boolean 
 }
 
 export function getRepositoryForFile(gitAPI: GitApiImpl, file: vscode.Uri): Repository | undefined {
-	for (const repository of gitAPI.repositories) {
+	const foundRepos: Repository[] = [];
+	for (const repository of gitAPI.repositories.reverse()) {
 		if (isFileInRepo(repository, file)) {
-			return repository;
+			foundRepos.push(repository);
 		}
+	}
+	if (foundRepos.length > 0) {
+		foundRepos.sort((a, b) => b.rootUri.path.length - a.rootUri.path.length);
+		return foundRepos[0];
 	}
 	return undefined;
 }


### PR DESCRIPTION
This pull request fixes the issue where the "copy github permalink" feature in submodules would use the URL of the main repository instead of the submodule repository. The fix ensures that the correct repository URL is used when copying the permalink.

Fixes #5181