### PR TITLE
Use config for multi-diff setting in when clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -2006,7 +2006,7 @@
 				},
 				{
 					"command": "pr.openChanges",
-					"when": "view =~ /(pr|prStatus):github/ && viewItem =~ /description/",
+					"when": "view =~ /(pr|prStatus):github/ && viewItem =~ /description/ && config.multiDiffEditor.experimental.enabled",
 					"group": "inline"
 				},
 				{


### PR DESCRIPTION
This pull request updates the when clause in the package.json file to use the config.multiDiffEditor.experimental.enabled setting. This ensures that the multi-diff feature is only enabled when the setting is enabled.