### PR TITLE
A11y_Visual Studio Code Web Extensions _GitHub Pull request_ Create Pull request_ Screen Reader: Narrator is not announcing the state of Expanded/collapsed for "Create with Option" arrow button

### DIFF
--- a/webviews/components/contextDropdown.tsx
+++ b/webviews/components/contextDropdown.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import React from 'react';
+import React, { useState } from 'react';
 import { chevronDownIcon } from './icon';
 
 interface ContextDropdownProps {
@@ -17,6 +17,20 @@ interface ContextDropdownProps {
 }
 
 export const ContextDropdown = ({ optionsContext, defaultOptionLabel, defaultOptionValue, defaultAction, optionsTitle, disabled, hasSingleAction }: ContextDropdownProps) => {
+	const [expanded, setExpanded] = useState(false);
+	const onHideAction = (e: MouseEvent | KeyboardEvent) => {
+		if (e.target instanceof HTMLElement && e.target.classList.contains('split-right')) {
+			return;
+		}
+		setExpanded(false);
+	};
+	document.onclick = (e) => {
+		onHideAction(e);
+	};
+
+	document.onkeydown = (e) => {
+		onHideAction(e);
+	};
 	return <div className='primary-split-button'>
 		<button className='split-left' disabled={disabled} onClick={defaultAction} value={defaultOptionValue()}
 			title={defaultOptionLabel()}>
@@ -24,14 +38,21 @@ export const ContextDropdown = ({ optionsContext, defaultOptionLabel, defaultOpt
 		</button>
 		<div className='split'></div>
 		{hasSingleAction ? null :
-			<button className='split-right' title={optionsTitle} disabled={disabled} onClick={(e) => {
+			<button className='split-right' title={optionsTitle} disabled={disabled} aria-expanded={expanded} onClick={(e) => {
 				e.preventDefault();
 				const rect = (e.target as HTMLElement).getBoundingClientRect();
 				const x = rect.left;
 				const y = rect.bottom;
 				e.target.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: x, clientY: y }));
 				e.stopPropagation();
-			}} data-vscode-context={optionsContext()}>
+			}}
+			onMouseDown={() => setExpanded(true)}
+			onKeyDown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					setExpanded(true);
+				}
+			}}
+			data-vscode-context={optionsContext()}>
 				{chevronDownIcon}
 			</button>
 		}

--- a/webviews/components/contextDropdown.tsx
+++ b/webviews/components/contextDropdown.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { chevronDownIcon } from './icon';
 
 interface ContextDropdownProps {
@@ -24,13 +24,16 @@ export const ContextDropdown = ({ optionsContext, defaultOptionLabel, defaultOpt
 		}
 		setExpanded(false);
 	};
-	document.onclick = (e) => {
-		onHideAction(e);
-	};
-
-	document.onkeydown = (e) => {
-		onHideAction(e);
-	};
+	useEffect(() => {
+		const onClickOrKey = (e) => onHideAction(e);
+		if (expanded) {
+			document.addEventListener('click', onClickOrKey);
+			document.addEventListener('keydown', onClickOrKey);
+		} else {
+			document.removeEventListener('click', onClickOrKey);
+			document.removeEventListener('keydown', onClickOrKey);
+		}
+	}, [expanded, setExpanded]);
 	return <div className='primary-split-button'>
 		<button className='split-left' disabled={disabled} onClick={defaultAction} value={defaultOptionValue()}
 			title={defaultOptionLabel()}>


### PR DESCRIPTION
This is a best effort at adding `aria-expanded` to the context-menu backed dropdown button. 

Fixes #5483