### PR TITLE
extension explodes and kicks back out to GITHUB: LOGIN when non github repos are in working directory (specifically codeberg)

### DIFF
--- a/src/authentication/githubServer.ts
+++ b/src/authentication/githubServer.ts
@@ -14,7 +14,7 @@ import { HostHelper } from './configuration';
 export class GitHubManager {
 	private static readonly _githubDotComServers = new Set<string>().add('github.com').add('ssh.github.com');
 	private static readonly _gheServers = new Set<string>().add('ghe.com');
-	private static readonly _neverGitHubServers = new Set<string>().add('bitbucket.org').add('gitlab.com');
+	private static readonly _neverGitHubServers = new Set<string>().add('bitbucket.org').add('gitlab.com').add('codeberg.org');
 	private _knownServers: Map<string, GitHubServerType> = new Map([...Array.from(GitHubManager._githubDotComServers.keys()).map(key => [key, GitHubServerType.GitHubDotCom]), ...Array.from(GitHubManager._gheServers.keys()).map(key => [key, GitHubServerType.Enterprise])] as [string, GitHubServerType][]);
 
 	public static isGithubDotCom(host: string): boolean {

--- a/src/github/folderRepositoryManager.ts
+++ b/src/github/folderRepositoryManager.ts
@@ -464,7 +464,7 @@ export class FolderRepositoryManager extends Disposable {
 			// good
 		} else if ((enterpriseCount > 0) && this._credentialStore.isAuthenticated(AuthProvider.githubEnterprise)) {
 			// also good
-		} else if (isAuthenticated) {
+		} else if (isAuthenticated && ((dotComCount > 0) || (enterpriseCount > 0))) {
 			// Not good. We have a mismatch between auth type and server type.
 			isAuthenticated = false;
 		}


### PR DESCRIPTION
Fixes #6945