### PR TITLE
Add enum descriptions for githubPullRequests.pullPullRequestBranchBeforeCheckout

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,13 @@
 						"pullAndMergeBase",
 						"pullAndUpdateBase"
 					],
-					"default": "pull"
+					"default": "pull",
+					"enumDescriptions": [
+						"%githubPullRequests.pullPullRequestBranchBeforeCheckout.never%",
+						"%githubPullRequests.pullPullRequestBranchBeforeCheckout.pull%",
+						"%githubPullRequests.pullPullRequestBranchBeforeCheckout.pullAndMergeBase%",
+						"%githubPullRequests.pullPullRequestBranchBeforeCheckout.pullAndUpdateBase%"
+					]
 				},
 				"githubPullRequests.upstreamRemote": {
 					"type": "string",


### PR DESCRIPTION
This pull request adds enum descriptions for the `githubPullRequests.pullPullRequestBranchBeforeCheckout` setting in the `package.json` file. The enum descriptions provide a clearer understanding of the different options available for this setting. Fixes #5662