### PR TITLE
Fix mergeability polling in pull request overview

### DIFF
--- a/src/github/interface.ts
+++ b/src/github/interface.ts
@@ -31,6 +31,11 @@ export enum PullRequestMergeability {
 	Behind,
 }
 
+export interface PullRequestMergeabilityResult {
+	mergeability: PullRequestMergeability;
+	conflicts?: string[];
+}
+
 export enum MergeQueueState {
 	AwaitingChecks,
 	Locked,

--- a/src/github/pullRequestModel.ts
+++ b/src/github/pullRequestModel.ts
@@ -62,6 +62,7 @@ import {
 	PullRequest,
 	PullRequestChecks,
 	PullRequestMergeability,
+	PullRequestMergeabilityResult,
 	PullRequestReviewRequirement,
 	ReadyForReview,
 	ReviewEventEnum,
@@ -2055,7 +2056,7 @@ export class PullRequestModel extends IssueModel<PullRequest> implements IPullRe
 	/**
 	 * Get the current mergeability of the pull request.
 	 */
-	async getMergeability(): Promise<{ mergeability: PullRequestMergeability, conflicts?: string[] }> {
+	async getMergeability(): Promise<PullRequestMergeabilityResult> {
 		try {
 			Logger.debug(`Fetch pull request mergeability ${this.number} - enter`, PullRequestModel.ID);
 			const { query, remote, schema } = await this.githubRepository.ensure();

--- a/webviews/common/context.tsx
+++ b/webviews/common/context.tsx
@@ -10,7 +10,7 @@ import { getMessageHandler, MessageHandler } from './message';
 import { CloseResult, DescriptionResult, OpenCommitChangesArgs, OpenLocalFileArgs } from '../../common/views';
 import { IComment } from '../../src/common/comment';
 import { EventType, ReviewEvent, SessionLinkInfo, TimelineEvent } from '../../src/common/timelineEvent';
-import { IProjectItem, MergeMethod, PullRequestCheckStatus, ReadyForReview } from '../../src/github/interface';
+import { IProjectItem, MergeMethod, PullRequestCheckStatus, PullRequestMergeabilityResult, ReadyForReview } from '../../src/github/interface';
 import { CancelCodingAgentReply, ChangeAssigneesReply, ChangeBaseReply, ConvertToDraftReply, DeleteReviewResult, FileUploadCompletedMessage, MergeArguments, MergeResult, ProjectItemsReply, PullRequest, ReadyForReviewReply, SubmitReviewArgs, SubmitReviewReply, UploadFilesReply } from '../../src/github/views';
 
 /**
@@ -86,7 +86,8 @@ export class PRContext {
 		this.updatePR(this.pr);
 	};
 
-	public checkMergeability = () => this.postMessage({ command: 'pr.checkMergeability' });
+	public checkMergeability = (): Promise<PullRequestMergeabilityResult> =>
+		this.postMessage({ command: 'pr.checkMergeability' });
 
 	public changeEmail = async (current: string) => {
 		const newEmail = await this.postMessage({ command: 'pr.change-email', args: current });

--- a/webviews/components/merge.tsx
+++ b/webviews/components/merge.tsx
@@ -192,7 +192,7 @@ export const MergeStatusAndActions = ({ pr, isSimple }: { pr: PullRequest; isSim
 	useEffect(() => {
 		const handle = setInterval(async () => {
 			if (mergeable === PullRequestMergeability.Unknown) {
-				const newMergeability = await checkMergeability();
+				const { mergeability: newMergeability } = await checkMergeability();
 				setMergeability(newMergeability);
 			}
 		}, 3000);

--- a/webviews/editorWebview/test/merge.test.tsx
+++ b/webviews/editorWebview/test/merge.test.tsx
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { default as assert } from 'assert';
+import * as React from 'react';
+import { cleanup, render } from 'react-testing-library';
+import { createSandbox, SinonFakeTimers, SinonSandbox } from 'sinon';
+
+import { PullRequestBuilder } from './builder/pullRequest';
+import { PullRequestMergeability } from '../../../src/github/interface';
+import { PRContext, default as PullRequestContext } from '../../common/context';
+import { MergeStatusAndActions } from '../../components/merge';
+
+describe('Merge status and actions', function () {
+	let sinon: SinonSandbox;
+	let clock: SinonFakeTimers & { tickAsync(milliseconds: number): Promise<number> };
+
+	beforeEach(function () {
+		sinon = createSandbox();
+		clock = sinon.useFakeTimers() as SinonFakeTimers & { tickAsync(milliseconds: number): Promise<number> };
+	});
+
+	afterEach(function () {
+		cleanup();
+		sinon.restore();
+	});
+
+	it('updates an unknown mergeability state from the polling response', async function () {
+		const pr = new PullRequestBuilder()
+			.mergeable(PullRequestMergeability.Unknown)
+			.hasWritePermission(false)
+			.build();
+		const context = new PRContext(pr);
+		const checkMergeability = sinon.stub(context, 'checkMergeability').resolves({
+			mergeability: PullRequestMergeability.Mergeable,
+		});
+
+		const view = render(
+			<PullRequestContext.Provider value={context}>
+				<MergeStatusAndActions pr={pr} isSimple={true} />
+			</PullRequestContext.Provider>,
+		);
+
+		assert(view.queryByText('Checking if this branch can be merged...'));
+
+		await clock.tickAsync(3000);
+
+		assert(view.queryByText('This branch has no conflicts with the base branch.'));
+		assert.strictEqual(checkMergeability.calledOnce, true);
+
+		await clock.tickAsync(3000);
+
+		assert.strictEqual(checkMergeability.calledOnce, true);
+	});
+});


### PR DESCRIPTION
Fixes #8953

## Summary

- unwrap the mergeability value returned by the polling request
- define a shared response type for mergeability checks
- use the response type across the model and webview context

When GitHub initially returns an unknown mergeability state, the polling request returns an object containing `mergeability` and `conflicts`. The webview previously stored that entire object as its mergeability state, so polling stopped and the status remained "Checking if this branch can be merged..." indefinitely.

## Testing

- `npm run compile:node`
- `npm run lint`
- `npm run hygiene`
- `git diff --check`