### PR TITLE
Fix merge email confirmation when git config fails

### DIFF
--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -12,6 +12,7 @@ export const NEVER_SHOW_PULL_NOTIFICATION = 'github.pullRequest.pullNotification
 // Not synced keys
 export const REPO_KEYS = 'github.pullRequest.repos';
 export const PREVIOUS_CREATE_METHOD = 'github.pullRequest.previousCreateMethod';
+export const LAST_USED_EMAIL = 'github.pullRequest.lastUsedEmail';
 
 export interface RepoState {
 	mentionableUsers?: IAccount[];

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -466,6 +466,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 		message: IRequestMessage<MergeArguments>,
 	): Promise<void> {
 		const { title, description, method } = message.args;
+		const email = await this._folderRepositoryManager.getPreferredEmail(this._item);
 		const yes = vscode.l10n.t('Yes');
 		const confirmation = await vscode.window.showInformationMessage(
 			vscode.l10n.t('Merge this pull request?'),
@@ -478,7 +479,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 		}
 
 		this._folderRepositoryManager
-			.mergePullRequest(this._item, title, description, method)
+			.mergePullRequest(this._item, title, description, method, email)
 			.then(result => {
 				vscode.commands.executeCommand('pr.refreshList');
 

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -419,16 +419,8 @@ export class CredentialStore extends Disposable {
 				Logger.error(`Failed to get current user: ${e}, ${e.message}`, CredentialStore.ID);
 			});
 		});
-		github.currentUser = new Promise(resolve => {
-			getUser.then(result => {
-				resolve(convertRESTUserToAccount(result.data));
-			});
-		});
-		github.isEmu = new Promise(resolve => {
-			getUser.then(result => {
-				resolve(result.data.plan?.name === 'emu_user');
-			});
-		});
+		github.currentUser = getUser.then(result => convertRESTUserToAccount(result.data));
+		github.isEmu = getUser.then(result => result.data.plan?.name === 'emu_user');
 	}
 
 	private async getSession(authProviderId: AuthProvider, getAuthSessionOptions: vscode.AuthenticationGetSessionOptions, scopes: string[], requireScopes: boolean): Promise<{ session: vscode.AuthenticationSession | undefined, isNew: boolean, scopes: string[] }> {

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -2802,6 +2802,19 @@ export class FolderRepositoryManager extends Disposable {
 		}
 	}
 
+	public async getPreferredEmail(pullRequest: PullRequestModel): Promise<string | undefined> {
+		const isEmu = await this.credentialStore.getIsEmu(pullRequest.remote.authProviderId);
+		const gitHubEmails = await pullRequest.githubRepository.getAuthenticatedUserEmails();
+		const gitEmail = await PullRequestGitHelper.getEmail(this.repository);
+
+		if (isEmu) {
+			return undefined;
+		}
+
+		// If `gitEmail` is an empty string, then use the first GitHub email
+		return gitEmail && gitHubEmails.find(email => email.toLowerCase() === gitEmail.toLowerCase()) || gitHubEmails[0];
+	}
+
 	public getTitleAndDescriptionProvider(searchTerm?: string) {
 		return this._git.getTitleAndDescriptionProvider(searchTerm);
 	}

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -2803,7 +2803,7 @@ export class FolderRepositoryManager extends Disposable {
 	}
 
 	public saveLastUsedEmail(email: string | undefined) {
-		this.context.globalState.update(LAST_USED_EMAIL, email);
+		return this.context.globalState.update(LAST_USED_EMAIL, email);
 	}
 
 	public async getPreferredEmail(pullRequest: PullRequestModel): Promise<string | undefined> {

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -895,7 +895,8 @@ export class GitHubRepository extends Disposable {
 			const { octokit } = await this.ensure();
 			const { data } = await octokit.call(octokit.api.users.listEmailsForAuthenticatedUser, {});
 			Logger.debug(`Fetch authenticated user emails - done`, this.id);
-			return data.map(email => email.email);
+			// sort the primary email to the first index
+			return data.sort((a, b) => +b.primary - +a.primary).map(email => email.email);
 		} catch (e) {
 			Logger.error(`Unable to fetch authenticated user emails: ${e}`, this.id);
 			return [];

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -517,6 +517,9 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 
 	private async changeEmail(message: IRequestMessage<string>): Promise<void> {
 		const email = await pickEmail(this._item.githubRepository, message.args);
+		if (email) {
+			this._folderRepositoryManager.saveLastUsedEmail(email);
+		}
 		return this._replyMessage(message, email ?? message.args);
 	}
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -214,9 +214,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 			this._folderRepositoryManager.mergeQueueMethodForBranch(pullRequestModel.base.ref, pullRequestModel.remote.owner, pullRequestModel.remote.repositoryName),
 			this._folderRepositoryManager.isHeadUpToDateWithBase(pullRequestModel),
 			pullRequestModel.getMergeability(),
-			this._folderRepositoryManager.credentialStore.getIsEmu(pullRequestModel.remote.authProviderId),
-			pullRequestModel.githubRepository.getAuthenticatedUserEmails(),
-			PullRequestGitHelper.getEmail(this._folderRepositoryManager.repository)])
+			this._folderRepositoryManager.getPreferredEmail(pullRequestModel)])
 			.then(result => {
 				const [
 					pullRequest,
@@ -232,9 +230,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 					mergeQueueMethod,
 					isBranchUpToDateWithBase,
 					mergeability,
-					isEmu,
-					gitHubEmails,
-					gitEmail
+					emailForCommit,
 				] = result;
 				if (!pullRequest) {
 					throw new Error(
@@ -256,7 +252,6 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 
 				const isUpdateBranchWithGitHubEnabled: boolean = this.isUpdateBranchWithGitHubEnabled();
 				const reviewState = this.getCurrentUserReviewState(this._existingReviewers, currentUser);
-				const emailForCommit = isEmu ? undefined : ((gitEmail && gitHubEmails.find(email => email.toLowerCase() === gitEmail.toLowerCase())) ?? currentUser.email);
 
 				Logger.debug('pr.initialize', PullRequestOverviewPanel.ID);
 				const baseContext = this.getInitializeContext(pullRequest, timelineEvents, repositoryAccess, viewerCanEdit);


### PR DESCRIPTION
Centralizes the preferred email logic for a `PullRequestModel` in the `FolderRepositoryManager`.

`PullRequestGitHelper.getEmail` can return an empty string when it is unable to find `user.email` in the local or global config. This can occur when the `user.email` config is set in a different scope (system, worktree) or its in an include file of the requested (local, global) scope (`git config` is not run with the `--includes` argument). Ideally there would be an API method to get config from _any_ scope, sadly this is not exposed on the `Repository` interface from the core git extension. If we are unable to get the email from git config, continue to default to the primary GitHub email and allow users to manually select the correct address to use.

Use this same default email logic in the Activity Bar View so that the merge buttons behave in a similar manner with regard to what email is used for merge commits.

See #6593, #6696