### PR TITLE
Revert "Bump fast-uri from 3.1.5 to 3.1.7 (#8920)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5740,9 +5740,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
-			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
This reverts commit 23e7aa9ec60a3cf0b1ffc72803b8e66646c80162.