### PR TITLE
Treat `githubIssues.useBranchForIssues` setting description as markdown (fix #5506)

### DIFF
--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
 						"%githubIssues.useBranchForIssues.prompt%"
 					],
 					"default": "on",
-					"description": "%githubIssues.useBranchForIssues.description%"
+					"markdownDescription": "%githubIssues.useBranchForIssues.markdownDescription%"
 				},
 				"githubIssues.issueCompletionFormatScm": {
 					"type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -95,7 +95,7 @@
 			"Do not translate what's inside of the '${..}'. It is an internal syntax for the extension"
 		]
 	},
-	"githubIssues.useBranchForIssues.description": {
+	"githubIssues.useBranchForIssues.markdownDescription": {
 		"message": "Determines whether a branch should be checked out when working on an issue. To configure the name of the branch, set `#githubIssues.issueBranchTitle#`.",
 		"comment": [
 			"{Locked='`#githubIssues.issueBranchTitle#`'}",


### PR DESCRIPTION
This PR fixes #5506