### PR TITLE
Use editor font for diff

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -1053,15 +1053,15 @@ code {
 }
 
 .win32 .diff .diffLine {
-	font-family: Consolas, Inconsolata, 'Courier New', monospace;
+	font-family: var(--vscode-editor-font-family), Consolas, Inconsolata, 'Courier New', monospace;
 }
 
 .darwin .diff .diffLine {
-	font-family: Monaco, Menlo, Inconsolata, 'Courier New', monospace;
+	font-family: var(--vscode-editor-font-family), Monaco, Menlo, Inconsolata, 'Courier New', monospace;
 }
 
 .linux .diff .diffLine {
-	font-family: 'Droid Sans Mono', Inconsolata, 'Courier New', monospace, 'Droid Sans Fallback';
+	font-family: var(--vscode-editor-font-family), 'Droid Sans Mono', Inconsolata, 'Courier New', monospace, 'Droid Sans Fallback';
 }
 
 .diff .diffLine.add {


### PR DESCRIPTION
Fixes #6146

New look (my default is Berkeley Mono)
<img width="859" alt="Screenshot 2024-08-17 at 11 54 03" src="https://github.com/user-attachments/assets/b5db5cf4-8b00-4250-8337-d3fd2f3380ba">

Alternatively, I found this line:
https://github.com/microsoft/vscode-pull-request-github/blob/05ce44deae820c01c4339818436eff028649bab9/webviews/editorWebview/index.css#L1092

We could probably remove it with this new addition, but the `lineNumber` will change
