### PR TITLE
Add viewport detection and count display for collapsed labels in sidebar

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -1536,6 +1536,10 @@ svg.octicon path {
 	flex-shrink: 0;
 }
 
+.collapsed-section-count {
+	color: var(--vscode-descriptionForeground);
+}
+
 .pill-container {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Addresses #7732

Implement viewport detection to adjust the display of label counts in the sidebar based on screen width. This enhancement improves usability by showing counts in narrow viewports while maintaining the original display in wider views.