### PR TITLE
added github flavoured markdown preview for issues and pull requests

### DIFF
--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -118,7 +118,7 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 			const html = await this._item.githubRepository.renderMarkdown(message.args.text);
 			this._replyMessage(message, { html });
 		} catch (e) {
-			this._replyMessage(message, { html: message.args.text });
+			this._replyMessage(message, { html: null, error: true });
 		}
 	}
 

--- a/src/github/activityBarViewProvider.ts
+++ b/src/github/activityBarViewProvider.ts
@@ -108,6 +108,17 @@ export class PullRequestViewProvider extends WebviewViewBase implements vscode.W
 				return this.updateBranch(message);
 			case 'pr.re-request-review':
 				return this.reRequestReview(message);
+			case 'pr.render-markdown':
+				return this.renderMarkdown(message);
+		}
+	}
+
+	private async renderMarkdown(message: IRequestMessage<{ text: string }>) {
+		try {
+			const html = await this._item.githubRepository.renderMarkdown(message.args.text);
+			this._replyMessage(message, { html });
+		} catch (e) {
+			this._replyMessage(message, { html: message.args.text });
 		}
 	}
 

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -1579,9 +1579,22 @@ Don't forget to commit your template file to the repository so that it can be us
 			case 'pr.cancelPreReview':
 				return this.cancelPreReview();
 
+			case 'pr.render-markdown':
+				return this.renderMarkdown(message);
+
 			default:
 				// Log error
 				vscode.window.showErrorMessage('Unsupported webview message');
+		}
+	}
+
+	private async renderMarkdown(message: IRequestMessage<{ text: string }>) {
+		try {
+			const repo = this.model.gitHubRepository ?? this._folderRepositoryManager.gitHubRepositories[0];
+			const html = await repo.renderMarkdown(message.args.text);
+			this._replyMessage(message, { html });
+		} catch (e) {
+			this._replyMessage(message, { html: message.args.text });
 		}
 	}
 }

--- a/src/github/createPRViewProvider.ts
+++ b/src/github/createPRViewProvider.ts
@@ -1594,7 +1594,7 @@ Don't forget to commit your template file to the repository so that it can be us
 			const html = await repo.renderMarkdown(message.args.text);
 			this._replyMessage(message, { html });
 		} catch (e) {
-			this._replyMessage(message, { html: message.args.text });
+			this._replyMessage(message, { html: null, error: true });
 		}
 	}
 }

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -2134,6 +2134,24 @@ export class GitHubRepository extends Disposable {
 	}
 
 	/**
+	 * Render markdown text into HTML using GitHub's native API.
+	 */
+	public async renderMarkdown(text: string): Promise<string> {
+		try {
+			const { octokit, remote } = await this.ensure();
+			const { data } = await octokit.call(octokit.api.markdown.render, {
+				text,
+				mode: 'gfm',
+				context: `${remote.owner}/${remote.repositoryName}`
+			});
+			return data;
+		} catch (e) {
+			Logger.error(`Unable to render markdown: ${e}`, this.id);
+			return text;
+		}
+	}
+
+	/**
 	 * Upload a file's raw bytes to GitHub via the mobile upload policy API.
 	 * Returns a markdown snippet appropriate for embedding in an issue/PR comment.
 	 */

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -2147,7 +2147,7 @@ export class GitHubRepository extends Disposable {
 			return data;
 		} catch (e) {
 			Logger.error(`Unable to render markdown: ${e}`, this.id);
-			return text;
+			throw e;
 		}
 	}
 

--- a/src/github/issueOverview.ts
+++ b/src/github/issueOverview.ts
@@ -469,7 +469,7 @@ export class IssueOverviewPanel<TItem extends IssueModel = IssueModel> extends W
 			const html = await this._item.githubRepository.renderMarkdown(message.args.text);
 			this._replyMessage(message, { html });
 		} catch (e) {
-			this._replyMessage(message, { html: message.args.text });
+			this._replyMessage(message, { html: null, error: true });
 		}
 	}
 

--- a/src/github/issueOverview.ts
+++ b/src/github/issueOverview.ts
@@ -457,8 +457,19 @@ export class IssueOverviewPanel<TItem extends IssueModel = IssueModel> extends W
 				return this.uploadFiles(message);
 			case 'pr.upload-pasted-files':
 				return this.uploadPastedFiles(message);
+			case 'pr.render-markdown':
+				return this.renderMarkdown(message);
 			default:
 				return this.MESSAGE_UNHANDLED;
+		}
+	}
+
+	private async renderMarkdown(message: IRequestMessage<{ text: string }>) {
+		try {
+			const html = await this._item.githubRepository.renderMarkdown(message.args.text);
+			this._replyMessage(message, { html });
+		} catch (e) {
+			this._replyMessage(message, { html: message.args.text });
 		}
 	}
 

