### PR TITLE
Add base and compare branch names to Copilot PR title and description generation

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -256,7 +256,7 @@ export interface IGit {
 }
 
 export interface TitleAndDescriptionProvider {
-	provideTitleAndDescription(context: { commitMessages: string[], patches: string[] | { patch: string, fileUri: string, previousFileUri?: string }[], issues?: { reference: string, content: string }[], template?: string }, token: CancellationToken): Promise<{ title: string, description?: string } | undefined>;
+	provideTitleAndDescription(context: { commitMessages: string[], patches: string[] | { patch: string, fileUri: string, previousFileUri?: string }[], issues?: { reference: string, content: string }[], template?: string, baseBranch?: string, compareBranch?: string }, token: CancellationToken): Promise<{ title: string, description?: string } | undefined>;
 }
 
 export interface ReviewerComments {

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -256,7 +256,7 @@ export interface IGit {
 }
 
 export interface TitleAndDescriptionProvider {
-	provideTitleAndDescription(context: { commitMessages: string[], patches: string[] | { patch: string, fileUri: string, previousFileUri?: string }[], issues?: { reference: string, content: string }[], template?: string, baseBranch?: string, compareBranch?: string }, token: CancellationToken): Promise<{ title: string, description?: string } | undefined>;
+	provideTitleAndDescription(context: { commitMessages: string[], patches: string[] | { patch: string, fileUri: string, previousFileUri?: string }[], issues?: { reference: string, content: string }[], template?: string, compareBranch?: string }, token: CancellationToken): Promise<{ title: string, description?: string } | undefined>;
 }
 
 export interface ReviewerComments {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2106,7 +2106,7 @@ ${contents}
 
 				const tokenSource = new vscode.CancellationTokenSource();
 				const result = await provider.provider.provideTitleAndDescription(
-					{ commitMessages, patches, issues, template },
+					{ commitMessages, patches, issues, template, baseBranch: args.baseBranch, compareBranch: args.compareBranch },
 					tokenSource.token,
 				);
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2106,7 +2106,7 @@ ${contents}
 
 				const tokenSource = new vscode.CancellationTokenSource();
 				const result = await provider.provider.provideTitleAndDescription(
-					{ commitMessages, patches, issues, template, baseBranch: args.baseBranch, compareBranch: args.compareBranch },
+					{ commitMessages, patches, issues, template, compareBranch: args.compareBranch },
 					tokenSource.token,
 				);
 

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -1229,8 +1229,7 @@ Don't forget to commit your template file to the repository so that it can be us
 				const template = await templatePromise;
 
 				const provider = this._folderRepositoryManager.getTitleAndDescriptionProvider(searchTerm);
-				const result = await provider?.provider.provideTitleAndDescription({ commitMessages, patches, issues, template }, token);
-
+				const result = await provider?.provider.provideTitleAndDescription({ commitMessages, patches, issues, template, baseBranch: this.model.baseBranch, compareBranch: this.model.compareBranch }, token);
 				if (provider) {
 					this.lastGeneratedTitleAndDescription = { ...result, providerTitle: provider.title };
 					/* __GDPR__

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -1229,7 +1229,7 @@ Don't forget to commit your template file to the repository so that it can be us
 				const template = await templatePromise;
 
 				const provider = this._folderRepositoryManager.getTitleAndDescriptionProvider(searchTerm);
-				const result = await provider?.provider.provideTitleAndDescription({ commitMessages, patches, issues, template, baseBranch: this.model.baseBranch, compareBranch: this.model.compareBranch }, token);
+				const result = await provider?.provider.provideTitleAndDescription({ commitMessages, patches, issues, template, compareBranch: this.model.compareBranch }, token);
 				if (provider) {
 					this.lastGeneratedTitleAndDescription = { ...result, providerTitle: provider.title };
 					/* __GDPR__

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -1099,7 +1099,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 			const templateContent = await this._folderRepositoryManager.getPullRequestTemplateBody(this._item.remote.owner);
 
 			const result = await provider.provider.provideTitleAndDescription(
-				{ commitMessages, patches, issues: [], template: templateContent },
+				{ commitMessages, patches, issues: [], template: templateContent, baseBranch: this._item.base.ref, compareBranch: this._item.head?.ref },
 				this.generatingDescriptionCancellationToken.token
 			);
 

--- a/src/github/pullRequestOverview.ts
+++ b/src/github/pullRequestOverview.ts
@@ -1099,7 +1099,7 @@ export class PullRequestOverviewPanel extends IssueOverviewPanel<PullRequestMode
 			const templateContent = await this._folderRepositoryManager.getPullRequestTemplateBody(this._item.remote.owner);
 
 			const result = await provider.provider.provideTitleAndDescription(
-				{ commitMessages, patches, issues: [], template: templateContent, baseBranch: this._item.base.ref, compareBranch: this._item.head?.ref },
+				{ commitMessages, patches, issues: [], template: templateContent, compareBranch: this._item.head?.ref },
 				this.generatingDescriptionCancellationToken.token
 			);
 


### PR DESCRIPTION
Adds `baseBranch` and `compareBranch` to the context passed to `TitleAndDescriptionProvider.provideTitleAndDescription`, and forwards them from all three call sites where title and description generation is triggered.

Previously the model had no knowledge of which branches were involved, causing it to hallucinate branch names in the generated description. With this change, the actual branch names are passed to the provider so they can be included in the prompt.

### Changes

- `src/api/api.d.ts`: Added `baseBranch?` and `compareBranch?` to the `TitleAndDescriptionProvider` context interface.
- `src/github/createPRViewProvider.ts`: Passes `this.model.baseBranch` and `this.model.compareBranch` when calling `provideTitleAndDescription` from the Create PR view.
- `src/github/pullRequestOverview.ts`: Passes `this._item.base.ref` and `this._item.head?.ref` when regenerating a description from the PR overview.
- `src/commands.ts`: Passes `args.baseBranch` and `args.compareBranch` when calling through the `github.createPullRequest.generate` command API.

Fixes #8662

The corresponding change to the Copilot Chat extension that uses these values to render them in the prompt is at microsoft/vscode-copilot-chat#5083.