### PR TITLE
Fix placeholder text case in projects section of sidebar

### DIFF
--- a/webviews/components/sidebar.tsx
+++ b/webviews/components/sidebar.tsx
@@ -186,7 +186,7 @@ export default function Sidebar({ reviewers, labels, hasWritePermission, isIssue
 							? projects.map(project => (
 								<Project key={project.project.title} {...project} canDelete={hasWritePermission} />
 							)) :
-							<div className="section-placeholder">None Yet</div>
+							<div className="section-placeholder">None yet</div>
 					}
 				</div>
 			}


### PR DESCRIPTION
This pull request includes a minor text change in the `Sidebar` component. The placeholder text "None Yet" was updated to "None yet" for consistency in capitalization.