### PR TITLE
When `copilot-swe-agent` is the author of a comment, render with the Copilot identity

### DIFF
--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -81,5 +81,6 @@ const COPILOT_AUTHOR = {
 
 export const SPECIAL_COMMENT_AUTHORS: { [key: string]: { postComment: string, name: string } } = {
 	'copilot-pull-request-reviewer': COPILOT_AUTHOR,
-	'copilot-swe-agent': COPILOT_AUTHOR
+	'copilot-swe-agent': COPILOT_AUTHOR,
+	'Copilot': COPILOT_AUTHOR
 };

--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -74,9 +74,12 @@ export interface IComment {
 	isResolved?: boolean;
 }
 
+const COPILOT_AUTHOR = {
+	name: 'Copilot', // TODO: The copilot reviewer is a Bot, but per the graphQL schema, Bots don't have a name, just a login. We have it hardcoded here for now.
+	postComment: vscode.l10n.t('Copilot is powered by AI, so mistakes are possible. Review output carefully before use.')
+};
+
 export const SPECIAL_COMMENT_AUTHORS: { [key: string]: { postComment: string, name: string } } = {
-	'copilot-pull-request-reviewer': {
-		name: 'Copilot', // TODO: The copilot reviewer is a Bot, but per the graphQL schema, Bots don't have a name, just a login. We have it hardcoded here for now.
-		postComment: vscode.l10n.t('Copilot is powered by AI, so mistakes are possible. Review output carefully before use.')
-	}
+	'copilot-pull-request-reviewer': COPILOT_AUTHOR,
+	'copilot-swe-agent': COPILOT_AUTHOR
 };

--- a/src/github/queries.gql
+++ b/src/github/queries.gql
@@ -52,6 +52,7 @@ fragment IssueBase on Issue {
 	title
 	titleHTML
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -66,6 +67,7 @@ fragment IssueBase on Issue {
 	}
 	assignees(first: 10) {
 		nodes {
+			...Actor
 			...User
 		}
 	}
@@ -125,6 +127,7 @@ fragment PullRequestFragment on PullRequest {
 	title
 	titleHTML
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -139,6 +142,7 @@ fragment PullRequestFragment on PullRequest {
 	}
 	assignees(first: 10) {
 		nodes {
+			...Actor
 			...User
 		}
 	}
@@ -217,8 +221,8 @@ fragment PullRequestFragment on PullRequest {
 		isAuthor
 		isCommenter
 		reviewer {
-			...User
 			...Actor
+			...User
 			...Node
 		}
 	}

--- a/src/github/queriesExtra.gql
+++ b/src/github/queriesExtra.gql
@@ -52,6 +52,7 @@ fragment IssueBase on Issue {
 	title
 	titleHTML
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -66,6 +67,7 @@ fragment IssueBase on Issue {
 	}
 	assignees(first: 10) {
 		nodes {
+			...Actor
 			...User
 		}
 	}
@@ -134,6 +136,7 @@ fragment PullRequestFragment on PullRequest {
 	title
 	titleHTML
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -148,6 +151,7 @@ fragment PullRequestFragment on PullRequest {
 	}
 	assignees(first: 10) {
 		nodes {
+			...Actor
 			...User
 		}
 	}
@@ -235,8 +239,8 @@ fragment PullRequestFragment on PullRequest {
 		isAuthor
 		isCommenter
 		reviewer {
-			...User
 			...Actor
+			...User
 			...Node
 		}
 	}

--- a/src/github/queriesLimited.gql
+++ b/src/github/queriesLimited.gql
@@ -41,6 +41,7 @@ fragment IssueBase on Issue {
 	title
 	titleHTML
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -55,6 +56,7 @@ fragment IssueBase on Issue {
 	}
 	assignees(first: 10) {
 		nodes {
+			...Actor
 			...User
 		}
 	}
@@ -114,6 +116,7 @@ fragment PullRequestFragment on PullRequest {
 	title
 	titleHTML
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -128,6 +131,7 @@ fragment PullRequestFragment on PullRequest {
 	}
 	assignees(first: 10) {
 		nodes {
+			...Actor
 			...User
 		}
 	}
@@ -195,8 +199,8 @@ fragment PullRequestFragment on PullRequest {
 		isAuthor
 		isCommenter
 		reviewer {
-			...User
 			...Actor
+			...User
 			...Node
 		}
 	}

--- a/src/github/queriesShared.gql
+++ b/src/github/queriesShared.gql
@@ -90,6 +90,7 @@ fragment Comment on IssueComment {
 	databaseId
 	authorAssociation
 	author {
+		...Actor
 		...User
 		...Organization
 	}
@@ -108,6 +109,7 @@ fragment Commit on PullRequestCommit {
 	commit {
 		author {
 			user {
+				...Actor
 				...User
 			}
 		}
@@ -129,6 +131,7 @@ fragment AssignedEvent on AssignedEvent {
 		...Actor
 	}
 	user {
+		...Actor
 		...User
 	}
 }
@@ -749,6 +752,7 @@ query GetMentionableUsers($owner: String!, $name: String!, $first: Int!, $after:
 	repository(owner: $owner, name: $name) {
 		mentionableUsers(first: $first, after: $after) {
 			nodes {
+				...Actor
 				...User
 			}
 			pageInfo {
@@ -766,6 +770,7 @@ query GetAssignableUsers($owner: String!, $name: String!, $first: Int!, $after: 
 	repository(owner: $owner, name: $name) {
 		assignableUsers(first: $first, after: $after) {
 			nodes {
+				...Actor
 				...User
 			}
 			pageInfo {

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -589,7 +589,7 @@ export function parseAccount(
 			avatarUrl: githubRepository ? getAvatarWithEnterpriseFallback(avatarUrl, undefined, githubRepository.remote.isEnterprise) : avatarUrl,
 			email: author.email ?? undefined,
 			id: id,
-			name: author.name ?? undefined,
+			name: author.name ?? SPECIAL_COMMENT_AUTHORS[author.login]?.name ?? undefined,
 			specialDisplayName: SPECIAL_COMMENT_AUTHORS[author.login] ? (author.name ?? SPECIAL_COMMENT_AUTHORS[author.login].name) : undefined,
 			accountType: toAccountType('__typename' in author ? author.__typename : author.type),
 		};


### PR DESCRIPTION
With Project Padawan ([external blog link](https://github.blog/news-insights/product-news/github-copilot-the-agent-awakens/)). we're building an autonomous, asynchronous SWE agent integrated into issues and PRs on GitHub.com.

You give Copilot a task by assigning an issue to Copilot via the normal issues UI - and under the hood, this is an assignment to a bot called `copilot-swe-agent`.

You can then interact with the agent using pull request reviews - including the ability to `@mention` it as you can a human.

As part of this, Copilot leaves comments. 

My changes (72f6a30) show those comments from Copilot under the `Copilot` identity, rather than `copilot-swe-agent`, piggy-backing on logic built for Copilot code review (`copilot-pull-request-reviewer`).

Relates to https://github.com/microsoft/vscode-pull-request-github/issues/6793.