### PR TITLE
Make branch list timeout configurable (#2840)

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,12 @@
 					"description": "%githubPullRequests.logLevel.description%",
 					"markdownDeprecationMessage": "%githubPullRequests.logLevel.markdownDeprecationMessage%"
 				},
+				"githubPullRequests.branchListTimeout": {
+					"type": "number",
+					"default": 5000,
+					"minimum": 1000,
+					"markdownDescription": "%githubPullRequests.branchListTimeout.description%"
+				},
 				"githubPullRequests.remotes": {
 					"type": "array",
 					"default": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,6 +20,7 @@
 			"{Locked='](command:workbench.action.setLogLevel)'}"
 		]
 	},
+	"githubPullRequests.branchListTimeout.description": "Maximum time in milliseconds to wait when fetching the list of branches for pull request creation. Repositories with thousands of branches may need a higher value to ensure all branches (including the default branch) are retrieved. Minimum value is 1000 (1 second).",
 	"githubPullRequests.codingAgent.description": "Enables integration with the asynchronous Copilot coding agent. The '#copilotCodingAgent' tool will be available in agent mode when this setting is enabled.",
 	"githubPullRequests.codingAgent.uiIntegration.description": "Enables UI integration within VS Code to create new coding agent sessions.",
 	"githubPullRequests.codingAgent.autoCommitAndPush.description": "Allow automatic git operations (commit, push) to be performed when starting a coding agent session",

--- a/src/common/settingKeys.ts
+++ b/src/common/settingKeys.ts
@@ -6,6 +6,7 @@
 export const PR_SETTINGS_NAMESPACE = 'githubPullRequests';
 export const TERMINAL_LINK_HANDLER = 'terminalLinksHandler';
 export const BRANCH_PUBLISH = 'createOnPublishBranch';
+export const BRANCH_LIST_TIMEOUT = 'branchListTimeout';
 export const USE_REVIEW_MODE = 'useReviewMode';
 export const FILE_LIST_LAYOUT = 'fileListLayout';
 export const HIDE_VIEWED_FILES = 'hideViewedFiles';

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -11,6 +11,7 @@ import { AuthenticationError, AuthProvider, GitHubServerType, isSamlError } from
 import { Disposable, disposeAll } from '../common/lifecycle';
 import Logger from '../common/logger';
 import { GitHubRemote, parseRemote } from '../common/remote';
+import { BRANCH_LIST_TIMEOUT, PR_SETTINGS_NAMESPACE } from '../common/settingKeys';
 import { ITelemetry } from '../common/telemetry';
 import { PullRequestCommentController } from '../view/pullRequestCommentController';
 import { PRCommentControllerRegistry } from '../view/pullRequestCommentControllerRegistry';
@@ -1194,6 +1195,7 @@ export class GitHubRepository extends Disposable {
 		const branches: string[] = [];
 		const defaultBranch = (await this.getMetadataForRepo(owner, repositoryName)).default_branch;
 		const startingTime = new Date().getTime();
+		const timeout = vscode.workspace.getConfiguration(PR_SETTINGS_NAMESPACE).get<number>(BRANCH_LIST_TIMEOUT, 5000);
 
 		do {
 			try {
@@ -1208,8 +1210,8 @@ export class GitHubRepository extends Disposable {
 				});
 
 				branches.push(...data.repository.refs.nodes.map(node => node.name));
-				if (new Date().getTime() - startingTime > 5000) {
-					Logger.warn('List branches timeout hit.', this.id);
+				if (new Date().getTime() - startingTime > timeout) {
+					Logger.warn(`List branches timeout hit after ${timeout}ms.`, this.id);
 					break;
 				}
 				hasNextPage = data.repository.refs.pageInfo.hasNextPage;


### PR DESCRIPTION
Added a new setting `githubPullRequests.branchListTimeout`, allowing users to set the maximum time (in milliseconds) to wait when fetching branches for pull request creation.