### PR TITLE
Update label for create + auto merge queue option

### DIFF
--- a/webviews/createPullRequestViewNew/app.tsx
+++ b/webviews/createPullRequestViewNew/app.tsx
@@ -46,7 +46,7 @@ export function main() {
 					let label: string;
 					if (autoMerge && baseHasMergeQueue) {
 						value = 'create-automerge-merge';
-						label = 'Merge When Ready';
+						label = 'Create + Merge When Ready';
 					} else if (autoMerge && autoMergeMethod) {
 						value = `create-automerge-${autoMergeMethod}` as CreateMethod;
 						const mergeMethodLabel = autoMergeMethod.charAt(0).toUpperCase() + autoMergeMethod.slice(1);


### PR DESCRIPTION
This pull request updates the label for the create + auto merge queue option in the app.tsx file. The label was changed from "Merge When Ready" to "Create + Merge When Ready".

Fixes #5514