### PR TITLE
Hide some recently added commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -2058,6 +2058,14 @@
 					"when": "false"
 				},
 				{
+					"command": "pr.applyChangesFromDescription",
+					"when": "false"
+				},
+				{
+					"command": "pr.checkoutChatSessionPullRequest",
+					"when": "false"
+				},
+				{
 					"command": "pr.checkoutOnVscodeDevFromDescription",
 					"when": "false"
 				},


### PR DESCRIPTION
They shouldn't be shown in the command palette as they are intended to be used exclusively from other menus.

@rebornix FYI because of https://github.com/microsoft/vscode-pull-request-github/pull/7669#discussion_r2303277666 and https://github.com/microsoft/vscode-pull-request-github/pull/7690#discussion_r2306609481