### PR TITLE
Remove the `rateLimit` selection from the MaxPullRequest GraphQL query

### DIFF
--- a/src/github/queriesShared.gql
+++ b/src/github/queriesShared.gql
@@ -991,9 +991,6 @@ query MaxPullRequest($owner: String!, $name: String!) {
 			}
 		}
 	}
-	rateLimit {
-		...RateLimit
-	}
 }
 
 query GetMilestones($owner: String!, $name: String!, $states: [MilestoneState!]!) {


### PR DESCRIPTION
<!-- human-description -->


`MaxPullRequest` represents a big chunk of our graphql traffic volume and we're currently trying to optimize it.

The `rateLimit` portion is only used by `LoggingApolloClient.query` which is a high level client and it's never read by the query actual caller - `_getMaxItem`  - shared by both `MaxIssue` and `MaxPullRequest` - returns only [number](https://github.com/microsoft/vscode-pull-request-github/blob/00c5f147d9bd197daf9cc05025b714e31e1f6483/src/github/githubRepository.ts#L949). It never reads `data.rateLimit`.

Since other queries are requesting this field the global store should be fine and updated on any other occasion.

---

<details>
<summary>🤖 AI-generated description</summary>

## What changed

This PR removes the top-level `rateLimit { ...RateLimit }` selection from the `MaxPullRequest` query in `src/github/queriesShared.gql`. No other queries are touched — `MaxIssue` and the ~28 other operations that select `rateLimit` keep it, and the shared `fragment RateLimit on RateLimit` remains in use elsewhere, so it stays defined.

## Why

`MaxPullRequest` is a high-frequency, per-repo change-detection poll — one of the hottest GraphQL operations the extension emits. Its handler `_getMaxItem` (`src/github/githubRepository.ts`) reads only `data.repository.issues.edges[0].node.number` (the latest PR number) and never touches `data.rateLimit`. Selecting `rateLimit` on every poll asks the GitHub GraphQL API to resolve an extra top-level field whose result is discarded. Dropping it trims that unused resolver from the highest-volume query.

## Scope & safety

- **No functional impact.** The only generic consumer of the field is `RateLogger.logRateLimit` (`src/github/loggingOctokit.ts`), invoked by the `LoggingApolloClient.query` wrapper on every query. It reads `resolvedResult?.data?.rateLimit` and already degrades gracefully when the field is absent: it falls back to `?? 5000` / `?? 1000` defaults. As a result, removing the selection produces **no** spurious "Unexpectedly low rate limit" warning, and the `pr.lowRateLimitRemaining` telemetry simply does not fire for this single call path.
- **Rate-limit visibility is preserved.** Every other query that selects `rateLimit` continues to report it, so overall rate-limit monitoring and telemetry are unaffected.
- **No type changes needed.** `_getMaxItem` does not reference `rateLimit`, and the `MaxIssueResponse` interface still applies to `MaxIssue`. The `.gql` files are loaded at build time via the graphql-tag webpack loader; there is no committed generated TypeScript to regenerate.

## Notes

- The change is intentionally surgical: `MaxPullRequest` only, leaving `MaxIssue` and all other `rateLimit`-selecting queries as-is.
- Because `logRateLimit` already handles the missing-field case, this is a safe no-op for behavior — it only reduces what `MaxPullRequest` asks the API to resolve.

</details>

<!--
copilot-session-ids: 07d55658-0588-4033-af6d-54d28bdb5c55
Copilot sessions that authored this PR body — hidden metadata for future reference.
-->
