### PR TITLE
Fix video preview not working

### DIFF
--- a/src/github/issueOverview.ts
+++ b/src/github/issueOverview.ts
@@ -396,7 +396,7 @@ export class IssueOverviewPanel<TItem extends IssueModel = IssueModel> extends W
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
-		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https:; script-src 'nonce-${nonce}'; style-src vscode-resource: 'unsafe-inline' http: https: data:;">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https:; media-src https:; script-src 'nonce-${nonce}'; style-src vscode-resource: 'unsafe-inline' http: https: data:;">
 
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Pull Request #${number}</title>


### PR DESCRIPTION
This pull request fixes the issue where the video preview in the extension was not working. The player was shown but all the buttons were disabled. The issue has been resolved by updating the Content-Security-Policy meta tag in the issueOverview.ts file to include the media-src directive. This allows the video to be played in the preview.

Fixes #4761