### PR TITLE
Filter out repeat sessions

### DIFF
--- a/src/github/copilotRemoteAgent/chatSessionContentBuilder.ts
+++ b/src/github/copilotRemoteAgent/chatSessionContentBuilder.ts
@@ -30,9 +30,13 @@ export class ChatSessionContentBuilder {
 		capi: CopilotApi,
 		timelineEventsPromise: Promise<TimelineEvent[]>
 	): Promise<Array<vscode.ChatRequestTurn | vscode.ChatResponseTurn2>> {
-		const sortedSessions = sessions.slice().sort((a, b) =>
-			new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-		);
+		const sortedSessions = sessions
+			.filter((session, index, array) =>
+				array.findIndex(s => s.id === session.id) === index
+			)
+			.slice().sort((a, b) =>
+				new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+			);
 
 		// Process all sessions concurrently while maintaining order
 		const sessionResults = await Promise.all(


### PR DESCRIPTION
Before: 
<img width="1160" height="840" alt="Screenshot 2025-09-22 at 9 39 19 AM" src="https://github.com/user-attachments/assets/9f5054a9-a6b6-42b0-9436-e5160d6c42d5" />

After: 
<img width="801" height="630" alt="image" src="https://github.com/user-attachments/assets/cd7ab568-dbad-4f4c-a439-1e4a1644f786" />

Capi seems to now return >1 copy of a session. 
<img width="578" height="86" alt="image" src="https://github.com/user-attachments/assets/3086d5a6-af2d-4faf-9286-14bca19cbde9" />
