### PR TITLE
Fix auto merge checkbox not showing when PR is ready for review

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -696,7 +696,7 @@ export function registerCommands(
 					let isDraft;
 					if (value === yes) {
 						try {
-							isDraft = await pullRequest.setReadyForReview();
+							isDraft = (await pullRequest.setReadyForReview()).isDraft;
 							vscode.commands.executeCommand('pr.refreshList');
 							return isDraft;
 						} catch (e) {

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -421,10 +421,10 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 	private setReadyForReview(message: IRequestMessage<Record<string, unknown>>): void {
 		this._item
 			.setReadyForReview()
-			.then(isDraft => {
+			.then(result => {
 				vscode.commands.executeCommand('pr.refreshList');
 
-				this._replyMessage(message, { isDraft });
+				this._replyMessage(message, result);
 			})
 			.catch(e => {
 				vscode.window.showErrorMessage(vscode.l10n.t('Unable to set PR ready for review. {0}', formatError(e)));

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -396,6 +396,10 @@ export interface MarkPullRequestReadyForReviewResponse {
 	markPullRequestReadyForReview: {
 		pullRequest: {
 			isDraft: boolean;
+			mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
+			mergeStateStatus: 'BEHIND' | 'BLOCKED' | 'CLEAN' | 'DIRTY' | 'HAS_HOOKS' | 'UNKNOWN' | 'UNSTABLE';
+			viewerCanEnableAutoMerge: boolean;
+			viewerCanDisableAutoMerge: boolean;
 		};
 	};
 }

--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -42,6 +42,12 @@ export interface ReviewState {
 	state: string;
 }
 
+export interface ReadyForReview {
+	isDraft: boolean;
+	mergeable: PullRequestMergeability;
+	allowAutoMerge: boolean;
+}
+
 export interface IActor {
 	login: string;
 	avatarUrl?: string;

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -646,10 +646,10 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 	private setReadyForReview(message: IRequestMessage<{}>): void {
 		this._item
 			.setReadyForReview()
-			.then(isDraft => {
+			.then(result => {
 				vscode.commands.executeCommand('pr.refreshList');
 
-				this._replyMessage(message, { isDraft });
+				this._replyMessage(message, result);
 			})
 			.catch(e => {
 				vscode.window.showErrorMessage(`Unable to set PR ready for review. ${formatError(e)}`);

--- a/src/github/queriesShared.gql
+++ b/src/github/queriesShared.gql
@@ -755,6 +755,10 @@ mutation ReadyForReview($input: MarkPullRequestReadyForReviewInput!) {
 	markPullRequestReadyForReview(input: $input) {
 		pullRequest {
 			isDraft
+			mergeable
+			mergeStateStatus
+			viewerCanEnableAutoMerge
+			viewerCanDisableAutoMerge
 		}
 	}
 }

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -6,7 +6,7 @@
 import { createContext } from 'react';
 import { IComment } from '../../src/common/comment';
 import { EventType, ReviewEvent, TimelineEvent } from '../../src/common/timelineEvent';
-import { IProjectItem, MergeMethod, ReviewState } from '../../src/github/interface';
+import { IProjectItem, MergeMethod, ReadyForReview, ReviewState } from '../../src/github/interface';
 import { MergeArguments, ProjectItemsReply, PullRequest } from '../../src/github/views';
 import { getState, setState, updateState } from './cache';
 import { getMessageHandler, MessageHandler } from './message';
@@ -64,7 +64,7 @@ export class PRContext {
 
 	public deleteBranch = () => this.postMessage({ command: 'pr.deleteBranch' });
 
-	public readyForReview = () => this.postMessage({ command: 'pr.readyForReview' });
+	public readyForReview = (): Promise<ReadyForReview> => this.postMessage({ command: 'pr.readyForReview' });
 
 	public addReviewers = () => this.postMessage({ command: 'pr.change-reviewers' });
 	public changeProjects = (): Promise<ProjectItemsReply> => this.postMessage({ command: 'pr.change-projects' });

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -277,8 +277,8 @@ export const ReadyForReview = ({ isSimple }: { isSimple: boolean }) => {
 	const markReadyForReview = useCallback(async () => {
 		try {
 			setBusy(true);
-			await readyForReview();
-			updatePR({ isDraft: false });
+			const result = await readyForReview();
+			updatePR(result);
 		} finally {
 			setBusy(false);
 		}


### PR DESCRIPTION
Pressing the "Ready for Review" button in the PR overview does not create the checkbox for Auto-merge. This PR fixes the issue by updating the code to correctly display the checkbox when the PR is ready for review.

Fixes #5721