### PR TITLE
Create issue from markdown template

### DIFF
--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -1185,6 +1185,17 @@ export class FolderRepositoryManager implements vscode.Disposable {
 		return max;
 	}
 
+	async getIssueTemplates(): Promise<vscode.Uri[]> {
+		const pattern = '{docs,.github}/ISSUE_TEMPLATE/*.md';
+		const templatesPattern = vscode.workspace.findFiles(
+			new vscode.RelativePattern(this._repository.rootUri, pattern), null
+		);
+
+		const result = await templatesPattern;
+
+		return result;
+	}
+
 	async getPullRequestTemplatesWithCache(): Promise<vscode.Uri[]> {
 		const cacheLocation = `${CACHED_TEMPLATE_URI}+${this.repository.rootUri.toString()}`;
 

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -1187,13 +1187,9 @@ export class FolderRepositoryManager implements vscode.Disposable {
 
 	async getIssueTemplates(): Promise<vscode.Uri[]> {
 		const pattern = '{docs,.github}/ISSUE_TEMPLATE/*.md';
-		const templatesPattern = vscode.workspace.findFiles(
+		return vscode.workspace.findFiles(
 			new vscode.RelativePattern(this._repository.rootUri, pattern), null
 		);
-
-		const result = await templatesPattern;
-
-		return result;
 	}
 
 	async getPullRequestTemplatesWithCache(): Promise<vscode.Uri[]> {

--- a/src/issues/issueFeatureRegistrar.ts
+++ b/src/issues/issueFeatureRegistrar.ts
@@ -1090,7 +1090,7 @@ ${body ?? ''}\n
 		}
 
 		interface IssueChoice extends vscode.QuickPickItem {
-			uri: vscode.Uri;
+			uri?: vscode.Uri;
 		}
 		const templateUris = await folderManager.getIssueTemplates();
 		if (templateUris.length === 0) {
@@ -1103,10 +1103,13 @@ ${body ?? ''}\n
 				uri: uri,
 			};
 		});
+		choices.push({
+			label: vscode.l10n.t('Blank issue'),
+		});
 		const selectedUriChoice = await vscode.window.showQuickPick(choices, {
 			placeHolder: vscode.l10n.t('Select a template for the new issue.'),
 		});
-		if (!selectedUriChoice) {
+		if (!selectedUriChoice?.uri) {
 			return undefined;
 		}
 

--- a/src/issues/issueFeatureRegistrar.ts
+++ b/src/issues/issueFeatureRegistrar.ts
@@ -1133,9 +1133,9 @@ ${body ?? ''}\n
 	}
 
 	private getDataFromTemplate(template: string): IssueTemplate {
-		const title = template.match(/title:\s*(.*)/)?.[1];
-		const name = template.match(/name:\s*(.*)/)?.[1];
-		const about = template.match(/about:\s*(.*)/)?.[1];
+		const title = template.match(/title:\s*(.*)/)?.[1]?.replace(/^["']|["']$/g, '');;
+		const name = template.match(/name:\s*(.*)/)?.[1]?.replace(/^["']|["']$/g, '');;
+		const about = template.match(/about:\s*(.*)/)?.[1]?.replace(/^["']|["']$/g, '');;
 		const body = template.match(/---([\s\S]*)---([\s\S]*)/)?.[2];
 		return { title, name, about, body };
 	}

--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -302,6 +302,13 @@ export interface NewIssue {
 	range: vscode.Range | vscode.Selection;
 }
 
+export interface IssueTemplate {
+	name: string | undefined,
+	about: string | undefined,
+	title: string | undefined,
+	body: string | undefined
+}
+
 const HEAD = 'HEAD';
 const UPSTREAM = 1;
 const UPS = 2;


### PR DESCRIPTION
I was wondering why #1792 is still open so I tried to create a proof of concept for that.

At the current state I can read from `{docs,.github}/ISSUE_TEMPLATE/*.md` and put the files to the quick pick to get selected by the user.
If a file is selected I read the content and roughly parse title and body to pass them to `makeNewIssueFile`, otherwise the existing default file is opened.

https://github.com/microsoft/vscode-pull-request-github/assets/7253929/e84c69de-334f-4552-b20b-d46535849ee0

If it's something worth working on I'll be happy to put some more effort in either in this PR of in future ones, for example:
- Add a "blank" option to the quick pick
- Improve the parsing logic
- Parse more fields from the metadata
- Display the template name instead of the file name on the quick pick
- Add support for yaml issue forms

