### PR TITLE
Fix hover in issue tree not working

### DIFF
--- a/src/issues/issuesView.ts
+++ b/src/issues/issuesView.ts
@@ -8,11 +8,11 @@ import * as vscode from 'vscode';
 import { commands, contexts } from '../common/executeCommands';
 import { groupBy } from '../common/utils';
 import { FolderRepositoryManager, ReposManagerState } from '../github/folderRepositoryManager';
+import { IssueModel } from '../github/issueModel';
 import { RepositoriesManager } from '../github/repositoriesManager';
 import { issueBodyHasLink } from './issueLinkLookup';
 import { IssueItem, QueryGroup, StateManager } from './stateManager';
 import { issueMarkdown } from './util';
-import { IssueModel } from '../github/issueModel';
 
 export class QueryNode {
 	constructor(

--- a/src/issues/issuesView.ts
+++ b/src/issues/issuesView.ts
@@ -12,6 +12,7 @@ import { RepositoriesManager } from '../github/repositoriesManager';
 import { issueBodyHasLink } from './issueLinkLookup';
 import { IssueItem, QueryGroup, StateManager } from './stateManager';
 import { issueMarkdown } from './util';
+import { IssueModel } from '../github/issueModel';
 
 export class QueryNode {
 	constructor(
@@ -121,7 +122,7 @@ export class IssuesTreeData
 		item: vscode.TreeItem,
 		element: FolderRepositoryManager | QueryNode | IssueGroupNode | IssueItem,
 	): Promise<vscode.TreeItem> {
-		if (element instanceof IssueItem) {
+		if (element instanceof IssueModel) {
 			item.tooltip = await issueMarkdown(element, this.context, this.manager);
 		}
 		return item;


### PR DESCRIPTION
This pull request fixes the issue where hovering over an issue in the Issues view does not show the markdown hover with the issue title and body. The hover was previously the same as the tree item label. This PR updates the code in the Issues view to correctly display the markdown hover for issues. Fixes #5686