### PR TITLE
Fixed issues with remote agent for workspace having multiple repos

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -226,7 +226,7 @@ export function registerCommands(
 					if (activePullRequests.length >= 1) {
 						const result = await chooseItem<PullRequestModel>(
 							activePullRequests,
-							itemValue => itemValue.html_url,
+							itemValue => ({ label: itemValue.html_url }),
 						);
 						if (result) {
 							openPullRequestOnGitHub(result, telemetry);
@@ -263,7 +263,7 @@ export function registerCommands(
 					? (
 						await chooseItem(
 							activePullRequestsWithFolderManager,
-							itemValue => itemValue.activePr.html_url,
+							itemValue => ({ label: itemValue.activePr.html_url }),
 						)
 					)
 					: activePullRequestsWithFolderManager[0];
@@ -442,7 +442,7 @@ export function registerCommands(
 		}
 		return chooseItem<ReviewManager>(
 			reviewsManager.reviewManagers,
-			itemValue => pathLib.basename(itemValue.repository.rootUri.fsPath),
+			itemValue => ({ label: pathLib.basename(itemValue.repository.rootUri.fsPath) }),
 			{ placeHolder: vscode.l10n.t('Choose a repository to create a pull request in'), ignoreFocusOut: true },
 		);
 	}
@@ -794,7 +794,7 @@ export function registerCommands(
 				pullRequestModel = await chooseItem<PullRequestModel>(reposManager.folderManagers
 					.map(folderManager => folderManager.activePullRequest!)
 					.filter(activePR => !!activePR),
-					itemValue => `${itemValue.number}: ${itemValue.title}`,
+					itemValue => ({ label: `${itemValue.number}: ${itemValue.title}` }),
 					{ placeHolder: vscode.l10n.t('Choose the pull request to exit') });
 			} else {
 				pullRequestModel = pr;
@@ -932,7 +932,7 @@ export function registerCommands(
 			if (activePullRequests.length >= 1) {
 				issueModel = await chooseItem<PullRequestModel>(
 					activePullRequests,
-					itemValue => itemValue.title,
+					itemValue => ({ label: itemValue.title }),
 				);
 			}
 		} else {
@@ -1610,7 +1610,7 @@ ${contents}
 					.filter(activePR => !!activePR);
 				pr = await chooseItem<PullRequestModel>(
 					activePullRequests,
-					itemValue => `${itemValue.number}: ${itemValue.title}`,
+					itemValue => ({ label: `${itemValue.number}: ${itemValue.title}` }),
 					{ placeHolder: vscode.l10n.t('Pull request to create a link for') },
 				);
 			}
@@ -1666,7 +1666,7 @@ ${contents}
 			}
 			const githubRepo = await chooseItem<{ manager: FolderRepositoryManager, repo: GitHubRepository }>(
 				githubRepositories,
-				itemValue => `${itemValue.repo.remote.owner}/${itemValue.repo.remote.repositoryName}`,
+				itemValue => ({ label: `${itemValue.repo.remote.owner}/${itemValue.repo.remote.repositoryName}` }),
 				{ placeHolder: vscode.l10n.t('Which GitHub repository do you want to checkout the pull request from?') }
 			);
 			if (!githubRepo) {
@@ -1702,7 +1702,7 @@ ${contents}
 		});
 		return chooseItem<GitHubRepository>(
 			githubRepositories,
-			itemValue => `${itemValue.remote.owner}/${itemValue.remote.repositoryName}`,
+			itemValue => ({ label: `${itemValue.remote.owner}/${itemValue.remote.repositoryName}` }),
 			{ placeHolder: vscode.l10n.t('Which GitHub repository do you want to open?') }
 		);
 	}
@@ -1926,7 +1926,7 @@ ${contents}
 
 			const pr = await chooseItem<PullRequestModel>(
 				activePullRequests,
-				itemValue => `${itemValue.number}: ${itemValue.title}`,
+				itemValue => ({ label: `${itemValue.number}: ${itemValue.title}` }),
 				{ placeHolder: vscode.l10n.t('Pull request to create a link for') },
 			);
 			if (pr) {

--- a/src/github/copilotRemoteAgent.ts
+++ b/src/github/copilotRemoteAgent.ts
@@ -426,7 +426,7 @@ export class CopilotRemoteAgentManager extends Disposable {
 	private chooseFolderManager(): Promise<FolderRepositoryManager | undefined> {
 		return chooseItem<FolderRepositoryManager>(
 			this.repositoriesManager.folderManagers,
-			itemValue => pathLib.basename(itemValue.repository.rootUri.fsPath),
+			itemValue => ({ label: pathLib.basename(itemValue.repository.rootUri.fsPath) }),
 		);
 	}
 
@@ -461,7 +461,7 @@ export class CopilotRemoteAgentManager extends Disposable {
 
 		const result = await chooseItem<GitHubRemote>(
 			ghRemotes,
-			itemValue => `${itemValue.remoteName} (${itemValue.owner}/${itemValue.repositoryName})`,
+			itemValue => ({ label: itemValue.remoteName, description: `(${itemValue.owner}/${itemValue.repositoryName})` }),
 			{
 				title: vscode.l10n.t('Coding agent will create pull requests against the selected remote.'),
 			}
@@ -665,6 +665,8 @@ export class CopilotRemoteAgentManager extends Disposable {
 			summary,
 			undefined,
 			autoPushAndCommit,
+			undefined,
+			fm
 		);
 
 		if (result.state !== 'success') {
@@ -728,7 +730,7 @@ export class CopilotRemoteAgentManager extends Disposable {
 		return vscode.l10n.t('🚀 Coding agent will continue work in [#{0}]({1}).  Track progress [here]({2}).', number, link, webviewUri.toString());
 	}
 
-	async invokeRemoteAgent(prompt: string, problemContext?: string, token?: vscode.CancellationToken, autoPushAndCommit = true, chatStream?: vscode.ChatResponseStream): Promise<RemoteAgentResult> {
+	async invokeRemoteAgent(prompt: string, problemContext?: string, token?: vscode.CancellationToken, autoPushAndCommit = true, chatStream?: vscode.ChatResponseStream, fm?: FolderRepositoryManager): Promise<RemoteAgentResult> {
 		const capiClient = await this.copilotApi;
 		if (!capiClient) {
 			return { error: vscode.l10n.t('Failed to initialize Copilot API. Please try again later.'), state: 'error' };
@@ -736,7 +738,7 @@ export class CopilotRemoteAgentManager extends Disposable {
 
 		await this.promptAndUpdatePreferredGitHubRemote(true);
 
-		const repoInfo = await this.repoInfo();
+		const repoInfo = await this.repoInfo(fm);
 		if (!repoInfo) {
 			return { error: vscode.l10n.t('No repository information found. Please open a workspace with a GitHub repository.'), state: 'error' };
 		}
@@ -1108,7 +1110,16 @@ export class CopilotRemoteAgentManager extends Disposable {
 
 				const uri = await toOpenPullRequestWebviewUri({ owner: pullRequest.remote.owner, repo: pullRequest.remote.repositoryName, pullRequestNumber: pullRequest.number });
 				const prLinkTitle = vscode.l10n.t('Open pull request in VS Code');
-				const description = new vscode.MarkdownString(`[#${pullRequest.number}](${uri.toString()} "${prLinkTitle}")`); //  pullRequest.base.ref === defaultBranch ? `PR #${pullRequest.number}`: `PR #${pullRequest.number} → ${pullRequest.base.ref}`;
+
+				// If we have multiple repositories, include the repo name in the link text
+				// e.g., 'owner/repo #123' instead of just '#123'
+				let repoInfo = '';
+				if (this.repositoriesManager.folderManagers.length > 1) {
+					const owner = pullRequest.remote.owner;
+					const repo = pullRequest.remote.repositoryName;
+					repoInfo = `${owner}/${repo} `;
+				}
+				const description = new vscode.MarkdownString(`[${repoInfo}#${pullRequest.number}](${uri.toString()} "${prLinkTitle}")`); //  pullRequest.base.ref === defaultBranch ? `PR #${pullRequest.number}`: `PR #${pullRequest.number} → ${pullRequest.base.ref}`;
 				return {
 					id: `${pullRequest.number}`,
 					label: pullRequest.title || `Session ${pullRequest.number}`,

--- a/src/github/quickPicks.ts
+++ b/src/github/quickPicks.ts
@@ -20,7 +20,7 @@ import { formatError } from '../common/utils';
 
 export async function chooseItem<T>(
 	itemsToChooseFrom: T[],
-	propertyGetter: (itemValue: T) => string,
+	propertyGetter: (itemValue: T) => { label: string; description?: string; },
 	options?: vscode.QuickPickOptions,
 ): Promise<T | undefined> {
 	if (itemsToChooseFrom.length === 0) {
@@ -34,7 +34,7 @@ export async function chooseItem<T>(
 	}
 	const items: Item[] = itemsToChooseFrom.map(currentItem => {
 		return {
-			label: propertyGetter(currentItem),
+			...propertyGetter(currentItem),
 			itemValue: currentItem,
 		};
 	});


### PR DESCRIPTION
Fixed following issues:
- No idea what repo coding agent was working on #264555
- Remote agent picks incorrect repo from workspace with multiple repos #270672

Attached gif is demo of the fixes. Remote agent now uses the repo picked  and the repo owner/name shows up in the sessions list.

![repoFix](https://github.com/user-attachments/assets/32409636-bb5a-408b-a8ca-2154918f437b)
