### PR TITLE
Fix missing semantic heading tag in PR webview comments

### DIFF
--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -7,6 +7,16 @@ body a {
 	text-decoration: none;
 }
 
+h3 {
+	display: unset;
+	font-size: unset;
+	margin-block-start: unset;
+	margin-block-end: unset;
+	margin-inline-start: unset;
+	margin-inline-end: unset;
+	font-weight: unset;
+}
+
 body a:hover {
 	text-decoration: underline;
 }

--- a/webviews/components/comment.tsx
+++ b/webviews/components/comment.tsx
@@ -148,7 +148,7 @@ function CommentBox({ for: comment, onFocus, onMouseEnter, onMouseLeave, childre
 	return (
 		<div className="comment-container comment review-comment" {...{ onFocus, onMouseEnter, onMouseLeave }}>
 			<div className="review-comment-container">
-				<div className="review-comment-header">
+				<h3 className="review-comment-header">
 					<Spaced>
 						<Avatar for={author} />
 						<AuthorLink for={author} />
@@ -170,7 +170,7 @@ function CommentBox({ for: comment, onFocus, onMouseEnter, onMouseLeave, childre
 							</>
 						) : null}
 					</Spaced>
-				</div>
+				</h3>
 				{children}
 			</div>
 		</div>


### PR DESCRIPTION
This pull request fixes the issue where the semantic heading tag is missing in PR webview comments in the VSCode GitHub extension. The h3 tag for commentor names was not present, making it difficult for screen reader users to navigate between comments. This PR adds the missing h3 tag to improve accessibility.

Fixes #5524