--- a/webviews/common/common.css
+++ b/webviews/common/common.css
@@ -622,3 +622,65 @@ button.inlined-dropdown:last-child {
 		transform: rotate(360deg);
 	}
 }
+
+/* Markdown Editor */
+
+.markdown-editor {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	flex: 1;
+}
+
+.markdown-editor-tabs {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 4px;
+	padding: 0 4px;
+}
+
+.markdown-editor-tab {
+	background: transparent;
+	border: none;
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	padding: 4px 8px;
+	font-size: 13px;
+	opacity: 0.7;
+}
+
+.markdown-editor-tab:hover {
+	opacity: 1;
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.markdown-editor-tab.active {
+	opacity: 1;
+	border-bottom: 2px solid var(--vscode-focusBorder);
+	font-weight: 600;
+}
+
+.markdown-editor-content {
+	position: relative;
+	display: flex;
+	flex: 1;
+	width: 100%;
+}
+
+.markdown-editor-content textarea {
+	flex: 1;
+	width: 100%;
+}
+
+.markdown-editor-preview {
+	box-sizing: border-box;
+	width: 100%;
+	padding: 8px;
+	border: 1px solid var(--vscode-dropdown-border);
+	background-color: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+	border-radius: 4px;
+	min-height: 80px;
+	max-height: 500px;
+	overflow-y: auto;
+}

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -169,6 +169,11 @@ export class PRContext {
 	public cancelGenerateDescription = () =>
 		this.postMessage({ command: 'pr.cancel-generate-description' });
 
+	public renderMarkdown = async (text: string): Promise<string> => {
+		const result = await this.postMessage({ command: 'pr.render-markdown', args: { text } });
+		return result?.html ?? text;
+	};
+
 	public updateDraft = (id: number, body: string) => {
 		const pullRequest = getState();
 		const pendingCommentDrafts = pullRequest.pendingCommentDrafts || Object.create(null);

--- a/webviews/common/createContextNew.ts
+++ b/webviews/common/createContextNew.ts
@@ -223,6 +223,11 @@ export class CreatePRContextNew {
 		return this.postMessage({ command: 'pr.cancelPreReview' });
 	};
 
+	public renderMarkdown = async (text: string): Promise<string> => {
+		const result = await this.postMessage({ command: 'pr.render-markdown', args: { text } });
+		return result?.html ?? text;
+	};
+
 	public validate = (): boolean => {
 		let isValid = true;
 		if (!this.createParams.pendingTitle) {

--- a/webviews/components/comment.tsx
+++ b/webviews/components/comment.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { ContextDropdown } from './contextDropdown';
 import { cloudUploadIcon, copyIcon, editIcon, quoteIcon, sparkleIcon, stopCircleIcon, trashIcon } from './icon';
+import { MarkdownEditor } from './markdownEditor';
 import { nbsp, Spaced } from './space';
 import { Timestamp } from './timestamp';
 import { AuthorLink, Avatar } from './user';
@@ -262,7 +263,7 @@ type EditCommentProps = {
 };
 
 function EditComment({ id, body, isPRDescription, onCancel, onSave }: EditCommentProps) {
-	const { updateDraft, pr, generateDescription, cancelGenerateDescription, uploadFiles, uploadPastedFiles } = useContext(PullRequestContext);
+	const { updateDraft, pr, generateDescription, cancelGenerateDescription, uploadFiles, uploadPastedFiles, renderMarkdown } = useContext(PullRequestContext);
 	const draftComment = useRef<{ body: string; dirty: boolean }>({ body, dirty: false });
 	const form = useRef<HTMLFormElement>();
 	const [isGenerating, setIsGenerating] = useState(false);
@@ -365,7 +366,7 @@ function EditComment({ id, body, isPRDescription, onCancel, onSave }: EditCommen
 	return (
 		<form ref={form as React.MutableRefObject<HTMLFormElement>} onSubmit={onSubmit}>
 			<div className="textarea-wrapper">
-				<textarea name="markdown" defaultValue={body} onKeyDown={onKeyDown} onInput={onInput} onPaste={handlePaste} disabled={isGenerating} />
+				<MarkdownEditor name="markdown" defaultValue={body} onKeyDown={onKeyDown} onInput={onInput} onPaste={handlePaste} disabled={isGenerating} renderMarkdown={renderMarkdown} />
 				{isPRDescription ? (
 					isGenerating ? (
 						<button
@@ -498,7 +499,7 @@ export function AddComment({
 	repo,
 	number
 }: PullRequest) {
-	const { updatePR, requestChanges, approve, close, openOnGitHub, submit, uploadFilesIntoPendingComment, uploadPastedFilesIntoPendingComment } = useContext(PullRequestContext);
+	const { updatePR, requestChanges, approve, close, openOnGitHub, submit, uploadFilesIntoPendingComment, uploadPastedFilesIntoPendingComment, renderMarkdown } = useContext(PullRequestContext);
 	const [isBusy, setBusy] = useState(false);
 	const form = useRef<HTMLFormElement>();
 	const textareaRef = useRef<HTMLTextAreaElement>();
@@ -569,7 +570,7 @@ export function AddComment({
 	return (
 		<form id="comment-form" ref={form as React.MutableRefObject<HTMLFormElement>} className="comment-form main-comment-form" >
 			<div className="textarea-wrapper">
-				<textarea
+				<MarkdownEditor
 					id={COMMENT_TEXTAREA_ID}
 					name="body"
 					ref={textareaRef as React.MutableRefObject<HTMLTextAreaElement>}
@@ -584,6 +585,7 @@ export function AddComment({
 							textareaRef.current!.setSelectionRange(9, 9);
 						}
 					}}
+					renderMarkdown={renderMarkdown}
 				/>
 				<button
 					type="button"
@@ -690,7 +692,7 @@ const makeCommentMenuContext = (owner: string, repo: string, number: number, ava
 };
 
 export const AddCommentSimple = (pr: PullRequest) => {
-	const { updatePR, requestChanges, approve, submit, openOnGitHub, uploadFilesIntoPendingComment, uploadPastedFilesIntoPendingComment } = useContext(PullRequestContext);
+	const { updatePR, requestChanges, approve, submit, openOnGitHub, uploadFilesIntoPendingComment, uploadPastedFilesIntoPendingComment, renderMarkdown } = useContext(PullRequestContext);
 	const [isBusy, setBusy] = useState(false);
 	const textareaRef = useRef<HTMLTextAreaElement>();
 	let currentSelection: ReviewType = pr.lastReviewType ?? (pr.currentUserReviewState === 'APPROVED' ? ReviewType.Approve : (pr.currentUserReviewState === 'CHANGES_REQUESTED' ? ReviewType.RequestChanges : ReviewType.Comment));
@@ -752,7 +754,7 @@ export const AddCommentSimple = (pr: PullRequest) => {
 	return (
 		<span className="comment-form">
 			<div className="textarea-wrapper">
-				<textarea
+				<MarkdownEditor
 					id={COMMENT_TEXTAREA_ID}
 					name="body"
 					placeholder="Leave a comment"
@@ -762,6 +764,7 @@ export const AddCommentSimple = (pr: PullRequest) => {
 					onKeyDown={onKeyDown}
 					onPaste={onPasteUploadFiles(uploadPastedFilesIntoPendingComment)}
 					disabled={isBusy || pr.busy}
+					renderMarkdown={renderMarkdown}
 				/>
 				<button
 					type="button"

--- a/webviews/components/markdownEditor.tsx
+++ b/webviews/components/markdownEditor.tsx
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface MarkdownEditorProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+	renderMarkdown?: (text: string) => Promise<string>;
+}
+
+export const MarkdownEditor = React.forwardRef(function MarkdownEditor(
+	{ renderMarkdown, ...props }: MarkdownEditorProps,
+	forwardedRef: React.Ref<HTMLTextAreaElement>,
+) {
+	const [mode, setMode] = useState<'write' | 'preview'>('write');
+	const [html, setHtml] = useState<string>('');
+	const [isLoading, setIsLoading] = useState<boolean>(false);
+	const internalRef = useRef<HTMLTextAreaElement>(null);
+
+	const setRefs = useCallback(
+		(node: HTMLTextAreaElement) => {
+			(internalRef as React.MutableRefObject<HTMLTextAreaElement | null>).current =
+				node;
+			if (typeof forwardedRef === 'function') {
+				forwardedRef(node);
+			} else if (forwardedRef) {
+				(
+					forwardedRef as React.MutableRefObject<HTMLTextAreaElement | null>
+				).current = node;
+			}
+		},
+		[forwardedRef],
+	);
+
+	useEffect(() => {
+		if (mode !== 'preview') return;
+
+		if (!renderMarkdown) {
+			const text = internalRef.current?.value || '';
+			setHtml(text ? `<pre>${text}</pre>` : '<em>Nothing to preview</em>');
+			return;
+		}
+
+		let cancelled = false;
+		setIsLoading(true);
+
+		const text = internalRef.current?.value || '';
+		if (!text.trim()) {
+			setHtml('');
+			setIsLoading(false);
+			return;
+		}
+
+		renderMarkdown(text)
+			.then((rendered) => {
+				if (!cancelled) {
+					setHtml(rendered);
+					setIsLoading(false);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setHtml('<em>Error rendering preview</em>');
+					setIsLoading(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [mode, renderMarkdown]);
+
+	return (
+		<div className='markdown-editor'>
+			<div className='markdown-editor-tabs'>
+				<button
+					type='button'
+					className={`markdown-editor-tab${mode === 'write' ? ' active' : ''}`}
+					onClick={() => setMode('write')}
+				>
+					Write
+				</button>
+				<button
+					type='button'
+					className={`markdown-editor-tab${mode === 'preview' ? ' active' : ''}`}
+					onClick={() => setMode('preview')}
+					disabled={props.disabled}
+				>
+					Preview
+				</button>
+			</div>
+			<div className='markdown-editor-content'>
+				<textarea
+					ref={setRefs}
+					style={{ display: mode === 'write' ? 'block' : 'none' }}
+					{...props}
+				/>
+				{mode === 'preview' && (
+					<div className='markdown-editor-preview comment-body'>
+						{!isLoading && html && <div dangerouslySetInnerHTML={{ __html: html }} />}
+						{!isLoading && !html && <em>Nothing to preview</em>}
+						{isLoading && <em>Loading preview...</em>}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+});

--- a/webviews/components/markdownEditor.tsx
+++ b/webviews/components/markdownEditor.tsx
@@ -19,7 +19,7 @@ export const MarkdownEditor = React.forwardRef(function MarkdownEditor(
 	const internalRef = useRef<HTMLTextAreaElement>(null);
 
 	const setRefs = useCallback(
-		(node: HTMLTextAreaElement) => {
+		(node: HTMLTextAreaElement | null) => {
 			(internalRef as React.MutableRefObject<HTMLTextAreaElement | null>).current =
 				node;
 			if (typeof forwardedRef === 'function') {
@@ -37,8 +37,8 @@ export const MarkdownEditor = React.forwardRef(function MarkdownEditor(
 		if (mode !== 'preview') return;
 
 		if (!renderMarkdown) {
-			const text = internalRef.current?.value || '';
-			setHtml(text ? `<pre>${text}</pre>` : '<em>Nothing to preview</em>');
+			setHtml('');
+			setIsLoading(false);
 			return;
 		}
 

--- a/webviews/createPullRequestViewNew/app.tsx
+++ b/webviews/createPullRequestViewNew/app.tsx
@@ -14,6 +14,7 @@ import { ErrorBoundary } from '../common/errorBoundary';
 import { LabelCreate } from '../common/label';
 import { ContextDropdown } from '../components/contextDropdown';
 import { accountIcon, feedbackIcon, gitCompareIcon, milestoneIcon, notebookTemplate, prMergeIcon, projectIcon, settingsIcon, sparkleIcon, stopCircleIcon, tagIcon } from '../components/icon';
+import { MarkdownEditor } from '../components/markdownEditor';
 import { Avatar } from '../components/user';
 
 type CreateMethod = 'create-draft' | 'create' | 'create-automerge-squash' | 'create-automerge-rebase' | 'create-automerge-merge';
@@ -346,7 +347,7 @@ export function main() {
 						</div>
 					</div>
 					<div className='group-description'>
-						<textarea
+						<MarkdownEditor
 							id='description'
 							name='description'
 							placeholder='Description'
@@ -354,7 +355,9 @@ export function main() {
 							onChange={(e) => ctx.updateState({ pendingDescription: e.currentTarget.value })}
 							onKeyDown={(e) => onKeyDown(false, e)}
 							data-vscode-context='{"preventDefaultContextMenuItems": false}'
-							disabled={!ctx.initialized || isBusy || isGeneratingTitle || params.reviewing}></textarea>
+							disabled={!ctx.initialized || isBusy || isGeneratingTitle || params.reviewing}
+							renderMarkdown={ctx.renderMarkdown}
+						/>
 					</div>
 
 					<div className={params.validate && !!params.createError ? 'wrapper validation-error' : 'hidden'} aria-live='assertive'>


### PR DESCRIPTION
Hi, I added this feature which closes #5382 

> Before creating a pull request, if the issues involves making changes to the UI, please discuss it in the issue beforehand. This will help keep reviews focused on the code changes.


This feature makes changes to the ui as shown below. I'm open to the discussion on how the ui should be displayed

Some images on how it looks like
1. <img width="560" height="694" alt="image" src="https://github.com/user-attachments/assets/041f87fa-9e1b-452e-8f0e-26ea36c095fb" />

2. <img width="1843" height="384" alt="image" src="https://github.com/user-attachments/assets/524d721e-f35f-4051-b6e7-66b386cd3d74" />
3. <img width="1727" height="583" alt="image" src="https://github.com/user-attachments/assets/9154079f-7691-4baf-a055-f0a48417e412" />
4. <img width="1832" height="1095" alt="image" src="https://github.com/user-attachments/assets/a8c542a7-26a2-4b47-9054-2dd4f601b2a5" />
