### PR TITLE
fix: ignore null in timeline event

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -262,7 +262,7 @@ export interface TimelineEventsResponse {
 	repository: {
 		pullRequest: {
 			timelineItems: {
-				nodes: (MergedEvent | Review | IssueComment | Commit | AssignedEvent | HeadRefDeletedEvent)[];
+				nodes: (MergedEvent | Review | IssueComment | Commit | AssignedEvent | HeadRefDeletedEvent | null)[];
 			};
 		};
 	} | null;

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -1120,6 +1120,7 @@ export async function parseCombinedTimelineEvents(
 		| GraphQL.AssignedEvent
 		| GraphQL.HeadRefDeletedEvent
 		| GraphQL.CrossReferencedEvent
+		| null
 	)[],
 	restEvents: Common.TimelineEvent[],
 	githubRepository: GitHubRepository,
@@ -1149,6 +1150,9 @@ export async function parseCombinedTimelineEvents(
 
 	// TODO: work the rest events into the appropriate place in the timeline
 	for (const event of events) {
+		if (!event) {
+			continue;
+		}
 		const type = convertGraphQLEventType(event.__typename);
 
 		switch (type) {


### PR DESCRIPTION
Some PR timeline arrays can contain null values, which causes downstream parsing errors
Ignoring null entries fixes the parsing error.

for example: https://github.com/TranscodeGroup/docker/pull/23. 
<img width="473" height="135" alt="截屏2025-10-20 17 56 26" src="https://github.com/user-attachments/assets/74a558b9-c04c-4c62-ae82-0194372c3b16" />

