### PR TITLE
Add option to keep viewed files open

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1804,7 +1804,7 @@ ${contents}
 				if (treeNodeOrOptions instanceof FileChangeNode || treeNodeOrOptions instanceof vscode.Uri) {
 					treeNode = treeNodeOrOptions;
 				} else {
-					options = treeNodeOrOptions;
+					options = treeNodeOrOptions ?? options;
 					// Use the active editor to enable keybindings
 					treeNode = vscode.window.activeTextEditor?.document.uri;
 				}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1798,9 +1798,13 @@ ${contents}
 	};
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('pr.markFileAsViewed', async (treeNode: FileChangeNode | vscode.Uri | undefined) => {
+		vscode.commands.registerCommand('pr.markFileAsViewed', async (treeNodeOrOptions: FileChangeNode | vscode.Uri | { dontCloseFile: boolean } | undefined, options?: { dontCloseFile: boolean }) => {
 			try {
-				if (treeNode === undefined) {
+				let treeNode: FileChangeNode | vscode.Uri | undefined;
+				if (treeNodeOrOptions instanceof FileChangeNode || treeNodeOrOptions instanceof vscode.Uri) {
+					treeNode = treeNodeOrOptions;
+				} else {
+					options = treeNodeOrOptions;
 					// Use the active editor to enable keybindings
 					treeNode = vscode.window.activeTextEditor?.document.uri;
 				}
@@ -1810,16 +1814,18 @@ ${contents}
 				} else if (treeNode) {
 					// When the argument is a uri it came from the editor menu and we should also close the file
 					// Do the close first to improve perceived performance of marking as viewed.
-					const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
-					if (tab) {
-						let compareUri: vscode.Uri | undefined = undefined;
-						if (tab.input instanceof vscode.TabInputTextDiff) {
-							compareUri = tab.input.modified;
-						} else if (tab.input instanceof vscode.TabInputText) {
-							compareUri = tab.input.uri;
-						}
-						if (compareUri && treeNode.toString() === compareUri.toString()) {
-							vscode.window.tabGroups.close(tab);
+					if (!options?.dontCloseFile) {
+						const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+						if (tab) {
+							let compareUri: vscode.Uri | undefined = undefined;
+							if (tab.input instanceof vscode.TabInputTextDiff) {
+								compareUri = tab.input.modified;
+							} else if (tab.input instanceof vscode.TabInputText) {
+								compareUri = tab.input.uri;
+							}
+							if (compareUri && treeNode.toString() === compareUri.toString()) {
+								vscode.window.tabGroups.close(tab);
+							}
 						}
 					}
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4,16 +4,26 @@ import { parseDiffHunk } from '../common/diffHunk';
 
 describe('Extension Tests', function () {
 	describe('markFileAsViewed', () => {
-		it('should keep the active editor open when dontCloseFile is true', async () => {
+		async function assertCommandKeepsTabOpen(...args: unknown[]) {
 			const document = await vscode.workspace.openTextDocument({ content: 'test' });
 			await vscode.window.showTextDocument(document);
 			const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
 			assert.ok(tab);
 
-			await vscode.commands.executeCommand('pr.markFileAsViewed', { dontCloseFile: true });
+			try {
+				await vscode.commands.executeCommand('pr.markFileAsViewed', ...args);
+				assert.strictEqual(vscode.window.tabGroups.activeTabGroup.activeTab, tab);
+			} finally {
+				await vscode.window.tabGroups.close(tab);
+			}
+		}
 
-			assert.strictEqual(vscode.window.tabGroups.activeTabGroup.activeTab, tab);
-			await vscode.window.tabGroups.close(tab);
+		it('should keep the active editor open with keybinding options', async () => {
+			await assertCommandKeepsTabOpen({ dontCloseFile: true });
+		});
+
+		it('should keep the active editor open with options as the second argument', async () => {
+			await assertCommandKeepsTabOpen(undefined, { dontCloseFile: true });
 		});
 	});
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,22 @@
 import { default as assert } from 'assert';
+import * as vscode from 'vscode';
 import { parseDiffHunk } from '../common/diffHunk';
 
 describe('Extension Tests', function () {
+	describe('markFileAsViewed', () => {
+		it('should keep the active editor open when dontCloseFile is true', async () => {
+			const document = await vscode.workspace.openTextDocument({ content: 'test' });
+			await vscode.window.showTextDocument(document);
+			const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+			assert.ok(tab);
+
+			await vscode.commands.executeCommand('pr.markFileAsViewed', { dontCloseFile: true });
+
+			assert.strictEqual(vscode.window.tabGroups.activeTabGroup.activeTab, tab);
+			await vscode.window.tabGroups.close(tab);
+		});
+	});
+
 	describe('parseDiffHunk', () => {
 		it('should handle empty string', () => {
 			const diffHunk = parseDiffHunk('');

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4,14 +4,14 @@ import { parseDiffHunk } from '../common/diffHunk';
 
 describe('Extension Tests', function () {
 	describe('markFileAsViewed', () => {
-		async function assertCommandKeepsTabOpen(...args: unknown[]) {
+		async function assertCommandKeepsTabOpen(getArgs: (uri: vscode.Uri) => unknown[]) {
 			const document = await vscode.workspace.openTextDocument({ content: 'test' });
 			await vscode.window.showTextDocument(document);
 			const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
 			assert.ok(tab);
 
 			try {
-				await vscode.commands.executeCommand('pr.markFileAsViewed', ...args);
+				await vscode.commands.executeCommand('pr.markFileAsViewed', ...getArgs(document.uri));
 				assert.strictEqual(vscode.window.tabGroups.activeTabGroup.activeTab, tab);
 			} finally {
 				await vscode.window.tabGroups.close(tab);
@@ -19,11 +19,15 @@ describe('Extension Tests', function () {
 		}
 
 		it('should keep the active editor open with keybinding options', async () => {
-			await assertCommandKeepsTabOpen({ dontCloseFile: true });
+			await assertCommandKeepsTabOpen(() => [{ dontCloseFile: true }]);
 		});
 
 		it('should keep the active editor open with options as the second argument', async () => {
-			await assertCommandKeepsTabOpen(undefined, { dontCloseFile: true });
+			await assertCommandKeepsTabOpen(() => [undefined, { dontCloseFile: true }]);
+		});
+
+		it('should keep the active editor open with a URI and options', async () => {
+			await assertCommandKeepsTabOpen(uri => [uri, { dontCloseFile: true }]);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- accept a `dontCloseFile` option in the `pr.markFileAsViewed` command
- support keybinding command arguments while preserving the existing default close behavior
- add regression coverage for keeping the active editor tab open

## Testing
- `npm run compile:test`
- `npx eslint src/commands.ts`
- `npm run hygiene`
- `npm run check:commands`
- `git diff --check`

Fixes #5092