### PR TITLE
Copilot - move checkout/apply actions to the working set

### DIFF
--- a/package.json
+++ b/package.json
@@ -3721,13 +3721,15 @@
 					"group": "context"
 				}
 			],
-			"chat/multiDiff/context": [
+			"chat/input/editing/sessionToolbar": [
 				{
 					"command": "pr.checkoutFromDescription",
+					"group": "navigation@0",
 					"when": "chatSessionType == copilot-cloud-agent && workspaceFolderCount > 0"
 				},
 				{
 					"command": "pr.applyChangesFromDescription",
+					"group": "navigation@1",
 					"when": "chatSessionType == copilot-cloud-agent && workspaceFolderCount > 0"
 				}
 			]

--- a/package.nls.json
+++ b/package.nls.json
@@ -305,7 +305,7 @@
 	"command.pr.toggleEditorCommentingOn.title": "Toggle Editor Commenting On",
 	"command.pr.toggleEditorCommentingOff.title": "Toggle Editor Commenting Off",
 	"command.pr.checkoutFromDescription.title": "Checkout",
-	"command.pr.applyChangesFromDescription.title": "Apply Changes",
+	"command.pr.applyChangesFromDescription.title": "Apply",
 	"command.pr.checkoutOnVscodeDevFromDescription.title": "Checkout on vscode.dev",
 	"command.pr.checkoutOnCodespacesFromDescription.title": "Checkout on Codespaces",
 	"command.pr.openSessionLogFromDescription.title": "View Session",


### PR DESCRIPTION
For a cloud agent session, the changes are now being shown in the working set.
This pull request moves the checkout/apply actions to the working set:

<img width="430" height="167" alt="image" src="https://github.com/user-attachments/assets/98e13060-ce3e-41bc-8577-c772d3f32ab5" />
