### PR TITLE
Follow builtin VSCode behavior by respecting `git.showInlineOpenFileAction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2435,7 +2435,7 @@
 				{
 					"command": "review.openFile",
 					"group": "inline@0",
-					"when": "openDiffOnClick && view == prStatus:github && viewItem =~ /filechange(?!:DELETE)/"
+					"when": "openDiffOnClick && view == prStatus:github && viewItem =~ /filechange(?!:DELETE)/ && config.git.showInlineOpenFileAction"
 				},
 				{
 					"command": "pr.openDiffView",


### PR DESCRIPTION
Fixes #6515