### PR TITLE
Restore accidental version number increase

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"tabInputTextMerge",
 		"treeViewMarkdownMessage"
 	],
-	"version": "0.82.0",
+	"version": "0.84.0",
 	"publisher": "GitHub",
 	"engines": {
 		"vscode": "^1.88.0"


### PR DESCRIPTION
Its safer to continue with the unintentional skipped version than it is to unpublish already released versions.