### PR TITLE
Fix suggested changes border in comment view not being themeable

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -93,7 +93,7 @@ body hr {
 	display: block;
 	height: 1px;
 	border: 0;
-	border-top: 1px solid #555;
+	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 	margin: 0 !important;
 	padding: 0;
 }


### PR DESCRIPTION
Adds theme colour reference to a "Suggested change" border to make it less jarring for themes that use different colour palette than the built-in VS Code themes. 🎨 

### Before:
![Screenshot 2024-05-23 at 22 43 51](https://github.com/microsoft/vscode-pull-request-github/assets/3058150/83f800bb-0561-4602-a70b-6623c9e0ccce)

### After:
![Screenshot 2024-05-23 at 22 42 59](https://github.com/microsoft/vscode-pull-request-github/assets/3058150/6ebdea21-5d14-465c-b9cb-369d59a5e160)

Theme: [Remedy](https://github.com/robertrossmann/vscode-remedy)