### PR TITLE
fix: Allow Github.com auth when `github-enterprise.uri` is set

### DIFF
--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -221,7 +221,6 @@ export class CredentialStore extends Disposable {
 	}
 
 	private async doCreate(options: vscode.AuthenticationGetSessionOptions, additionalScopes: boolean = false): Promise<AuthResult> {
-		const github = await this.initialize(AuthProvider.github, options, additionalScopes ? SCOPES_WITH_ADDITIONAL : undefined, additionalScopes);
 		let enterprise: AuthResult | undefined;
 		const initializeEnterprise = async () => {
 			enterprise = await this.initialize(AuthProvider.githubEnterprise, options, additionalScopes ? SCOPES_WITH_ADDITIONAL : undefined, additionalScopes);
@@ -232,6 +231,11 @@ export class CredentialStore extends Disposable {
 			// Listen for changes to the enterprise URI and try again if it changes.
 			initBasedOnSettingChange(GITHUB_ENTERPRISE, URI, hasEnterpriseUri, initializeEnterprise, this.context.subscriptions);
 		}
+		const githubOptions = { ...options };
+		if (enterprise && !enterprise.canceled) {
+			githubOptions.silent = true;
+		}
+		const github = await this.initialize(AuthProvider.github, githubOptions, additionalScopes ? SCOPES_WITH_ADDITIONAL : undefined, additionalScopes);
 		return {
 			canceled: github.canceled || !!(enterprise && enterprise.canceled)
 		};

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -221,6 +221,7 @@ export class CredentialStore extends Disposable {
 	}
 
 	private async doCreate(options: vscode.AuthenticationGetSessionOptions, additionalScopes: boolean = false): Promise<AuthResult> {
+		const github = await this.initialize(AuthProvider.github, options, additionalScopes ? SCOPES_WITH_ADDITIONAL : undefined, additionalScopes);
 		let enterprise: AuthResult | undefined;
 		const initializeEnterprise = async () => {
 			enterprise = await this.initialize(AuthProvider.githubEnterprise, options, additionalScopes ? SCOPES_WITH_ADDITIONAL : undefined, additionalScopes);
@@ -231,12 +232,8 @@ export class CredentialStore extends Disposable {
 			// Listen for changes to the enterprise URI and try again if it changes.
 			initBasedOnSettingChange(GITHUB_ENTERPRISE, URI, hasEnterpriseUri, initializeEnterprise, this.context.subscriptions);
 		}
-		let github: AuthResult | undefined;
-		if (!enterprise) {
-			github = await this.initialize(AuthProvider.github, options, additionalScopes ? SCOPES_WITH_ADDITIONAL : undefined, additionalScopes);
-		}
 		return {
-			canceled: !!(github && github.canceled) || !!(enterprise && enterprise.canceled)
+			canceled: github.canceled || !!(enterprise && enterprise.canceled)
 		};
 	}
 


### PR DESCRIPTION
## Problem
Since version `0.110.0`, setting the following configuration:

```json
"github-enterprise.uri": "https://someghe.com"
```

causes the GitHub.com authentication flow to be skipped entirely. This results in:
- No prompt to authenticate with `github.com`
- Pull Request extension for `Github.com` repos breaking silently

For many developers (including myself), contributing to both `github.com` and a company-hosted GitHub Enterprise is common. 

Even though the config can be set **per workspace**, it can be tedious to maintain across multiple repositories. 
And, in practice, setting `github-enterprise.uri` in user settings makes more sense. But this intentionally disables `github.com` functionality with the current logic.

## What does change?
This PR updates `doCreate` so that GitHub.com is initialized even though the enterprise URI is configured.
This mirrors pre-`0.110.0` behavior.

### Before

![before](https://github.com/user-attachments/assets/bee2ce3c-821f-4235-975c-785c0b8ec243)

### After

![after](https://github.com/user-attachments/assets/47b48a80-e9e0-4d6a-be6a-c9a016a91312)




