### PR TITLE
Changing name of the participant to `Github Pull Requests and Issues`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 			{
 				"id": "githubpr",
 				"name": "githubpr",
-				"fullName": "GitHub",
+				"fullName": "GitHub Pull Requests and Issues",
 				"description": "Chat participant for GitHub Pull Requests extension",
 				"when": "config.githubPullRequests.experimental.chat"
 			}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 			{
 				"id": "githubpr",
 				"name": "githubpr",
-				"fullName": "GitHub Pull Requests and Issues",
+				"fullName": "GitHub Pull Requests",
 				"description": "Chat participant for GitHub Pull Requests extension",
 				"when": "config.githubPullRequests.experimental.chat"
 			}


### PR DESCRIPTION
Changing name of the participant to `Github Pull Requests and Issues` from `GitHub`

fixes https://github.com/microsoft/vscode-pull-request-github/issues/6358