### PR TITLE
Retry current user request after failure

### DIFF
--- a/src/gitProviders/GitHubContactServiceProvider.ts
+++ b/src/gitProviders/GitHubContactServiceProvider.ts
@@ -125,7 +125,7 @@ export class GitHubContactServiceProvider implements ContactServiceProvider {
 		}
 		const origin = await this.pullRequestManager.folderManagers[0]?.getOrigin();
 		if (origin) {
-			const currentUser = origin.hub.currentUser ? await origin.hub.currentUser : undefined;
+			const currentUser = await origin.getAuthenticatedUser();
 			if (currentUser) {
 				return currentUser.login;
 			}

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -551,19 +551,25 @@ export class CredentialStore extends Disposable {
 	}
 
 	public async isCurrentUser(authProviderId: AuthProvider, username: string): Promise<boolean> {
-		const api = authProviderId === AuthProvider.github ? this._githubAPI : this._githubEnterpriseAPI;
-		return (await api?.currentUser)?.login === username;
+		return (await this.getCurrentUser(authProviderId))?.login === username;
 	}
 
 	public async getIsEmu(authProviderId: AuthProvider): Promise<boolean> {
 		const github = this.getHub(authProviderId);
+		this.ensureCurrentUser(github);
 		return !!(await github?.isEmu);
 	}
 
 	public getCurrentUser(authProviderId: AuthProvider): Promise<IAccount> {
 		const github = this.getHub(authProviderId);
-		const octokit = github?.octokit;
-		return (octokit && github?.currentUser)!;
+		this.ensureCurrentUser(github);
+		return github?.currentUser!;
+	}
+
+	private ensureCurrentUser(github: GitHub | undefined): void {
+		if (github && (!github.currentUser || !github.isEmu)) {
+			this.setCurrentUser(github);
+		}
 	}
 
 	private setCurrentUser(github: GitHub): void {
@@ -577,8 +583,28 @@ export class CredentialStore extends Disposable {
 				reject(e);
 			});
 		});
