### PR TITLE
Fix refresh button not fetching latest data

### DIFF
--- a/src/view/prsTreeDataProvider.ts
+++ b/src/view/prsTreeDataProvider.ts
@@ -65,7 +65,7 @@ export class PullRequestsTreeDataProvider extends Disposable implements vscode.T
 		}));
 		this._register(vscode.commands.registerCommand('pr.refreshList', _ => {
 			this.prsTreeModel.forceClearCache();
-			this.refreshAllQueryResults(true);
+			this.refreshAllQueryResults();
 		}));
 
 		this._register(vscode.commands.registerCommand('pr.loadMore', (node: CategoryTreeNode) => {

--- a/src/view/prsTreeModel.ts
+++ b/src/view/prsTreeModel.ts
@@ -181,7 +181,6 @@ export class PrsTreeModel extends Disposable {
 	public forceClearCache() {
 		this._cachedPRs.clear();
 		this._allCachedPRs.clear();
-		this._onDidChangeData.fire();
 	}
 
 	public hasPullRequest(pr: PullRequestModel): boolean {


### PR DESCRIPTION
## Summary

- Remove `_onDidChangeData.fire()` from `forceClearCache()` to eliminate a duplicate event source
- Update `pr.refreshList` command to call `refreshAllQueryResults()` instead of `refreshAllQueryResults(true)` (the `true` flag was a no-op anyway after `forceClearCache()`)

## Root Cause

When the refresh button (`pr.refreshList`) was clicked, two separate `_onDidChangeTreeData` events fired on the same `CategoryTreeNode` instances:

1. `forceClearCache()` fired `_onDidChangeData` → handler called `refreshAllQueryResults(true)` → fired `_onDidChangeTreeData([...existingNodes])`
2. `pr.refreshList` handler itself also called `refreshAllQueryResults(true)` → fired `_onDidChangeTreeData([...existingNodes])` again

This caused VS Code to call `getChildren()` **twice concurrently** on the same category nodes. The second call's `super.getChildren(true)` would dispose the PR children that the first call had just populated, resulting in the tree failing to display fresh data from GitHub.

## Fix

The refresh flow is now:

```
Click refresh button
  ↓
forceClearCache()  →  cache cleared, no event fired
  ↓
refreshAllQueryResults()  →  fires _onDidChangeTreeData([...existingNodes]) once
  ↓
VS Code calls getChildren() once per expanded category node
  ↓
doGetChildren() → cache is empty → fetches latest data from GitHub ✓
```

## Test plan

- [ ] Click the refresh button in the PR tree view
- [ ] Verify that newly created/updated PRs appear after refresh
- [ ] Verify that closed/merged PRs are removed after refresh
- [ ] Verify no visual flickering or double-refresh behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)