### PR TITLE
Disabling multidiff actions on empty workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -3632,11 +3632,11 @@
 			"chat/multiDiff/context": [
 				{
 					"command": "pr.checkoutFromDescription",
-					"when": "chatSessionType == copilot-cloud-agent"
+					"when": "chatSessionType == copilot-cloud-agent && workspaceFolderCount > 0"
 				},
 				{
 					"command": "pr.applyChangesFromDescription",
-					"when": "chatSessionType == copilot-cloud-agent"
+					"when": "chatSessionType == copilot-cloud-agent && workspaceFolderCount > 0"
 				}
 			]
 		},


### PR DESCRIPTION
Fix 2/2: https://github.com/microsoft/vscode/issues/281345