### PR TITLE
Open GH session url when session logs API fails

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,7 +234,7 @@ async function init(
 
 	context.subscriptions.push(new GitLensIntegration());
 
-	const sessionLogViewManager = new SessionLogViewManager(credentialStore, context, reposManager, telemetry);
+	const sessionLogViewManager = new SessionLogViewManager(credentialStore, context, reposManager, telemetry, copilotRemoteAgentManager);
 	context.subscriptions.push(sessionLogViewManager);
 
 	await vscode.commands.executeCommand('setContext', 'github:initialized', true);

--- a/src/lm/tools/activePullRequestTool.ts
+++ b/src/lm/tools/activePullRequestTool.ts
@@ -98,8 +98,8 @@ export class ActivePullRequestTool implements vscode.LanguageModelTool<FetchIssu
 	): Promise<string | string[]> {
 		let copilotSteps: string | string[] = [];
 		try {
-			const logsResponseText = await this.copilotRemoteAgentManager.getSessionLogsFromAPI(pullRequest);
-			copilotSteps = this.parseCopilotEventStream(logsResponseText);
+			const logsResponseText = await this.copilotRemoteAgentManager.getSessionLogsFromPullRequest(pullRequest);
+			copilotSteps = this.parseCopilotEventStream(logsResponseText.logs);
 			if (copilotSteps.length === 0) {
 				throw new Error('Empty Copilot agent logs received');
 			}


### PR DESCRIPTION
If we fail to fetch the session logs, it will open the url of the gh action in the browser:
![image](https://github.com/user-attachments/assets/57385d7f-b4fd-496c-a795-7701cad0738b)
