### PR TITLE
fix: message wrapping in narrow editor panes

### DIFF
--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -244,18 +244,20 @@ export const MergeStatus = ({ mergeable, isSimple, canUpdateBranch }: { mergeabl
 		}
 	}
 	return (
-		<div className="status-item status-section">
-			{icon}
-			<p>
-				{summary}
-			</p>
-			{(action && canUpdateBranch) ?
-				<div className="button-container">
-					<button className="secondary" onClick={onClick} disabled={busy} >
-						{action}
-					</button>
-				</div>
-			: null}
+		<div className="status-section">
+			<div className="status-item">
+				{icon}
+				<p>
+					{summary}
+				</p>
+				{(action && canUpdateBranch) ?
+					<div className="button-container">
+						<button className="secondary" onClick={onClick} disabled={busy} >
+							{action}
+						</button>
+					</div>
+				: null}
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
This PR fixes #8098 text wrapping of the branch protection message in narrow editor panes to match other status messages.

**Before**
<img width="380" height="233" alt="image" src="https://github.com/user-attachments/assets/4230efa9-5220-40b0-a4fd-f09a1bdead2e" />

**After:**
<img width="391" height="213" alt="image" src="https://github.com/user-attachments/assets/2e9e4b3c-d2e0-4c20-8a5f-08c610d4204b" />