### PR TITLE
Include ul in comment-body spacing rule

### DIFF
--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -437,6 +437,7 @@ body .comment-container .review-comment-container .review-comment-body {
 
 body .comment-container .comment-body>p,
 body .comment-container .comment-body>div>p,
+body .comment-container .comment-body>div>ul,
 .comment-container .review-body>p {
 	margin-top: 0;
 	line-height: 1.5em;


### PR DESCRIPTION
Add spacing for unordered lists within comment bodies to improve readability.

<img width="754" height="604" alt="image" src="https://github.com/user-attachments/assets/3cd3eb17-bcf5-4c6c-8dd1-11193276d7a7" />
