### PR TITLE
Improve rate limit management around PullRequestComments

### DIFF
--- a/src/github/loggingOctokit.ts
+++ b/src/github/loggingOctokit.ts
@@ -53,7 +53,7 @@ export class RateLogger {
 	}
 
 	public async logRateLimit(info: string | undefined, result: Promise<{ data: { rateLimit: RateLimit | undefined } | undefined } | undefined>, isRest: boolean = false) {
-		let rateLimitInfo;
+		let rateLimitInfo: { limit: number, remaining: number, cost: number } | undefined;
 		try {
 			const resolvedResult = await result;
 			rateLimitInfo = resolvedResult?.data?.rateLimit;
@@ -65,11 +65,11 @@ export class RateLogger {
 		if ((rateLimitInfo?.limit ?? 5000) < 5000) {
 			if (!isSearch) {
 				Logger.appendLine(`Unexpectedly low rate limit: ${rateLimitInfo?.limit}`, RateLogger.ID);
-			} else if (rateLimitInfo.limit < 30) {
+			} else if ((rateLimitInfo?.limit ?? 30) < 30) {
 				Logger.appendLine(`Unexpectedly low SEARCH rate limit: ${rateLimitInfo?.limit}`, RateLogger.ID);
 			}
 		}
-		const remaining = `${isRest ? 'REST' : 'GraphQL'} Rate limit remaining: ${rateLimitInfo?.remaining}, ${info}`;
+		const remaining = `${isRest ? 'REST' : 'GraphQL'} Rate limit remaining: ${rateLimitInfo?.remaining}, cost: ${rateLimitInfo?.cost}, ${info}`;
 		if (((rateLimitInfo?.remaining ?? 1000) < 1000) && !isSearch) {
 			if (!this.hasLoggedLowRateLimit) {
 				/* __GDPR__

--- a/src/github/queriesShared.gql
+++ b/src/github/queriesShared.gql
@@ -447,7 +447,7 @@ query GetPendingReviewId($pullRequestId: ID!, $author: String!) {
 query PullRequestComments($owner: String!, $name: String!, $number: Int!, $after: String) {
 	repository(owner: $owner, name: $name) {
 		pullRequest(number: $number) {
-			reviewThreads(first: 100, after: $after) {
+			reviewThreads(first: 20, after: $after) {
 				nodes {
 					id
 					isResolved

--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -770,7 +770,7 @@ export class ReviewManager {
 		try {
 			const contentChanges = await pr.getFileChangesInfo();
 			this._reviewModel.localFileChanges = await this.getLocalChangeNodes(pr, contentChanges);
-			await Promise.all([pr.initializeReviewComments(), pr.initializeReviewThreadCache(), pr.initializePullRequestFileViewState()]);
+			await Promise.all([pr.initializeReviewThreadCacheAndReviewComments(), pr.initializePullRequestFileViewState()]);
 			this._folderRepoManager.setFileViewedContext();
 			const outdatedComments = pr.comments.filter(comment => !comment.position);
 


### PR DESCRIPTION
- Include cost in rate limit log
- Reduce cost of PullRequestComments by only requesting 20 at a time (will result in slower fetching when there are more than 20 comments though)
- Only run the PullRequestComments query once on startup when a PR is checked out
Part of #4351