### PR TITLE
Add friendly title for PR link

### DIFF
--- a/src/github/copilotRemoteAgent.ts
+++ b/src/github/copilotRemoteAgent.ts
@@ -920,7 +920,7 @@ export class CopilotRemoteAgentManager extends Disposable {
 				const tooltip = await issueMarkdown(pullRequest, this.context, this.repositoriesManager);
 
 				const uri = await toOpenPullRequestWebviewUri({ owner: pullRequest.remote.owner, repo: pullRequest.remote.repositoryName, pullRequestNumber: pullRequest.number });
-				const prLinkTitle = vscode.l10n.t('Click to open this pull request in VS Code');
+				const prLinkTitle = vscode.l10n.t('Open pull request in VS Code');
 				const description = new vscode.MarkdownString(`[#${pullRequest.number}](${uri.toString()} "${prLinkTitle}")`); //  pullRequest.base.ref === defaultBranch ? `PR #${pullRequest.number}`: `PR #${pullRequest.number} → ${pullRequest.base.ref}`;
 				return {
 					id: `${pullRequest.number}`,


### PR DESCRIPTION
Fixes [#264641](https://github.com/microsoft/vscode/issues/264641)

Add user friendly title to PR link markdown so that link tool tip in chat window shows up with this title instead of the full PR link URL.

This is the new tooltip UI with this change:

<img width="1536" height="864" alt="image" src="https://github.com/user-attachments/assets/c0bb8fc2-f4ef-4315-9d8e-60790429e2c3" />
