### PR TITLE
Make code blocks use the editor's font family by default

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -894,7 +894,7 @@ h3 {
 }
 
 code {
-	font-family: Menlo, Monaco, Consolas, 'Droid Sans Mono', 'Courier New', monospace, 'Droid Sans Fallback';
+	font-family: var(--vscode-editor-font-family), Menlo, Monaco, Consolas, 'Droid Sans Mono', 'Courier New', monospace, 'Droid Sans Fallback';
 }
 
 .comment-body .snippet-clipboard-content {


### PR DESCRIPTION
Similar to #6146 & #6148, but for code blocks in comments

Before:
<img width="899" alt="Screenshot 2024-08-17 at 12 08 56" src="https://github.com/user-attachments/assets/fbb1f67f-5c16-4e3f-bb43-90c82ce993c8">

After (my default font is Berkeley Mono):
<img width="774" alt="Screenshot 2024-08-17 at 11 59 53" src="https://github.com/user-attachments/assets/4ccd1757-3fc2-4846-8fe9-f0dfdfa1bb18">
