### PR TITLE
fix: make `review.openLocalFile` support triggering from the keyboard.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1126,7 +1126,11 @@ ${contents}
 	);
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('review.openLocalFile', (value: vscode.Uri) => {
+		vscode.commands.registerCommand('review.openLocalFile', (_value: vscode.Uri) => {
+			const value = _value ?? vscode.window.activeTextEditor?.document.uri;
+			if (!value) {
+				return;
+			}
 			const localUri = localUriFromReviewUri(value);
 			const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri.toString() === value.toString());
 			const command = openFileCommand(localUri, editor ? { selection: editor.selection } : undefined);


### PR DESCRIPTION
After configuring a keyboard shortcut for the `review.openLocalFile` command, triggering the keyboard shortcut will report the following error:
```
2024-03-18 14:43:41.194 [error] TypeError: Cannot read properties of undefined (reading 'query')
	at /Users/ipcjs/.vscode/extensions/github.vscode-pull-request-github-0.82.0/dist/extension.js:2024:1200
	at l.h (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:184839)
	at l.$executeContributedCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:150:185699)
```

This PR fixes this issue.
