### PR TITLE
Don't show hover cards for @-mentioned users in JSDocs in jsx and tsx files

### DIFF
--- a/src/issues/userHoverProvider.ts
+++ b/src/issues/userHoverProvider.ts
@@ -32,7 +32,13 @@ export class UserHoverProvider implements vscode.HoverProvider {
 			if (match) {
 				const username = match[1];
 				// JS and TS doc checks
-				if (((document.languageId === 'javascript') || (document.languageId === 'typescript'))
+				const JS_TS_LANGUAGE_IDS = [
+					'javascript',
+					'javascriptreact',
+					'typescript',
+					'typescriptreact',
+				];
+				if (JS_TS_LANGUAGE_IDS.includes(document.languageId)
 					&& JSDOC_NON_USERS.indexOf(username) >= 0) {
 					return;
 				}


### PR DESCRIPTION
The fix in #3122 does not work for jsx and tsx files