### PR TITLE
Disable creating a release

### DIFF
--- a/azure-pipeline.nightly.yml
+++ b/azure-pipeline.nightly.yml
@@ -27,6 +27,8 @@ parameters:
 extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
+    ghCreateRelease: false
+
     l10nSourcePaths: ./src
 
     buildSteps:

--- a/azure-pipeline.release.yml
+++ b/azure-pipeline.release.yml
@@ -24,6 +24,8 @@ parameters:
 extends:
   template: azure-pipelines/extension/stable.yml@templates
   parameters:
+    ghCreateRelease: false
+
     l10nSourcePaths: ./src
 
     buildSteps:


### PR DESCRIPTION
This pull request disables the creation of releases in the Azure pipelines for both nightly and release builds. This change is made by setting the `ghCreateRelease` parameter to `false` in the pipeline templates.