### PR TITLE
Remove the python language user mention exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -547,9 +547,7 @@
 						"type": "string",
 						"description": "%githubIssues.ignoreUserCompletionTrigger.items%"
 					},
-					"default": [
-						"python"
-					],
+					"default": [],
 					"description": "%githubIssues.ignoreUserCompletionTrigger.description%"
 				},
 				"githubIssues.issueBranchTitle": {


### PR DESCRIPTION
Motivation: #6469 

Implementation:
* Remove the default `python` language exception for user tags (`@`)

Tests:
* Attempt to use python decorators without interjection from the extension