### PR TITLE
fix: status check items alignment

### DIFF
--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -582,7 +582,7 @@ const StatusCheckDetails = ( { statuses }: { statuses: PullRequestCheckStatus[] 
 						{s.workflowName ? `${s.workflowName} / ` : null}{s.context}{s.event ? ` (${s.event})` : null} {s.description ? `— ${s.description}` : null}
 					</span>
 				</div>
-				<div>
+				<div className='status-check-detail-links'>
 				{s.isRequired ? (
 					<span className="label">Required</span>
 				) : null }

--- a/webviews/editorWebview/index.css
+++ b/webviews/editorWebview/index.css
@@ -230,6 +230,11 @@ body .comment-container .review-comment-header {
 	gap: 8px;
 }
 
+.status-check-detail-links {
+	display: flex;
+	align-items: center;
+}
+
 #merge-on-github {
 	margin-top: 10px;
 }


### PR DESCRIPTION
This PR fixes #8176 to fix the alighment of tags and details link in status checks.


https://github.com/user-attachments/assets/f2735213-fe44-4a8e-8ede-78c261b0ae09

