### PR TITLE
fix(reviewManager): use pr.base.ref instead of pr.base.name in hasBranch call

### DIFF
--- a/src/view/reviewManager.ts
+++ b/src/view/reviewManager.ts
@@ -543,7 +543,7 @@ export class ReviewManager extends Disposable {
 			Logger.appendLine('Resolving pull request', this.id);
 			let pr = await this._folderRepoManager.resolvePullRequest(owner, repositoryName, metadata.prNumber, useCache);
 
-			if (!pr || !pr.isResolved() || !(await pr.githubRepository.hasBranch(pr.base.name))) {
+			if (!pr || !pr.isResolved() || !(await pr.githubRepository.hasBranch(pr.base.ref))) {
 				await this.clear(true);
 				this._prNumber = undefined;
 				Logger.appendLine('This PR is no longer valid', this.id);


### PR DESCRIPTION
## Summary
- Fix `hasBranch()` call to use `pr.base.ref` (branch name) instead of `pr.base.name` (repository name)

## Why
In `resolvePullRequest()`, the check `hasBranch(pr.base.name)` was passing the repository name instead of the branch name:
- `pr.base.ref` = branch name (e.g., `"main"`)
- `pr.base.name` = repository name (e.g., `"vscode-pull-request-github"`)

This caused `hasBranch()` to query `refs/heads/<repo-name>` which never matches an actual branch, making the validation always fail.

## Validation
- Single line change, no test modification needed
- Logic review: `pr.base.ref` is the correct property for branch name lookup

## Related
Fixes #8668