### PR TITLE
When a review fails to submit, the buttons stay disabled and you have to re-open the webview to get them back.

### DIFF
--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -126,14 +126,20 @@ export class PRContext {
 		this.updatePR({ pendingCommentDrafts: pendingCommentDrafts });
 	};
 
-	public requestChanges = async (body: string) =>
-		this.appendReview(await this.postMessage({ command: 'pr.request-changes', args: body }));
+	private async submitReviewCommand(command: string, body: string) {
+		try {
+			const result: SubmitReviewReply = await this.postMessage({ command, args: body });
+			return this.appendReview(result);
+		} catch (error) {
+			return this.updatePR({ busy: false });
+		}
+	}
 
-	public approve = async (body: string) =>
-		this.appendReview(await this.postMessage({ command: 'pr.approve', args: body }));
+	public requestChanges = (body: string) => this.submitReviewCommand('pr.request-changes', body);
 
-	public submit = async (body: string) =>
-		this.appendReview(await this.postMessage({ command: 'pr.submit', args: body }));
+	public approve = (body: string) => this.submitReviewCommand('pr.approve', body);
+
+	public submit = (body: string) => this.submitReviewCommand('pr.submit', body);
 
 	public close = async (body?: string) => {
 		try {

--- a/webviews/components/timeline.tsx
+++ b/webviews/components/timeline.tsx
@@ -209,7 +209,7 @@ function AddReviewSummaryComment() {
 	const comment = useRef<HTMLTextAreaElement>();
 	const [isBusy, setBusy] = useState(false);
 
-	async function submitAction(event: React.MouseEvent, action: ReviewType): Promise<void> {
+	async function submitAction(event: React.MouseEvent | React.KeyboardEvent, action: ReviewType): Promise<void> {
 		event.preventDefault();
 		const { value } = comment.current!;
 		setBusy(true);
@@ -226,9 +226,20 @@ function AddReviewSummaryComment() {
 		setBusy(false);
 	}
 
+	const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+			submitAction(event, ReviewType.Comment);
+		}
+	};
+
 	return (
 		<form>
-			<textarea id='pending-review' ref={comment} placeholder="Leave a review summary comment"></textarea>
+			<textarea
+				id='pending-review'
+				ref={comment}
+				placeholder="Leave a review summary comment"
+				onKeyDown={onKeyDown}
+			></textarea>
 			<div className="form-actions">
 				{isAuthor ? null : (
 					<button


### PR DESCRIPTION
Fixes #6913