### PR TITLE
Fix sparkle icon focus border and hover highlight

### DIFF
--- a/webviews/createPullRequestViewNew/app.tsx
+++ b/webviews/createPullRequestViewNew/app.tsx
@@ -244,8 +244,8 @@ export function main() {
 						</input>
 						{ctx.createParams.generateTitleAndDescriptionTitle ?
 							isGeneratingTitle ?
-								<button title='Cancel' className='title-action' onClick={ctx.cancelGenerateTitle} disabled={isBusy || !ctx.initialized}>{stopIcon}</button>
-								: <button title={ctx.createParams.generateTitleAndDescriptionTitle} className='title-action' onClick={() => generateTitle()} disabled={isBusy || !ctx.initialized}>{sparkleIcon}</button> : null}
+								<a title='Cancel' className={`title-action icon-button${isBusy || !ctx.initialized ? ' disabled' : ''}`} onClick={ctx.cancelGenerateTitle} tabIndex={0}>{stopIcon}</a>
+								: <a title={ctx.createParams.generateTitleAndDescriptionTitle} className={`title-action icon-button${isBusy || !ctx.initialized ? ' disabled' : ''}`} onClick={() => generateTitle()} tabIndex={0}>{sparkleIcon}</a> : null}
 						<div id='title-error' className={params.showTitleValidationError ? 'validation-error below-input-error' : 'hidden'}>A title is required</div>
 					</div>
 

--- a/webviews/createPullRequestViewNew/index.css
+++ b/webviews/createPullRequestViewNew/index.css
@@ -121,13 +121,35 @@ textarea:disabled {
 	display: flex;
 }
 
-.group-title .title-action:focus,
 .group-title .title-action:hover {
+	outline-style: none;
+	cursor: pointer;
 	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.group-title .title-action:focus {
+	outline-style: none;
+}
+
+.group-title .title-action:focus-visible {
+	outline-width: 1px;
+	outline-style: solid;
+	outline-offset: -1px;
+	outline-color: var(--vscode-focusBorder);
+	background: unset;
+}
+
+.group-title .title-action.disabled {
+	cursor: default;
+	background-color: unset;
 }
 
 .group-title .title-action svg {
 	padding: 2px;
+}
+
+.group-title .title-action.disabled svg path  {
+	fill: var(--vscode-disabledForeground);
 }
 
 .group-title .title-action {


### PR DESCRIPTION
This pull request fixes the issue where the sparkle icon in the Create-PR view doesn't visually indicate that it has focus. The changes include adding a focus border and hover highlight to the sparkle action. This improves the user experience and makes it easier to interact with the sparkle icon.

Fixes #5471