### PR TITLE
Adjust margin for inlined-dropdown buttons for better spacing

### DIFF
--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -455,9 +455,13 @@ button.input-box:focus {
 button.inlined-dropdown {
 	width: 100%;
 	max-width: 150px;
-	margin-right: 5px;
+	margin-right: 8px;
 	display: inline-block;
 	text-align: center;
+}
+
+button.inlined-dropdown:last-child {
+	margin-right: 0;
 }
 
 .spinner {


### PR DESCRIPTION
Increase the right margin for inlined-dropdown buttons to enhance spacing and ensure the last button has no margin.