### PR TITLE
feat: add setting to control editor close behavior after marking file as viewed

### DIFF
--- a/package.json
+++ b/package.json
@@ -862,6 +862,11 @@
 					"default": "author",
 					"description": "%githubPullRequests.pullRequestAvatarDisplay.description%"
 				},
+				"githubPullRequests.closeAfterMarkAsViewed": {
+					"type": "boolean",
+					"default": false,
+					"description": "%githubPullRequests.closeAfterMarkAsViewed.description%"
+				},
 				"githubIssues.alwaysPromptForNewIssueRepo": {
 					"type": "boolean",
 					"default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -187,6 +187,7 @@
 	"githubPullRequests.pullRequestAvatarDisplay.author": "Show the pull request author avatar",
 	"githubPullRequests.pullRequestAvatarDisplay.state": "Show the pull request type (draft or not) and state (open/closed/merged) as a colored icon",
 	"githubPullRequests.pullRequestAvatarDisplay.generic": "Show a GitHub icon",
+	"githubPullRequests.closeAfterMarkAsViewed.description": "When enabled, the editor will close automatically after marking a file as viewed.",
 	"githubIssues.issueAvatarDisplay.state": "Show the issue state (open/closed) as a colored icon",
 	"githubIssues.issueAvatarDisplay.generic": "Show an issues icon regardless of state",
 	"githubIssues.alwaysPromptForNewIssueRepo.description": "Enabling will always prompt which repository to create an issue in instead of basing off the current open file.",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1558,18 +1558,20 @@ ${contents}
 				if (treeNode instanceof FileChangeNode) {
 					await treeNode.markFileAsViewed(false);
 				} else if (treeNode) {
-					// When the argument is a uri it came from the editor menu and we should also close the file
-					// Do the close first to improve perceived performance of marking as viewed.
-					const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
-					if (tab) {
-						let compareUri: vscode.Uri | undefined = undefined;
-						if (tab.input instanceof vscode.TabInputTextDiff) {
-							compareUri = tab.input.modified;
-						} else if (tab.input instanceof vscode.TabInputText) {
-							compareUri = tab.input.uri;
-						}
-						if (compareUri && treeNode.toString() === compareUri.toString()) {
-							vscode.window.tabGroups.close(tab);
+					const closeAfterMarkAsViewed = vscode.workspace.getConfiguration('githubPullRequests').get<boolean>('closeAfterMarkAsViewed', false);
+					if (closeAfterMarkAsViewed) {
+						// Do the close first to improve perceived performance of marking as viewed.
+						const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+						if (tab) {
+							let compareUri: vscode.Uri | undefined = undefined;
+							if (tab.input instanceof vscode.TabInputTextDiff) {
+								compareUri = tab.input.modified;
+							} else if (tab.input instanceof vscode.TabInputText) {
+								compareUri = tab.input.uri;
+							}
+							if (compareUri && treeNode.toString() === compareUri.toString()) {
+								vscode.window.tabGroups.close(tab);
+							}
 						}
 					}
 


### PR DESCRIPTION
Fixes #5092

## Problem
When `pr.markFileAsViewed` is triggered via keybinding or editor menu bar, the active editor closes automatically. This is surprising to users who want the file to stay open after marking it as viewed.

## Solution
Add a new configuration setting `githubPullRequests.closeAfterMarkAsViewed` (boolean, default: `false`).

- When `false` (default): editor stays open after marking as viewed -- matches tree view behavior
- When `true`: restores the previous auto-close behavior

## Changes
- `package.json`: register new `githubPullRequests.closeAfterMarkAsViewed` setting
- `package.nls.json`: add description string
- `src/commands.ts`: wrap the tab-close logic in a check for the new setting

## Test plan
- [ ] With setting `false` (default): trigger `pr.markFileAsViewed` via keybinding -- editor should stay open
- [ ] With setting `true`: trigger `pr.markFileAsViewed` via keybinding -- editor should close
- [ ] Tree view behavior unchanged (uses `FileChangeNode` path, not affected by this setting)
