### PR TITLE
Render sections immediately on first load of GHPRI view

### DIFF
--- a/src/test/view/prsTree.test.ts
+++ b/src/test/view/prsTree.test.ts
@@ -199,6 +199,8 @@ describe('GitHub Pull Requests view', function () {
 			const localNode = rootNodes.find((_node, index) => rootTreeItems[index].label === 'Local Pull Request Branches');
 			assert(localNode);
 
+			// Need to call getChildren twice to get past the quick render with an empty list
+			await localNode!.getChildren();
 			const localChildren = await localNode!.getChildren();
 			assert.strictEqual(localChildren.length, 2);
 			const [localItem0, localItem1] = await Promise.all(localChildren.map(node => node.getTreeItem()));

--- a/src/view/treeNodes/categoryNode.ts
+++ b/src/view/treeNodes/categoryNode.ts
@@ -124,6 +124,7 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 	public repositoryPageInformation: Map<string, PageInformation> = new Map<string, PageInformation>();
 	public contextValue: string;
 	public readonly id: string = '';
+	private _firstLoad: boolean = true;
 
 	constructor(
 		public parent: TreeNodeParent,
@@ -305,8 +306,16 @@ export class CategoryTreeNode extends TreeNode implements vscode.TreeItem {
 	}
 
 	async getChildren(): Promise<TreeNode[]> {
-		super.getChildren();
+		await super.getChildren();
+		if (this._firstLoad) {
+			this._firstLoad = false;
+			this.doGetChildren().then(() => this.refresh(this));
+			return [];
+		}
+		return this.doGetChildren();
+	}
 
+	private async doGetChildren(): Promise<TreeNode[]> {
 		let hasMorePages = false;
 		let hasUnsearchedRepositories = false;
 		let needLogin = false;


### PR DESCRIPTION
This pull request fixes the issue where the first load of the GHPRI view renders empty for approximately 3 seconds. By immediately rendering the sections, we can make the view much snappier.

Part of microsoft/vscode#198951