### PR TITLE
do not exclude markdown when detecting comment for Delegate codelens

### DIFF
--- a/src/issues/issueTodoProvider.ts
+++ b/src/issues/issueTodoProvider.ts
@@ -120,7 +120,7 @@ export class IssueTodoProvider implements vscode.CodeActionProvider, vscode.Code
 			if (!todoInfo) {
 				continue;
 			}
-			if (!(await isComment(document, new vscode.Position(lineNumber, firstNonWhitespaceCharacterIndex)))) {
+			if (!(await isComment(document, new vscode.Position(lineNumber, firstNonWhitespaceCharacterIndex), []))) {
 				continue;
 			}
 			const { match, search, insertIndex } = todoInfo;

--- a/src/issues/util.ts
+++ b/src/issues/util.ts
@@ -516,8 +516,8 @@ export async function pushAndCreatePR(
 	}
 }
 
-export async function isComment(document: vscode.TextDocument, position: vscode.Position): Promise<boolean> {
-	if (document.languageId !== 'markdown' && document.languageId !== 'plaintext') {
+export async function isComment(document: vscode.TextDocument, position: vscode.Position, excludedLanguageIds = ['markdown', 'plaintext']): Promise<boolean> {
+	if (!excludedLanguageIds.includes(document.languageId)) {
 		const tokenInfo = await vscode.languages.getTokenInformationAtPosition(document, position);
 		if (tokenInfo.type !== vscode.StandardTokenType.Comment) {
 			return false;


### PR DESCRIPTION
### Before
<img width="497" height="282" alt="image" src="https://github.com/user-attachments/assets/9a330007-16ea-44c0-88cf-85bc1f94069e" />


### After
<img width="425" height="196" alt="image" src="https://github.com/user-attachments/assets/424ccb73-4cbf-4a28-84ac-f5744f286110" />
