### PR TITLE
Fix button border styles for disabled state and split buttons

### DIFF
--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -142,7 +142,7 @@ input[type='checkbox'] {
 body button:disabled,
 input[type='submit']:disabled {
 	opacity: 0.4;
-	border: 1px solid var(--vscode-button-border, transparent) !important;
+	border: 1px solid var(--vscode-button-background, transparent) !important;
 }
 
 body .hidden {
@@ -396,6 +396,8 @@ button.split-left {
 
 .split.disabled {
 	opacity: 0.4;
+	border-top: 1px solid var(--vscode-button-background);
+	border-bottom: 1px solid var(--vscode-button-background);
 }
 
 .split.secondary {


### PR DESCRIPTION
This pull request makes minor style adjustments to the `webviews/common/common.css` file, focusing on improving the appearance of disabled buttons and split button groups.

Button styling updates:

* Updated the border color for disabled buttons to use `--vscode-button-background` instead of `--vscode-button-border` for better visual consistency.
* Added top and bottom borders to `.split.disabled` elements, using `--vscode-button-background` to enhance the visual separation of disabled split buttons.