### PR TITLE
Enable all LLM tools in prompts (agent mode)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3724,7 +3724,7 @@
 				"displayName": "%languageModelTools.github-pull-request_notification_fetch.displayName%",
 				"modelDescription": "Get a GitHub notification's details as a JSON object.",
 				"icon": "$(info)",
-				"canBeReferencedInPrompt": true,
+				"canBeReferencedInPrompt": false,
 				"inputSchema": {
 					"type": "object",
 					"properties": {
@@ -3750,7 +3750,7 @@
 				"displayName": "%languageModelTools.github-pull-request_issue_summarize.displayName%",
 				"modelDescription": "Summarizes a GitHub issue or pull request. A summary is a great way to describe an issue or pull request.",
 				"icon": "$(info)",
-				"canBeReferencedInPrompt": true,
+				"canBeReferencedInPrompt": false,
 				"inputSchema": {
 					"type": "object",
 					"properties": {
@@ -3825,7 +3825,7 @@
 				"displayName": "%languageModelTools.github-pull-request_notification_summarize.displayName%",
 				"modelDescription": "Summarizes a GitHub notification. A summary is a great way to describe a notification.",
 				"icon": "$(info)",
-				"canBeReferencedInPrompt": true,
+				"canBeReferencedInPrompt": false,
 				"inputSchema": {
 					"type": "object",
 					"properties": {


### PR DESCRIPTION
Enables [`canBeReferencedInPrompt`](https://code.visualstudio.com/api/extension-guides/tools) for all LLM tools.

> Set to `true` if the tool can be used in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode.md) or referenced in chat.

Previously, these tools could only be used via the `@githubpr` chat participant. Only the `activePullRequest` tool was available directly. Now, they can all be called with `#` syntax or invoked by agent mode.

Perhaps this was disabled intentionally and there is additional polish to do. But this works and https://github.com/microsoft/vscode-pull-request-github/issues/6792#issuecomment-2862104548 suggested that there was some confusion on whether this is live today (it's not).

## Before

![Screenshot 2025-05-14 at 11 48 59](https://github.com/user-attachments/assets/a16d8010-2900-401d-8c73-a792243fb0cc)

![Screenshot 2025-05-14 at 11 53 36](https://github.com/user-attachments/assets/6fbf6551-6a16-4f14-a026-9d42316f2f17)

Using the web fetch tool works for public repositories, albeit with a lot of HTML noise as compared to feeding the model a JSON representation of the issue.

Agent mode is unable to fetch details about any issues in private repositories.

## After

![Screenshot 2025-05-14 at 11 44 13](https://github.com/user-attachments/assets/51246064-1f09-4029-8470-71c8aa6a2f27)
![Screenshot 2025-05-14 at 11 45 07](https://github.com/user-attachments/assets/38e5f983-6c22-4889-8cf6-b9c22178d5f5)

## Related

* https://github.com/microsoft/vscode-pull-request-github/issues/6792