### PR TITLE
Remove redundant prefix-style info from PR change view

### DIFF
--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -141,7 +141,7 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 			}),
 		);
 
-		this.accessibilityInformation = { label: `View diffs and comments for file ${this.label}`, role: 'link' };
+		this.accessibilityInformation = { label: `${this.label} pull request diff`, role: 'link' };
 	}
 
 	get resourceUri(): vscode.Uri {


### PR DESCRIPTION
This pull request removes the redundant prefix-style information from the PR change view in order to improve accessibility for screen reader users. The unnecessary instruction "View diffs and comments for file" is removed, making it easier for users to navigate through the changed files. 
Fixes #5705.