-		github.currentUser = getUser.then(result => convertRESTUserToAccount(result.data));
-		github.isEmu = getUser.then(result => result.data.plan?.name === 'emu_user');
+		let currentUser: Promise<IAccount>;
+		let isEmu: Promise<boolean>;
+		const clearFailedRequest = () => {
+			if (github.currentUser === currentUser && github.isEmu === isEmu) {
+				github.currentUser = undefined;
+				github.isEmu = undefined;
+			}
+		};
+		currentUser = getUser.then(result => convertRESTUserToAccount(result.data), e => {
+			clearFailedRequest();
+			throw e;
+		});
+		isEmu = getUser.then(result => result.data.plan?.name === 'emu_user', e => {
+			clearFailedRequest();
+			throw e;
+		});
+		github.currentUser = currentUser;
+		github.isEmu = isEmu;
+
+		// Both promises share the same request, but callers may only observe one of them.
+		void currentUser.catch(() => undefined);
+		void isEmu.catch(() => undefined);
 	}
 
 	private async getSession(authProviderId: AuthProvider, getAuthSessionOptions: vscode.AuthenticationGetSessionOptions, scopes: string[], requireScopes: boolean): Promise<{ session: vscode.AuthenticationSession | undefined, isNew: boolean, scopes: string[] }> {

--- a/src/github/credentials.ts
+++ b/src/github/credentials.ts
@@ -80,8 +80,8 @@ export async function findExistingSession(
 export interface GitHub {
 	octokit: LoggingOctokit;
 	graphql: LoggingApolloClient;
-	currentUser?: Promise<IAccount>;
-	isEmu?: Promise<boolean>;
+	currentUser?: IAccount;
+	isEmu?: boolean;
 }
 
 interface AuthResult {
@@ -102,6 +102,7 @@ export class CredentialStore extends Disposable {
 	private _isSamling: boolean = false;
 	private _handlingAuthError: Map<AuthProvider, Promise<AuthResult>> = new Map();
 	private _lastAuthErrorHandledAt: Map<AuthProvider, number> = new Map();
+	private _currentUserRequests: WeakMap<GitHub, Promise<void>> = new WeakMap();
 	// Cooldown long enough to absorb retries from in-flight requests that were
 	// issued with the now-invalid token, but short enough that a token that
 	// is invalidated again soon after re-auth will still trigger another prompt.
@@ -556,55 +557,48 @@ export class CredentialStore extends Disposable {
 
 	public async getIsEmu(authProviderId: AuthProvider): Promise<boolean> {
 		const github = this.getHub(authProviderId);
-		this.ensureCurrentUser(github);
-		return !!(await github?.isEmu);
+		await this.ensureCurrentUser(github);
+		return !!github?.isEmu;
 	}
 
-	public getCurrentUser(authProviderId: AuthProvider): Promise<IAccount> {
+	public async getCurrentUser(authProviderId: AuthProvider): Promise<IAccount> {
 		const github = this.getHub(authProviderId);
-		this.ensureCurrentUser(github);
+		await this.ensureCurrentUser(github);
 		return github?.currentUser!;
 	}
 
-	private ensureCurrentUser(github: GitHub | undefined): void {
-		if (github && (!github.currentUser || !github.isEmu)) {
-			this.setCurrentUser(github);
+	private ensureCurrentUser(github: GitHub | undefined): Promise<void> {
+		if (!github || (github.currentUser && github.isEmu !== undefined)) {
+			return Promise.resolve();
 		}
-	}
 
-	private setCurrentUser(github: GitHub): void {
-		const getUser: ReturnType<typeof github.octokit.api.users.getAuthenticated> = new Promise((resolve, reject) => {
-			Logger.debug('Getting current user', CredentialStore.ID);
-			github.octokit.call(github.octokit.api.users.getAuthenticated, {}).then(result => {
-				Logger.debug(`Got current user ${result.data.login}`, CredentialStore.ID);
-				resolve(result);
-			}).catch(e => {
-				Logger.error(`Failed to get current user: ${e}, ${e.message}`, CredentialStore.ID);
-				reject(e);
-			});
-		});
-		let currentUser: Promise<IAccount>;
-		let isEmu: Promise<boolean>;
-		const clearFailedRequest = () => {
-			if (github.currentUser === currentUser && github.isEmu === isEmu) {
-				github.currentUser = undefined;
-				github.isEmu = undefined;
+		const existingRequest = this._currentUserRequests.get(github);
+		if (existingRequest) {
+			return existingRequest;
+		}
+
+		const request = this.setCurrentUser(github);
+		this._currentUserRequests.set(github, request);
+		const clearRequest = () => {
+			if (this._currentUserRequests.get(github) === request) {
+				this._currentUserRequests.delete(github);
 			}
 		};
-		currentUser = getUser.then(result => convertRESTUserToAccount(result.data), e => {
-			clearFailedRequest();
-			throw e;
-		});
-		isEmu = getUser.then(result => result.data.plan?.name === 'emu_user', e => {
-			clearFailedRequest();
-			throw e;
-		});
-		github.currentUser = currentUser;
-		github.isEmu = isEmu;
+		void request.then(clearRequest, clearRequest);
+		return request;
+	}
 
-		// Both promises share the same request, but callers may only observe one of them.
-		void currentUser.catch(() => undefined);
-		void isEmu.catch(() => undefined);
+	private async setCurrentUser(github: GitHub): Promise<void> {
+		Logger.debug('Getting current user', CredentialStore.ID);
+		try {
+			const result = await github.octokit.call(github.octokit.api.users.getAuthenticated, {});
+			Logger.debug(`Got current user ${result.data.login}`, CredentialStore.ID);
+			github.currentUser = convertRESTUserToAccount(result.data);
+			github.isEmu = result.data.plan?.name === 'emu_user';
+		} catch (e) {
+			Logger.error(`Failed to get current user: ${e}, ${e.message}`, CredentialStore.ID);
+			throw e;
+		}
 	}
 
 	private async getSession(authProviderId: AuthProvider, getAuthSessionOptions: vscode.AuthenticationGetSessionOptions, scopes: string[], requireScopes: boolean): Promise<{ session: vscode.AuthenticationSession | undefined, isNew: boolean, scopes: string[] }> {
@@ -680,7 +674,7 @@ export class CredentialStore extends Disposable {
 			octokit: new LoggingOctokit(octokit, rateLogger),
 			graphql: new LoggingApolloClient(graphql, rateLogger),
 		};
-		this.setCurrentUser(github);
+		void this.ensureCurrentUser(github).catch(() => undefined);
 		return github;
 	}
 }

--- a/src/github/githubRepository.ts
+++ b/src/github/githubRepository.ts
@@ -424,7 +424,7 @@ export class GitHubRepository extends Disposable {
 			repo
 		});
 		Logger.debug(`Fetch metadata for repo ${owner}/${repo} - done`, this.id);
-		const metadata = { ...result.data, currentUser: await this._hub?.currentUser };
+		const metadata = { ...result.data, currentUser: await this.getAuthenticatedUser() };
 		return metadata;
 	}
 

--- a/src/test/github/credentials.test.ts
+++ b/src/test/github/credentials.test.ts
@@ -3,10 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strictEqual, deepStrictEqual } from 'assert';
+import { strictEqual, deepStrictEqual, rejects } from 'assert';
+import { Octokit } from '@octokit/rest';
+import { createSandbox, SinonSandbox } from 'sinon';
 import * as vscode from 'vscode';
 import { AuthProvider } from '../../common/authentication';
-import { findExistingSession } from '../../github/credentials';
+import { CredentialStore, findExistingSession, GitHub } from '../../github/credentials';
+import { LoggingApolloClient, LoggingOctokit, RateLogger } from '../../github/loggingOctokit';
+import { MockExtensionContext } from '../mocks/mockExtensionContext';
+import { MockTelemetry } from '../mocks/mockTelemetry';
 
 const oldestScopes = ['read:user', 'user:email', 'repo'];
 const defaultScopes = [...oldestScopes, 'workflow'];
@@ -29,6 +34,16 @@ function createSession(id: string, accountId: string, scopes: string[]): vscode.
 }
 
 describe('CredentialStore', function () {
+	let sinon: SinonSandbox;
+
+	beforeEach(function () {
+		sinon = createSandbox();
+	});
+
+	afterEach(function () {
+		sinon.restore();
+	});
+
 	describe('findExistingSession', function () {
 		it('keeps broader scope lookup on the preferred account', async function () {
 			const firstAccountAdditional = createSession('first-additional', 'first', additionalScopes);
@@ -97,6 +112,45 @@ describe('CredentialStore', function () {
 
 			strictEqual(additionalResult?.session, additionalSession);
 			deepStrictEqual(additionalResult?.scopes, additionalScopes);
+		});
+	});
+
+	it('retries the current user request after a failure', async function () {
+		const telemetry = new MockTelemetry();
+		const credentialStore = new CredentialStore(telemetry, new MockExtensionContext());
+		const github: GitHub = {
+			octokit: new LoggingOctokit(new Octokit(), new RateLogger(telemetry, false)),
+			graphql: {} as LoggingApolloClient,
+		};
+		sinon.stub(credentialStore, 'getHub').returns(github);
+		const getAuthenticatedUser = sinon.stub(github.octokit, 'call');
+		const error = new Error('Connect Timeout Error');
+		getAuthenticatedUser.onFirstCall().rejects(error);
+		getAuthenticatedUser.onSecondCall().resolves({
+			data: {
+				login: 'octocat',
+				node_id: 'MDQ6VXNlcjE=',
+				html_url: 'https://github.com/octocat',
+				avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+				type: 'User',
+				plan: { name: 'emu_user' },
+			}
+		});
+
+		await rejects(credentialStore.getCurrentUser(AuthProvider.github), candidate => candidate === error);
+		const [currentUser, isEmu] = await Promise.all([
+			credentialStore.getCurrentUser(AuthProvider.github),
+			credentialStore.getIsEmu(AuthProvider.github),
+		]);
+
+		deepStrictEqual({
+			requests: getAuthenticatedUser.callCount,
+			login: currentUser.login,
+			isEmu,
+		}, {
+			requests: 2,
+			login: 'octocat',
+			isEmu: true,
 		});
 	});
 });

--- a/src/test/github/credentials.test.ts
+++ b/src/test/github/credentials.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strictEqual, deepStrictEqual, rejects } from 'assert';
+import { strictEqual, deepStrictEqual } from 'assert';
 import { Octokit } from '@octokit/rest';
 import { createSandbox, SinonSandbox } from 'sinon';
 import * as vscode from 'vscode';
@@ -137,20 +137,32 @@ describe('CredentialStore', function () {
 			}
 		});
 
-		await rejects(credentialStore.getCurrentUser(AuthProvider.github), candidate => candidate === error);
+		deepStrictEqual(await Promise.allSettled([
+			credentialStore.getCurrentUser(AuthProvider.github),
+			credentialStore.getIsEmu(AuthProvider.github),
+		]), [
+			{ status: 'rejected', reason: error },
+			{ status: 'rejected', reason: error },
+		]);
+		strictEqual(getAuthenticatedUser.callCount, 1);
+		strictEqual(github.currentUser, undefined);
+		strictEqual(github.isEmu, undefined);
 		const [currentUser, isEmu] = await Promise.all([
 			credentialStore.getCurrentUser(AuthProvider.github),
 			credentialStore.getIsEmu(AuthProvider.github),
 		]);
+		const cachedCurrentUser = await credentialStore.getCurrentUser(AuthProvider.github);
 
 		deepStrictEqual({
 			requests: getAuthenticatedUser.callCount,
 			login: currentUser.login,
 			isEmu,
+			cachedLogin: cachedCurrentUser.login,
 		}, {
 			requests: 2,
 			login: 'octocat',
 			isEmu: true,
+			cachedLogin: 'octocat',
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Retry the authenticated GitHub user request after a transient failure instead of retaining and replaying its rejected promise for the lifetime of the authentication hub.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Fix the retained rejection at its source**: A connection timeout during extension activation rejected `github.currentUser`. Because that promise stayed cached, later PR refreshes failed immediately with the original timeout even after other GitHub requests recovered.
- **Retry on demand**: Failed `currentUser` and `isEmu` promises are cleared together. The next consumer creates one new shared request, preserving request deduplication without adding an automatic retry loop.
- **Keep recovery consistent**: Callers that directly read the cached promise now use the credential-store/repository API so they also trigger retry behavior.
- **Keep progress cleanup separate**: This root-cause fix is independent from #8897, which ensures the Changes in Pull Request progress indicator settles after refresh failures.

</details>

## Changes

- Clear the cached current-user and EMU promises when their shared request fails.
- Recreate the shared request on the next `getCurrentUser`, `getIsEmu`, or `isCurrentUser` call.
- Route metadata and contact-provider lookups through the retry-aware API.
- Add regression coverage for a failed request followed by a successful retry.

## Evidence

The log showed only one current-user request during activation:

```text
2026-08-24 11:24:52.079 [debug] [Authentication] Getting current user
2026-08-24 11:24:52.079 [error] [Authentication] Failed to get current user: HttpError: Connect Timeout Error (attempted address: api.github.com:443, timeout: 10000ms)
```

Hours later, PR initialization replayed that same failure within milliseconds while other GitHub requests succeeded:

```text
2026-08-25 08:37:09.747 [debug] [PullRequestModel] Fetch file changes, base, head and merge base of PR #332245 - enter
2026-08-25 08:37:09.752 [error] [Review+0] Failed to initialize PR data HttpError: Connect Timeout Error (attempted address: api.github.com:443, timeout: 10000ms)
2026-08-25 08:37:10.895 [debug] [GitHubRepository+0] Fetch pull request 332245 - done
```

![GitHub Pull Request log showing the api.github.com timeout](https://github.com/user-attachments/assets/bb830b06-6b47-4f88-9018-f56bd0dbb78b)

## Validation

- `npm test` - 478 passing
- `npm run lint`
- `npm run hygiene`
- `git diff --check`
