### PR TITLE
Inaccurate result when asking for authored issues

### DIFF
--- a/src/lm/tools/searchTools.ts
+++ b/src/lm/tools/searchTools.ts
@@ -234,7 +234,7 @@ You are getting ready to make a GitHub search query. Given a natural language qu
 		if (labels.some(label => freeForm.includes(label) || label.includes(freeForm))) {
 			return '';
 		}
-		if (Object.keys(githubSearchSyntax).includes(freeForm)) {
+		if (Object.keys(githubSearchSyntax).find(searchPart => freeForm.includes(searchPart) || searchPart.includes(freeForm))) {
 			return '';
 		}
 		return freeForm;


### PR DESCRIPTION
Prevent GH search syntax words (ex. "author", "label", etc.) from apearing in the free-form search query.

Fixes #6362